### PR TITLE
Removed required field and adding if condition to add tag only when true

### DIFF
--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -44,7 +44,6 @@ on:
         type: string 
       latest:
         description: 'Docker Latest tag Branch name'
-        required: true
         default: false
         type: boolean
 
@@ -312,7 +311,7 @@ jobs:
           mv /tmp/code_snippet/*.whl .
           mv /tmp/jlab_enhanced_cell_toolbar/*.whl .
           mv /tmp/elyra/elyra*tar.gz .
-          if [[ ${{ inputs.latest }} ]]; then 
+          if [[ ${{ inputs.latest }} == "true" ]]; then 
               bt="${{ env.DOCKER_IMAGE }}:${{ inputs.build_number }} -t ${{ env.DOCKER_IMAGE }}:latest"
           else 
               bt="${{ env.DOCKER_IMAGE }}:${{ inputs.build_number }}"


### PR DESCRIPTION
## Description
The Github Workflow had a bug that `latest` tag was added for every build. Fixed the logic and tested it with two seperate builds. 



### Testing
<img width="1114" alt="Screenshot 2022-12-17 at 10 38 47 PM" src="https://user-images.githubusercontent.com/87547684/208285139-a5458ce9-9c63-4528-8d5c-37d98aac195b.png">
<img width="1074" alt="Screenshot 2022-12-17 at 10 39 17 PM" src="https://user-images.githubusercontent.com/87547684/208285140-41f971a6-a161-4b44-96e3-8eb04c0eb072.png">



### Checklist:
- [x ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] Any dependent changes have been merged and published. 

### Documentation
No changes needed