### PR TITLE
Json Syntax Fix

### DIFF
--- a/AWS/legos/aws_list_access_keys/aws_list_access_keys.json
+++ b/AWS/legos/aws_list_access_keys/aws_list_access_keys.json
@@ -7,3 +7,4 @@
     "action_output_type": "ACTION_OUTPUT_TYPE_DICT",
     "action_supports_poll": true,
     "action_supports_iteration": true
+}


### PR DESCRIPTION
Json Syntax fix

## Description
aws_list_access_keys.json had a missing `}` at the end. Fixed it.
