### PR TITLE
Make proxy_host to the handler itself

### DIFF
--- a/SSH/legos/ssh_execute_remote_command/ssh_execute_remote_command.py
+++ b/SSH/legos/ssh_execute_remote_command/ssh_execute_remote_command.py
@@ -53,13 +53,7 @@ def ssh_execute_remote_command(sshClient, hosts: List[str], command: str, sudo: 
         :rtype: dict of command output
     """
 
-    client = sshClient(hosts)
-    if proxy_host is not None:
-        #Need to do the following:
-        # 1. Close the existing handles.
-        # 2. Create new handles using the new proxy_host.
-        client.join()
-        client =  client.duplicate(hosts, proxy_host)
+    client = sshClient(hosts, proxy_host)
 
     runCommandOutput = client.run_command(command=command, sudo=sudo)
     client.join()


### PR DESCRIPTION
## Description

Improve overriding proxy host.

## Unit-test

```
(connectors) amits-mbp-2:unskript amit$ pytest -s tests/ssh/test_ssh_execute_command.py::test_ssh_execute_command_via_override_proxy
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /Users/amit/workspace/src/unskript, configfile: setup.cfg
plugins: anyio-3.5.0, Faker-13.15.1
collected 1 item

tests/ssh/test_ssh_execute_command.py

{'10.0.1.169': 'fluent-bit\n'
               '\n'
               'jeg\n'
               '\n'
               'k3supgrade.yaml\n'
               '\n'
               'log.txt\n'
               '\n'
               'redis\n'
               '\n'
               'sidecar\n'
               '\n'
               'snap\n'
               '\n'
               'unskriptlog.txt\n'
               '\n'
               'update_cron.sh\n'
               '\n'
               'upgradeProxy\n'}
```