### PR TITLE
Runbook: Terminate EC2 instances without valid Lifetime Tag

### DIFF
--- a/AWS/Terminate_EC2_Instances_Without_Valid_Lifetime_Tag.ipynb
+++ b/AWS/Terminate_EC2_Instances_Without_Valid_Lifetime_Tag.ipynb
@@ -2,59 +2,58 @@
     "cells": [
         {
             "cell_type": "markdown",
-            "id": "5ae7173b-05af-4450-bc89-701a3283590a",
+            "id": "280d4d6f-a47c-4fa2-8d55-a4e19899d46c",
             "metadata": {
                 "jupyter": {
                     "source_hidden": false
                 },
-                "name": "Terminate EC2 Instance Without Valid Lifetime Tag",
+                "name": "Steps Overview",
                 "orderProperties": [],
                 "tags": [],
-                "title": "Terminate EC2 Instance Without Valid Lifetime Tag"
+                "title": "Steps Overview"
             },
             "source": [
-                "<img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\"/> \n",
-                "<h1> unSkript Runbooks </h1>\n",
+                "<center><img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\">\n",
+                "<h1 id=\"-unSkript-Runbooks-\">unSkript Runbooks</h1>\n",
                 "<div class=\"alert alert-block alert-success\">\n",
-                "    <b> This runbook demonstrates How to Terminate EC2 Instances Without Valid Lifetime Tag using unSkript legos.</b>\n",
-                "</div>\n",
-                "\n",
-                "<br>\n",
-                "\n",
-                "<center><h2>Terminate EC2 Instances Without Valid Lifetime Tag</h2></center>\n",
-                "\n",
-                "# Steps Overview\n",
-                "  - When an Auto Scaling group launches instances, it adds tags to the instances during              resource creation rather than after the resource is created.\n",
-                "\n",
-                "  - The Auto Scaling group automatically adds a tag to instances with a key of                       aws:autoscaling:groupName and a value of the Auto Scaling group name.\n",
-                "\n",
-                "  - If you specify instance tags in your launch template and you opted to propagate your             group's tags to its instances, all the tags are merged. If the same tag key is specified         for a tag in your launch template and a tag in your Auto Scaling group, then the tag value       from the group takes precedence.\n",
-                "\n",
-                "  - When you attach existing instances, the Auto Scaling group adds the tags to the instances,       overwriting any existing tags with the same tag key. It also adds a tag with a key of           aws:autoscaling:groupName and a value of the Auto Scaling group name.\n",
-                "\n",
-                "  - When you detach an instance from an Auto Scaling group, it removes only the                     aws:autoscaling:groupName tag."
+                "<h3 id=\"-Objective\">Objective</h3>\n",
+                "<br><strong style=\"color: #000000;\"><em>Filter and Terminate EC2 Instances Without Valid Lifetime Tag</em></strong></div>\n",
+                "</center>\n",
+                "<p>&nbsp;</p>\n",
+                "<center>\n",
+                "<h2 id=\"Terminate-EC2-Instances-Without-Valid-Lifetime-Tag\"><u>Terminate EC2 Instances Without Valid Lifetime Tag</u></h2>\n",
+                "</center>\n",
+                "<h1 id=\"Steps-Overview\">Steps Overview</h1>\n",
+                "<p>1)<a href=\"#1\" target=\"_self\" rel=\"noopener\"> Filter AWS EC2 Instances Without Lifetime Tag</a><br>2)<a href=\"#2\" target=\"_self\" rel=\"noopener\"> Terminate AWS Instance</a></p>"
             ]
         },
         {
             "cell_type": "markdown",
-            "id": "ef164c73-732a-43d8-887d-32d60559a2cb",
+            "id": "86a462b7-31c9-4f07-a3ea-bf662bc95ef3",
             "metadata": {
                 "jupyter": {
                     "source_hidden": false
                 },
-                "name": "Filter AWS EC2 Instances Without Lifetime Tag",
+                "name": "Step 1A",
                 "orderProperties": [],
                 "tags": [],
-                "title": "Filter AWS EC2 Instances Without Lifetime Tag"
+                "title": "Step 1A"
             },
             "source": [
-                "Here we will use unSkript Filter AWS EC2 Instances Without Lifetime Tag Lego. This lego takes lifetime_tag and region as input. This input is used to get all the EC2 instances which don't have lifetime tag"
+                "<h3 id=\"List-all-AWS-Regions\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>List all AWS Regions</h3>\n",
+                "<p>This action fetches all AWS Regions to execute Step 1👇. This action will only execute if no <code>region</code> is provided.</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>None</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following ouput: <code>region</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 6,
-            "id": "9f5de22f-2c35-4613-b26a-d8ae2eac5a8e",
+            "execution_count": 4,
+            "id": "c0ced73a-dfc6-4ed8-b596-98849ad7675a",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
@@ -62,51 +61,21 @@
                 "actionRequiredLinesInCode": [],
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
-                "action_uuid": "abe9fc82a53b80dc1dd4d5a89e31d22b0338e73e86d2ca859576f38cc6d19f48",
-                "continueOnError": false,
+                "action_modified": false,
+                "action_uuid": "708ea4af5f8fe7096a15b3a52c4a657606bab9e177386fad7a847341ed607d64",
+                "condition_enabled": true,
                 "createTime": "1970-01-01T00:00:00Z",
-                "credentialsJson": {},
                 "currentVersion": "0.1.0",
-                "description": "Filter AWS EC2 Instance by Tag",
+                "description": "List all available AWS Regions",
                 "execution_data": {
-                    "last_date_success_run_cell": "2022-09-29T13:30:11.492Z"
+                    "last_date_success_run_cell": "2023-01-30T14:30:49.619Z"
                 },
-                "id": 155,
-                "index": 155,
-                "inputData": [
-                    {
-                        "lifetime_tag": {
-                            "constant": false,
-                            "value": "Lifetime_Tag"
-                        },
-                        "region": {
-                            "constant": false,
-                            "value": "Region"
-                        }
-                    }
-                ],
+                "id": 215,
+                "index": 215,
                 "inputschema": [
                     {
-                        "properties": {
-                            "lifetime_tag": {
-                                "default": "\"aws:autoscaling:groupName\"",
-                                "description": "Valid lifetime tag",
-                                "title": "lifetime_tag",
-                                "type": "string"
-                            },
-                            "region": {
-                                "default": "",
-                                "description": "AWS Region.",
-                                "title": "Region",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag_key",
-                            "tag_value",
-                            "region"
-                        ],
-                        "title": "aws_filter_ec2_by_tags",
+                        "properties": {},
+                        "title": "aws_list_all_regions",
                         "type": "object"
                     }
                 ],
@@ -114,28 +83,191 @@
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_AWS",
-                "name": "Filter AWS EC2 Instances Without Lifetime Tag",
+                "name": "AWS List All Regions",
+                "nouns": [
+                    "regions",
+                    "aws"
+                ],
+                "orderProperties": [],
+                "output": {
+                    "type": ""
+                },
+                "outputParams": {
+                    "output_name": "region",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
+                "startcondition": "not region",
+                "tags": [
+                    "aws_list_all_regions"
+                ],
+                "trusted": true,
+                "verbs": [
+                    "list"
+                ]
+            },
+            "outputs": [],
+            "source": [
+                "#\n",
+                "# Copyright (c) 2021 unSkript.com\n",
+                "# All rights reserved.\n",
+                "#\n",
+                "\n",
+                "from pydantic import BaseModel, Field\n",
+                "from typing import Dict, List\n",
+                "import pprint\n",
+                "\n",
+                "from beartype import beartype\n",
+                "@beartype\n",
+                "def aws_list_all_regions_printer(output):\n",
+                "    if output is None:\n",
+                "        return\n",
+                "    pprint.pprint(output)\n",
+                "\n",
+                "\n",
+                "@beartype\n",
+                "def aws_list_all_regions(handle) -> List:\n",
+                "    \"\"\"aws_list_all_regions lists all the AWS regions\n",
+                "\n",
+                "        :type handle: object\n",
+                "        :param handle: Object returned from Task Validate\n",
+                "\n",
+                "        :rtype: Result List of result\n",
+                "    \"\"\"\n",
+                "\n",
+                "    result = handle.aws_cli_command(\"aws ec2 describe-regions --all-regions --query 'Regions[].{Name:RegionName}' --output text\")\n",
+                "    if result is None or result.returncode != 0:\n",
+                "        print(\"Error while executing command : {}\".format(result))\n",
+                "        return str()\n",
+                "    result_op = list(result.stdout.split(\"\\n\"))\n",
+                "    list_region = [x for x in result_op if x != '']\n",
+                "    return list_region\n",
+                "\n",
+                "\n",
+                "task = Task(Workflow())\n",
+                "task.configure(conditionsJson='''{\n",
+                "    \"condition_enabled\": true,\n",
+                "    \"condition_cfg\": \"not region\",\n",
+                "    \"condition_result\": true\n",
+                "    }''')\n",
+                "\n",
+                "task.configure(outputName=\"region\")\n",
+                "task.configure(credentialsJson='''{\n",
+                "    \"credential_name\": \"DevRole\",\n",
+                "    \"credential_type\": \"CONNECTOR_TYPE_AWS\",\n",
+                "    \"credential_id\": \"049e1bfd-59e4-44a4-9f3f-e96710a2387d\"\n",
+                "}''')\n",
+                "task.configure(printOutput=True)\n",
+                "(err, hdl, args) = task.validate(vars=vars())\n",
+                "if err is None:\n",
+                "    task.execute(aws_list_all_regions, lego_printer=aws_list_all_regions_printer, hdl=hdl, args=args)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "74abf372-b918-4c9e-acf5-e4213d747d5f",
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Step 1",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step 1"
+            },
+            "source": [
+                "<h3 id=\"Filter-AWS-EC2-Instances-Without-Lifetime-Tag\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>Filter AWS EC2 Instances Without Lifetime Tag</h3>\n",
+                "<p>Here we will use unSkript Filter AWS EC2 Instances Without Lifetime Tag action to get all the EC2 instances which don't have lifetime tag.</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>lifetime_tag</code>,<code>region</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following output: <code>untagged_ec2_instances</code></p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "d2b07f6f-2cdd-4bef-b8df-40481f8ba14e",
+            "metadata": {
+                "accessType": "ACCESS_TYPE_UNSPECIFIED",
+                "actionBashCommand": false,
+                "actionNeedsCredential": true,
+                "actionRequiredLinesInCode": [],
+                "actionSupportsIteration": true,
+                "actionSupportsPoll": true,
+                "action_modified": false,
+                "action_uuid": "6cc8a1355937c21df3ace495375225012fa8915f4125ad143367e0feb34486c5",
+                "continueOnError": true,
+                "createTime": "1970-01-01T00:00:00Z",
+                "currentVersion": "0.1.0",
+                "description": "Filter AWS EC2 Instances Without Termination and Lifetime Tag and Check of they are valid",
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-01-30T14:31:10.116Z"
+                },
+                "id": 265,
+                "index": 265,
+                "inputData": [
+                    {
+                        "region": {
+                            "constant": false,
+                            "value": "iter_item"
+                        }
+                    }
+                ],
+                "inputschema": [
+                    {
+                        "properties": {
+                            "region": {
+                                "default": "",
+                                "description": "Name of the AWS Region",
+                                "title": "Region",
+                                "type": "string"
+                            }
+                        },
+                        "title": "aws_filter_instances_without_termination_and_lifetime_tag",
+                        "type": "object"
+                    }
+                ],
+                "iterData": [
+                    {
+                        "iter_enabled": true,
+                        "iter_item": "region",
+                        "iter_list": {
+                            "constant": false,
+                            "objectItems": false,
+                            "value": "region"
+                        }
+                    }
+                ],
+                "jupyter": {
+                    "source_hidden": true
+                },
+                "legotype": "LEGO_TYPE_AWS",
+                "name": "Filter AWS EC2 Instances Without Termination and Lifetime Tag",
                 "nouns": [
                     "aws",
-                    "ec2",
                     "instances",
+                    "without",
+                    "termination",
+                    "lifetime",
                     "tag"
                 ],
                 "orderProperties": [
-                    "region",
-                    "lifetime_tag"
+                    "region"
                 ],
                 "output": {
                     "type": ""
                 },
                 "outputParams": {
-                    "output_name": "InstanceId",
+                    "output_name": "untagged_ec2_instances",
                     "output_name_enabled": true
                 },
+                "printOutput": true,
                 "tags": [
-                    "aws_filter_ec2_by_tags"
+                    "aws_filter_instances_without_termination_and_lifetime_tag"
                 ],
-                "title": "Filter AWS EC2 Instances Without Lifetime Tag",
                 "trusted": true,
                 "verbs": [
                     "filter"
@@ -148,85 +280,189 @@
                 "##  All rights reserved.\n",
                 "##\n",
                 "from pydantic import BaseModel, Field\n",
-                "from typing import List\n",
+                "from typing import List, Tuple, Optional\n",
                 "from unskript.connectors.aws import aws_get_paginator\n",
+                "from unskript.legos.utils import CheckOutput, CheckOutputStatus\n",
+                "from unskript.legos.aws.aws_list_all_regions.aws_list_all_regions import aws_list_all_regions\n",
                 "import pprint\n",
-                "\n",
+                "from datetime import datetime, date\n",
                 "\n",
                 "from beartype import beartype\n",
                 "@beartype\n",
-                "def aws_filter_ec2_without_lifetime_tag_printer(output):\n",
+                "def aws_filter_instances_without_termination_and_lifetime_tag_printer(output):\n",
                 "    if output is None:\n",
                 "        return\n",
-                "    pprint.pprint({\"Instances\": output})\n",
-                "\n",
+                "    pprint.pprint(output.json())\n",
                 "\n",
                 "@beartype\n",
-                "def aws_filter_ec2_without_lifetime_tag(handle, lifetime_tag: str, region: str) -> List:\n",
-                "    \"\"\"aws_filter_ec2_without_lifetime_tag Returns an array of instances matching tags.\n",
+                "def fetch_instances_from_valid_region(res,r):\n",
+                "    result=[]\n",
+                "    instances_dict={}\n",
+                "    for reservation in res:\n",
+                "            for instance in reservation['Instances']:\n",
+                "                try:\n",
+                "                    tagged_instance = instance['Tags']\n",
+                "                    tag_keys = [tags['Key'] for tags in tagged_instance]\n",
+                "                    if 'terminationDateTag' not in tag_keys or 'lifetimeTag' not in tag_keys:\n",
+                "                        result.append(instance['InstanceId'])\n",
+                "                    elif 'terminationDateTag' not in tag_keys and 'lifetimeTag' not in tag_keys:\n",
+                "                        result.append(instance['InstanceId'])\n",
+                "                    if 'terminationDateTag' in tag_keys:\n",
+                "                        for x in instance['Tags']:\n",
+                "                            if x['Key'] == 'terminationDateTag':\n",
+                "                                right_now = date.today()\n",
+                "                                date_object = datetime.strptime(x['Value'], '%d-%m-%Y').date()\n",
+                "                                if date_object < right_now:\n",
+                "                                    result.append(instance['InstanceId'])\n",
+                "                            elif x['Key'] == 'lifetimeTag':\n",
+                "                                launch_time = instance['LaunchTime']\n",
+                "                                convert_to_datetime = launch_time.strftime(\"%d-%m-%Y\")\n",
+                "                                launch_date = datetime.strptime(convert_to_datetime,'%d-%m-%Y').date()\n",
+                "                                if x['Value'] is not 'INDEFINITE':\n",
+                "                                    if launch_date < right_now:\n",
+                "                                        result.append(instance['InstanceId'])\n",
+                "                except Exception as e:\n",
+                "                        if len(instance['InstanceId'])!=0:\n",
+                "                            result.append(instance['InstanceId'])\n",
+                "    if len(result)!=0:\n",
+                "        instances_dict['region']= r\n",
+                "        instances_dict['instances']= result\n",
+                "    return instances_dict\n",
+                "\n",
+                "@beartype\n",
+                "def aws_filter_instances_without_termination_and_lifetime_tag(handle, region: str=None) -> CheckOutput:\n",
+                "    \"\"\"aws_filter_ec2_without_lifetime_tag Returns an List of instances which not have lifetime tag.\n",
+                "\n",
+                "        Assumed tag key format - terminationDateTag, lifetimeTag\n",
+                "        Assumed Date format for both keys is -> dd-mm-yy\n",
                 "\n",
                 "        :type handle: object\n",
-                "        :param handle: Object returned from task.validate(...)..\n",
-                "\n",
-                "        :type lifetime_tag: string\n",
-                "        :param lifetime_tag: Tag to filter Instances.\n",
+                "        :param handle: Object returned from task.validate(...).\n",
                 "\n",
                 "        :type region: string\n",
-                "        :param region: Used to filter the volume for specific region.\n",
+                "        :param region: Used to filter the instance for specific region.\n",
                 "\n",
-                "        :rtype: Array of instances which not having lifetime tag.\n",
+                "        :rtype: Object of status, instances which dont having terminationDateTag and lifetimeTag, and error\n",
                 "    \"\"\"\n",
-                "    # Input param validation.\n",
+                "    final_list=[]\n",
+                "    all_regions = [region]\n",
+                "    if region is None or len(region) == 0:\n",
+                "        all_regions = aws_list_all_regions(handle=handle)\n",
+                "    for r in all_regions:\n",
+                "        try:\n",
+                "            ec2Client = handle.client('ec2', region_name=r)\n",
+                "            all_reservations = aws_get_paginator(ec2Client, \"describe_instances\", \"Reservations\")\n",
+                "            instances_without_tags = fetch_instances_from_valid_region(all_reservations,r)\n",
+                "            if len(instances_without_tags)!=0:\n",
+                "                final_list.append(instances_without_tags)\n",
+                "        except Exception as e:\n",
+                "            pass\n",
+                "    return CheckOutput(status=CheckOutputStatus.SUCCESS,\n",
+                "                   objects=final_list,\n",
+                "                   error=str(\"\"))\n",
                 "\n",
-                "    ec2Client = handle.client('ec2', region_name=region)\n",
-                "    res = aws_get_paginator(ec2Client, \"describe_instances\", \"Reservations\")\n",
-                "\n",
-                "    result = []\n",
-                "    for reservation in res:\n",
-                "        for instance in reservation['Instances']:\n",
-                "            try:\n",
-                "                tagged_instance = instance['Tags']\n",
-                "                tag_keys = [tags['Key'] for tags in tagged_instance]\n",
-                "                if lifetime_tag not in tag_keys:\n",
-                "                    result.append(instance['InstanceId'])\n",
-                "            except Exception as e:\n",
-                "                result.append(instance['InstanceId'])\n",
-                "\n",
-                "    return result\n",
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
+                "task.configure(continueOnError=True)\n",
                 "task.configure(inputParamsJson='''{\n",
-                "    \"lifetime_tag\": \"Lifetime_Tag\",\n",
-                "    \"region\": \"Region\"\n",
+                "    \"region\": \"iter_item\"\n",
                 "    }''')\n",
-                "task.configure(outputName=\"InstanceId\")\n",
-                "\n",
+                "task.configure(iterJson='''{\n",
+                "    \"iter_enabled\": true,\n",
+                "    \"iter_list_is_const\": false,\n",
+                "    \"iter_list\": \"region\",\n",
+                "    \"iter_parameter\": \"region\"\n",
+                "    }''')\n",
+                "task.configure(outputName=\"untagged_ec2_instances\")\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
-                "    task.execute(aws_filter_ec2_without_lifetime_tag, lego_printer=aws_filter_ec2_without_lifetime_tag_printer, hdl=hdl, args=args)"
+                "    task.execute(aws_filter_instances_without_termination_and_lifetime_tag, lego_printer=aws_filter_instances_without_termination_and_lifetime_tag_printer, hdl=hdl, args=args)"
             ]
         },
         {
             "cell_type": "markdown",
-            "id": "adae7b60-f59e-46a8-887e-ca6986b95adc",
+            "id": "9cd2a6cc-c0b6-48c7-837f-c623f8cf53d4",
             "metadata": {
                 "jupyter": {
                     "source_hidden": false
                 },
-                "name": "Terminate AWS Instance",
+                "name": "Step 2A",
                 "orderProperties": [],
                 "tags": [],
-                "title": "Terminate AWS Instance"
+                "title": "Step 2A"
             },
             "source": [
-                "Here we will use unSkript Terminate AWS Instances Lego. This lego takes instance_id and region as input. This input is used to terminate EC2 instances which don't have lifetime tag"
+                "<h3 id=\"Create-List-of-Untagged-Instances\">Create List of Untagged Instances</h3>\n",
+                "<p>This action filters regions that have no untagged EC2 instances and creates a list of the ones that have have</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>None</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following output: <code>all_untagged_instances</code></p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "ff6ee3fa-b94b-4679-943b-782b32c1a095",
+            "metadata": {
+                "customAction": true,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-01-30T14:31:21.687Z"
+                },
+                "jupyter": {
+                    "source_hidden": true
+                },
+                "name": "Create List of Untagged Instances",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Create List of Untagged Instances",
+                "trusted": true
+            },
+            "outputs": [],
+            "source": [
+                "all_untagged_instances = []\n",
+                "dummy = []\n",
+                "for k,v in untagged_ec2_instances.items():\n",
+                "    if v.status==CheckOutputStatus.SUCCESS:\n",
+                "        if len(v.objects)!=0:\n",
+                "            dummy = v.objects\n",
+                "            for x in dummy:\n",
+                "                all_untagged_instances.append(x)\n",
+                "print(all_untagged_instances)\n",
+                "task.configure(outputName=\"all_untagged_instances\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "c09c5eb2-a9a7-4119-aef4-b07e0fdd6c80",
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Step 2",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step 2"
+            },
+            "source": [
+                "<h3 id=\"Terminate-AWS-Instance\">Terminate AWS Instance</h3>\n",
+                "<p>This action terminates EC2 instances which don't have lifetime tag as captured in Step 1👆</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>instance_ids, region</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following output: <code>None</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "83a33191-b8b7-46a6-ab31-16482237d10a",
+            "id": "7f622b00-2f51-4f44-aeaa-18f67823a4ea",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
@@ -234,23 +470,23 @@
                 "actionRequiredLinesInCode": [],
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
+                "action_modified": false,
                 "action_uuid": "8744e8836d7a0aff41120620fa4d703dacff25b0dbb5c9c7b87b83783c6c9d18",
-                "continueOnError": false,
+                "continueOnError": true,
                 "createTime": "1970-01-01T00:00:00Z",
-                "credentialsJson": {},
                 "currentVersion": "0.1.0",
-                "description": " Terminate AWS Instances",
-                "id": 187,
-                "index": 187,
+                "description": "Terminate AWS Instances",
+                "id": 192,
+                "index": 192,
                 "inputData": [
                     {
                         "instance_ids": {
                             "constant": false,
-                            "value": "InstanceId"
+                            "value": "\"iter.get(\\\\\"instances\\\\\")\""
                         },
                         "region": {
                             "constant": false,
-                            "value": "Region"
+                            "value": "\"iter.get(\\\\\"region\\\\\")\""
                         }
                     }
                 ],
@@ -279,15 +515,26 @@
                         "type": "object"
                     }
                 ],
+                "iterData": [
+                    {
+                        "iter_enabled": true,
+                        "iter_item": {
+                            "instance_ids": "instances",
+                            "region": "region"
+                        },
+                        "iter_list": {
+                            "constant": false,
+                            "objectItems": true,
+                            "value": "all_untagged_instances"
+                        }
+                    }
+                ],
                 "jupyter": {
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_AWS",
-                "name": " Terminate AWS Instances",
-                "nouns": [
-                    "aws",
-                    "instances"
-                ],
+                "name": "Terminate AWS Instances",
+                "nouns": [],
                 "orderProperties": [
                     "instance_ids",
                     "region"
@@ -295,12 +542,11 @@
                 "output": {
                     "type": ""
                 },
+                "printOutput": true,
                 "tags": [
                     "aws_terminate_instance"
                 ],
-                "verbs": [
-                    "terminate"
-                ]
+                "verbs": []
             },
             "outputs": [],
             "source": [
@@ -323,6 +569,19 @@
                 "\n",
                 "@beartype\n",
                 "def aws_terminate_instance(handle, instance_ids: List, region: str) -> Dict:\n",
+                "    \"\"\"aws_terminate_instance Returns an Dict of info terminated instance.\n",
+                "\n",
+                "        :type handle: object\n",
+                "        :param handle: Object returned from task.validate(...).\n",
+                "\n",
+                "        :type instance_ids: List\n",
+                "        :param instance_ids: Tag to filter Instances.\n",
+                "\n",
+                "        :type region: string\n",
+                "        :param region: Used to filter the instance for specific region.\n",
+                "\n",
+                "        :rtype: Dict of info terminated instance.\n",
+                "    \"\"\"\n",
                 "    ec2Client = handle.client('ec2', region_name=region)\n",
                 "    res = ec2Client.terminate_instances(InstanceIds=instance_ids)\n",
                 "\n",
@@ -330,11 +589,19 @@
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
+                "task.configure(continueOnError=True)\n",
                 "task.configure(inputParamsJson='''{\n",
-                "    \"instance_ids\": \"InstanceId\",\n",
-                "    \"region\": \"Region\"\n",
+                "    \"instance_ids\": \"iter.get(\\\\\"instances\\\\\")\",\n",
+                "    \"region\": \"iter.get(\\\\\"region\\\\\")\"\n",
+                "    }''')\n",
+                "task.configure(iterJson='''{\n",
+                "    \"iter_enabled\": true,\n",
+                "    \"iter_list_is_const\": false,\n",
+                "    \"iter_list\": \"all_untagged_instances\",\n",
+                "    \"iter_parameter\": [\"instance_ids\",\"region\"]\n",
                 "    }''')\n",
                 "\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
                 "    task.execute(aws_terminate_instance, lego_printer=aws_terminate_instance_printer, hdl=hdl, args=args)"
@@ -342,7 +609,7 @@
         },
         {
             "cell_type": "markdown",
-            "id": "e3993953-c63c-430f-8adb-30ce629d0494",
+            "id": "324ba188-b516-4100-aebd-18ec3ce8203c",
             "metadata": {
                 "jupyter": {
                     "source_hidden": false
@@ -353,49 +620,48 @@
                 "title": "Conclusion"
             },
             "source": [
-                "In this Runbook, we demonstrated the use of unSkript's AWS legos to perform AWS action of collecting (and then terminating) any EC2 instances which don't have a lifetime tag. To view the full platform capabilities of unSkript please visit https://unskript.com"
+                "<h3 id=\"Conclusion\">Conclusion</h3>\n",
+                "<p>In this Runbook, we demonstrated the use of unSkript's AWS actions to filter untagged instances and terminate them. To view the full platform capabilities of unSkript please visit <a href=\"https://us.app.unskript.io\" target=\"_blank\" rel=\"noopener\">us.app.unskript.io</a></p>"
             ]
         }
     ],
     "metadata": {
         "execution_data": {
-            "environment_id": "1499f27c-6406-4fbd-bd1b-c6f92800018f",
-            "environment_name": "Staging",
+            "environment_name": "SingleAMIInstance",
+            "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "9bd35239-4b27-4af6-8f8d-be5dc1b2e8c1.ipynb",
-            "parameters": null,
-            "runbook_name": "Terminate EC2 Instances Without Valid Lifetime Tag",
+            "notebook_id": "b0323336-04e8-46fb-a1af-e1de93ff1385.ipynb",
+            "parameters": [
+                "region"
+            ],
+            "proxy_id": "1b032d60-0671-498f-a117-6c2f355648fe",
+            "runbook_name": "Terminate Instances without a valid Lifetime or Termination Tag",
             "search_string": "",
             "show_tool_tip": false,
-            "tenant_id": "982dba5f-d9df-48ae-a5bf-ec1fc94d4882",
-            "tenant_url": "https://tenant-staging.alpha.unskript.io",
-            "user_email_id": "harshal.bangre@unskript.com",
-            "workflow_id": "dd409f4f-085d-4ef3-8872-fba9e86b0757"
+            "tenant_id": "117718cf-b601-4a00-9164-3e4311468e45",
+            "tenant_url": "https://tenant-jayasimha.dev.unskript.io",
+            "user_email_id": "jayasimha@unskript.com",
+            "workflow_id": "9aaaafb9-fd37-41f7-a462-190bc2c8ff32"
         },
         "kernelspec": {
-            "display_name": "unSkript (Build: 618)",
-            "name": "python_kubernetes"
+            "display_name": "Python 3.10.6 64-bit",
+            "language": "python",
+            "name": "python3"
         },
         "language_info": {
             "file_extension": ".py",
             "mimetype": "text/x-python",
             "name": "python",
-            "pygments_lexer": "ipython3"
+            "pygments_lexer": "ipython3",
+            "version": "3.10.6"
         },
         "parameterSchema": {
             "properties": {
-                "Lifetime_Tag": {
-                    "default": "aws:autoscaling:groupName",
-                    "description": "Lifetime_Tag",
-                    "title": "Lifetime_Tag",
-                    "type": "string"
-                },
-                "Region": {
-                    "default": "us-west-2",
-                    "description": "AWS Region",
-                    "title": "Region",
-                    "type": "string"
+                "region": {
+                    "description": "AWS Region(s) to search for EC2 instances. Eg: [\"us-west-2\",\"ap-south-1\"]",
+                    "title": "region",
+                    "type": "array"
                 }
             },
             "required": [],
@@ -403,8 +669,12 @@
             "type": "object"
         },
         "parameterValues": {
-            "Lifetime_Tag": "aws:autoscaling:groupName",
-            "Region": "us-west-2"
+            "region": null
+        },
+        "vscode": {
+            "interpreter": {
+                "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+            }
         }
     },
     "nbformat": 4,

--- a/AWS/Terminate_EC2_Instances_Without_Valid_Lifetime_Tag.ipynb
+++ b/AWS/Terminate_EC2_Instances_Without_Valid_Lifetime_Tag.ipynb
@@ -52,7 +52,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 4,
+            "execution_count": 3,
             "id": "c0ced73a-dfc6-4ed8-b596-98849ad7675a",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
@@ -68,7 +68,7 @@
                 "currentVersion": "0.1.0",
                 "description": "List all available AWS Regions",
                 "execution_data": {
-                    "last_date_success_run_cell": "2023-01-30T14:30:49.619Z"
+                    "last_date_success_run_cell": "2023-01-31T14:15:14.152Z"
                 },
                 "id": 215,
                 "index": 215,
@@ -152,11 +152,6 @@
                 "    }''')\n",
                 "\n",
                 "task.configure(outputName=\"region\")\n",
-                "task.configure(credentialsJson='''{\n",
-                "    \"credential_name\": \"DevRole\",\n",
-                "    \"credential_type\": \"CONNECTOR_TYPE_AWS\",\n",
-                "    \"credential_id\": \"049e1bfd-59e4-44a4-9f3f-e96710a2387d\"\n",
-                "}''')\n",
                 "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
@@ -188,8 +183,8 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 5,
-            "id": "d2b07f6f-2cdd-4bef-b8df-40481f8ba14e",
+            "execution_count": 4,
+            "id": "74fc0621-1f0d-46fb-ad63-c152b95cfb9e",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
@@ -204,7 +199,7 @@
                 "currentVersion": "0.1.0",
                 "description": "Filter AWS EC2 Instances Without Termination and Lifetime Tag and Check of they are valid",
                 "execution_data": {
-                    "last_date_success_run_cell": "2023-01-30T14:31:10.116Z"
+                    "last_date_success_run_cell": "2023-01-31T14:15:37.809Z"
                 },
                 "id": 265,
                 "index": 265,
@@ -292,7 +287,10 @@
                 "def aws_filter_instances_without_termination_and_lifetime_tag_printer(output):\n",
                 "    if output is None:\n",
                 "        return\n",
-                "    pprint.pprint(output.json())\n",
+                "    if isinstance(output, CheckOutput):\n",
+                "        pprint.pprint(output.json())\n",
+                "    else:\n",
+                "        pprint.pprint(output)\n",
                 "\n",
                 "@beartype\n",
                 "def fetch_instances_from_valid_region(res,r):\n",
@@ -357,10 +355,14 @@
                 "                final_list.append(instances_without_tags)\n",
                 "        except Exception as e:\n",
                 "            pass\n",
-                "    return CheckOutput(status=CheckOutputStatus.SUCCESS,\n",
+                "    if len(final_list)!=0:\n",
+                "        return CheckOutput(status=CheckOutputStatus.FAILED,\n",
                 "                   objects=final_list,\n",
                 "                   error=str(\"\"))\n",
-                "\n",
+                "    else:\n",
+                "        return CheckOutput(status=CheckOutputStatus.SUCCESS,\n",
+                "                   objects=final_list,\n",
+                "                   error=str(\"\"))\n",
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
@@ -374,7 +376,9 @@
                 "    \"iter_list\": \"region\",\n",
                 "    \"iter_parameter\": \"region\"\n",
                 "    }''')\n",
+                "\n",
                 "task.configure(outputName=\"untagged_ec2_instances\")\n",
+                "\n",
                 "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
@@ -406,15 +410,12 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 6,
+            "execution_count": 5,
             "id": "ff6ee3fa-b94b-4679-943b-782b32c1a095",
             "metadata": {
                 "customAction": true,
                 "execution_data": {
-                    "last_date_success_run_cell": "2023-01-30T14:31:21.687Z"
-                },
-                "jupyter": {
-                    "source_hidden": true
+                    "last_date_success_run_cell": "2023-01-31T14:15:49.592Z"
                 },
                 "name": "Create List of Untagged Instances",
                 "orderProperties": [],
@@ -427,7 +428,7 @@
                 "all_untagged_instances = []\n",
                 "dummy = []\n",
                 "for k,v in untagged_ec2_instances.items():\n",
-                "    if v.status==CheckOutputStatus.SUCCESS:\n",
+                "    if v.status==CheckOutputStatus.FAILED:\n",
                 "        if len(v.objects)!=0:\n",
                 "            dummy = v.objects\n",
                 "            for x in dummy:\n",
@@ -631,7 +632,7 @@
             "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "b0323336-04e8-46fb-a1af-e1de93ff1385.ipynb",
+            "notebook_id": "9dce0ae6-6ed6-43fc-82cf-59db86aff831.ipynb",
             "parameters": [
                 "region"
             ],


### PR DESCRIPTION
## Description
Added Check lego to get instances without Termination and Lifetime Tag

### Testing
https://user-images.githubusercontent.com/110628398/215515693-d314aa72-afc4-4fba-bfd9-1d2e8db382ac.mov


### Checklist:
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
