### PR TITLE
EN-3890-test-out-kafka-legos

### DIFF
--- a/Kafka/legos/kafka_run_command/kafka_run_command.py
+++ b/Kafka/legos/kafka_run_command/kafka_run_command.py
@@ -4,11 +4,6 @@
 #
 
 from pydantic import BaseModel, Field
-import pprint
-
-
-pp = pprint.PrettyPrinter(indent=4)
-
 
 class InputSchema(BaseModel):
     kafka_command: str = Field(
@@ -21,7 +16,7 @@ class InputSchema(BaseModel):
 def kafka_run_command_printer(output):
     if output is None:
         return
-    pprint.pprint(output)
+    print(output)
 
 
 def kafka_run_command(handle, kafka_command: str) -> str:
@@ -33,7 +28,7 @@ def kafka_run_command(handle, kafka_command: str) -> str:
         :rtype: string
     """
 
-    assert(kafka_command.startswith("kafka"))
+    assert(kafka_command.startswith("kafka") or kafka_command.startswith("./kafka"))
 
     result = handle.run_native_cmd(kafka_command)
-    return result
+    return result.stdout


### PR DESCRIPTION
## Description
Fix the kafka run command lego, also its printer function

### Testing
```
(connectors) Amits-MacBook-Pro-2:unskript amit$ pytest -s tests/kafka/test_kafka_run_command.py
=================================================================================================================== test session starts ====================================================================================================================
platform darwin -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /Users/amit/workspace/src/unskript, configfile: setup.cfg
plugins: anyio-3.5.0, Faker-13.15.1
collected 2 items

tests/kafka/test_kafka_run_command.py __consumer_offsets
dummy
log
my-topic
test
test_msg
wikipedia.recentchange

.__consumer_offsets
dummy
log
my-topic
test
test_msg
wikipedia.recentchange
```


### Checklist:
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published. 

