### PR TITLE
EN-3698 : Schema Changes supported for HealthCheck Epic

### DIFF
--- a/AWS/legos/aws_list_expiring_access_keys/aws_list_expiring_access_keys.json
+++ b/AWS/legos/aws_list_expiring_access_keys/aws_list_expiring_access_keys.json
@@ -9,5 +9,8 @@
     "action_supports_iteration": true,
     "action_verbs": ["list"],
     "action_nouns": ["expiring","access","aws"],
-    "action_is_check": true
+    "action_is_check": true,
+    "action_categories": [ "CATEGORY_TYPE_IAM", "CATEGORY_TYPE_SECOPS"],
+    "action_remediation": "<UUID of lego>",
+    "action_remediation_input": {}
 }

--- a/AWS/legos/aws_list_expiring_access_keys/aws_list_expiring_access_keys.json
+++ b/AWS/legos/aws_list_expiring_access_keys/aws_list_expiring_access_keys.json
@@ -4,13 +4,13 @@
     "action_type": "LEGO_TYPE_AWS",
     "action_entry_function": "aws_list_expiring_access_keys",
     "action_needs_credential": true,
-    "action_output_type": "ACTION_OUTPUT_TYPE_DICT",
+    "action_output_type": "ACTION_OUTPUT_TYPE_LIST",
     "action_supports_poll": true,
     "action_supports_iteration": true,
     "action_verbs": ["list"],
     "action_nouns": ["expiring","access","aws"],
     "action_is_check": true,
     "action_categories": [ "CATEGORY_TYPE_IAM", "CATEGORY_TYPE_SECOPS"],
-    "action_remediation": "<UUID of lego>",
-    "action_remediation_input": {}
+    "action_next_hop": "<UUID of lego for remediation if check fails>",
+    "action_next_hop_parameter_mapping": {}
 }

--- a/AWS/legos/aws_list_expiring_acm_certificates/aws_list_expiring_acm_certificates.json
+++ b/AWS/legos/aws_list_expiring_acm_certificates/aws_list_expiring_acm_certificates.json
@@ -4,13 +4,13 @@
     "action_type": "LEGO_TYPE_AWS",
     "action_entry_function": "aws_list_expiring_acm_certificates",
     "action_needs_credential": true,
-    "action_output_type": "ACTION_OUTPUT_TYPE_DICT",
+    "action_output_type": "ACTION_OUTPUT_TYPE_LIST",
     "action_supports_poll": true,
     "action_supports_iteration": true,
     "action_verbs": ["list"],
     "action_nouns": ["expiring","certificates","aws"],
     "action_is_check": true,
     "action_categories": [ "CATEGORY_TYPE_IAM", "CATEGORY_TYPE_SECOPS"],
-    "action_remediation": "<UUID of lego>",
-    "action_remediation_input": {}
+    "action_next_hop": "<UUID of lego for remediation if check fails>",
+    "action_next_hop_parameter_mapping": {}
 }

--- a/AWS/legos/aws_list_expiring_acm_certificates/aws_list_expiring_acm_certificates.json
+++ b/AWS/legos/aws_list_expiring_acm_certificates/aws_list_expiring_acm_certificates.json
@@ -9,5 +9,8 @@
     "action_supports_iteration": true,
     "action_verbs": ["list"],
     "action_nouns": ["expiring","certificates","aws"],
-    "action_is_check": true
+    "action_is_check": true,
+    "action_categories": [ "CATEGORY_TYPE_IAM", "CATEGORY_TYPE_SECOPS"],
+    "action_remediation": "<UUID of lego>",
+    "action_remediation_input": {}
 }


### PR DESCRIPTION
## Description

We need to add following keys for health checkup support

- action_is_check =T or F
- action_categories
- action_next_hop
- action_next_hop_parameter_mapping
- action_output_type is always ACTION_OUTPUT_TYPE_LIST in case of a check

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
