### PR TITLE
EN-3931: Fixed PostGres issue

### DIFF
--- a/Postgresql/legos/postgresql_read_query/postgresql_read_query.py
+++ b/Postgresql/legos/postgresql_read_query/postgresql_read_query.py
@@ -15,13 +15,13 @@ class InputSchema(BaseModel):
         title='Read Query',
         description='''
             Read query in Postgresql PREPARE statement format. For eg.
-            SELECT foo FROM table WHERE bar=$1 AND customer=$2.
-            The values for $1 and $2 should be passed in the params field as a tuple.
+            SELECT foo FROM table WHERE bar=%s AND customer=%s.
+            The values for %s and %s should be passed in the params field as a tuple.
         ''')
     params: tuple = Field(
         None,
         title='Parameters',
-        description='Parameters to the query in list format. For eg: [1, 2, "abc"]')
+        description='Parameters to the query in tuple format. For eg: ("abc")')
 
 
 def postgresql_read_query_printer(output):
@@ -56,15 +56,10 @@ def postgresql_read_query(handle, query: str, params: tuple = ()) -> List:
 
     query = "PREPARE psycop_{random_id} AS {query};".format(
         random_id=random_id, query=query)
-    if not params:
-        prepared_query = "EXECUTE psycop_{random_id};".format(
-            random_id=random_id)
-    else:
-        prepared_query = "EXECUTE psycop_{random_id} {params};".format(
-            random_id=random_id, params=tuple(params))
-
-    cur.execute(query)
-    cur.execute(prepared_query)
+    prepared_query = "EXECUTE psycop_{random_id};".format(
+        random_id=random_id)
+    cur.execute(query, params)
+    cur.execute(prepared_query, params)
     res = cur.fetchall()
     handle.commit()
     cur.close()

--- a/Postgresql/legos/postgresql_read_query/postgresql_read_query.py
+++ b/Postgresql/legos/postgresql_read_query/postgresql_read_query.py
@@ -15,13 +15,13 @@ class InputSchema(BaseModel):
         title='Read Query',
         description='''
             Read query in Postgresql PREPARE statement format. For eg.
-            SELECT foo FROM table WHERE bar=%s AND customer=%s.
-            The values for %s and %s should be passed in the params field as a tuple.
+            SELECT foo FROM table WHERE bar=$1 AND customer=$2.
+            The values for $1 and $2 should be passed in the params field as a tuple.
         ''')
-    params: tuple = Field(
+    params: List = Field(
         None,
         title='Parameters',
-        description='Parameters to the query in tuple format. For eg: ("abc")')
+        description='Parameters to the query in list format. For eg: [1, 2, "abc"]')
 
 
 def postgresql_read_query_printer(output):
@@ -33,7 +33,7 @@ def postgresql_read_query_printer(output):
     return output
 
 
-def postgresql_read_query(handle, query: str, params: tuple = ()) -> List:
+def postgresql_read_query(handle, query: str, params: list = ()) -> List:
     """postgresql_read_query Runs postgresql query with the provided parameters.
 
           :type handle: object
@@ -56,10 +56,20 @@ def postgresql_read_query(handle, query: str, params: tuple = ()) -> List:
 
     query = "PREPARE psycop_{random_id} AS {query};".format(
         random_id=random_id, query=query)
-    prepared_query = "EXECUTE psycop_{random_id};".format(
-        random_id=random_id)
-    cur.execute(query, params)
-    cur.execute(prepared_query, params)
+    if not params:
+        prepared_query = "EXECUTE psycop_{random_id};".format(
+            random_id=random_id)
+    else:
+        parameters_tuple = tuple(params)
+        ## If there is only one tuple element, remove the trailing comma before format
+        if len(parameters_tuple) == 1:
+            tuple_string = str(parameters_tuple)
+            parameters_tuple = tuple_string[:-2] + tuple_string[-1]
+        prepared_query = "EXECUTE psycop_{random_id} {params};".format(
+            random_id=random_id, params=parameters_tuple)
+
+    cur.execute(query)
+    cur.execute(prepared_query)
     res = cur.fetchall()
     handle.commit()
     cur.close()


### PR DESCRIPTION
## Description

When adding addtional params to the "Read PostgreSQL Query" lego, it fails with the following error:

![Screenshot from 2023-01-27 20-58-33](https://user-images.githubusercontent.com/95602213/215124229-9d4ce258-960f-41b9-ac9b-30cf0f69a0ba.png)

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
![Screenshot from 2023-02-01 13-39-19](https://user-images.githubusercontent.com/95602213/215986652-c591ba75-5aba-4743-852e-0420ed3cefec.png)



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
