### PR TITLE
Runbook: Restrict S3 Buckets with read/write permissions

### DIFF
--- a/AWS/Restrict_S3_Buckets_with_READ_WRITE_Permissions.ipynb
+++ b/AWS/Restrict_S3_Buckets_with_READ_WRITE_Permissions.ipynb
@@ -2,54 +2,58 @@
     "cells": [
         {
             "cell_type": "markdown",
-            "id": "4b0b59f0-ebc6-443c-aca3-827ddaf3c349",
+            "id": "c92fbc7c-b9b3-4fd9-8f55-9811f3580311",
             "metadata": {
                 "jupyter": {
                     "source_hidden": false
                 },
-                "name": "Restrict S3 Buckets with READ/WRITE Permissions",
+                "name": "Steps Overview",
                 "orderProperties": [],
                 "tags": [],
-                "title": "Restrict S3 Buckets with READ/WRITE Permissions"
+                "title": "Steps Overview"
             },
             "source": [
-                "<img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\"/> \n",
-                "<h1> unSkript Runbooks </h1>\n",
+                "<center><img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\">\n",
+                "<h1 id=\"unSkript-Runbooks\">unSkript Runbooks<a class=\"jp-InternalAnchorLink\" href=\"#unSkript-Runbooks\" target=\"_self\">&para;</a></h1>\n",
                 "<div class=\"alert alert-block alert-success\">\n",
-                "    <b> This runbook demonstrates Restrict S3 Buckets with READ/WRITE Permissions using unSkript legos.</b>\n",
-                "</div>\n",
-                "\n",
-                "<br>\n",
-                "\n",
-                "<center><h2>Restrict S3 Buckets with READ/WRITE Permissions to all Authenticated Users </h2></center>\n",
-                "\n",
-                "# Steps Overview\n",
-                " 1) List all the S3 buckets.\n",
-                " 2) Filter buckets which has ACL public READ/WRITE permissions.\n",
-                " 3) Change the ACL Public READ/WRITE permissions to private.\n",
-                "     "
+                "<h3 id=\"Objective\">Objective<a class=\"jp-InternalAnchorLink\" href=\"#Objective\" target=\"_self\">&para;</a></h3>\n",
+                "<br><strong style=\"color: #000000;\"><em><strong>Restrict S3 Buckets with READ/WRITE Permissions for all authenticated users.</strong></em></strong></div>\n",
+                "</center>\n",
+                "<p>&nbsp;</p>\n",
+                "<center>\n",
+                "<h2 id=\"Terminate-EC2-Instances-Without-Valid-Lifetime-Tag\"><u>Restrict S3 Buckets with READ/WRITE Permissions</u><a class=\"jp-InternalAnchorLink\" href=\"#Terminate-EC2-Instances-Without-Valid-Lifetime-Tag\" target=\"_self\">&para;</a></h2>\n",
+                "</center>\n",
+                "<h1 id=\"Steps-Overview\">Steps Overview<a class=\"jp-InternalAnchorLink\" href=\"#Steps-Overview\" target=\"_self\">&para;</a></h1>\n",
+                "<p>1)&nbsp;<a href=\"#1\">Filter Public S3 buckets with ACL Permissions</a><br>2)&nbsp;<a href=\"#2\">Change the permissions to private</a></p>"
             ]
         },
         {
             "cell_type": "markdown",
-            "id": "4c1483ea-56bf-4fc0-ae64-825c5d50a238",
+            "id": "f3d880d7-bf75-4908-bdf0-0c61f3552b30",
             "metadata": {
                 "jupyter": {
                     "source_hidden": false
                 },
-                "name": "List of S3 Buckets",
+                "name": "Step 1A",
                 "orderProperties": [],
                 "tags": [],
-                "title": "List of S3 Buckets"
+                "title": "Step 1A"
             },
             "source": [
-                "Here we will use unSkript List of S3 Buckets Lego. This lego takes region: str as input. This input is used to list all the S3 buckets available."
+                "<h3 id=\"List-all-AWS-Regions\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>List all AWS Regions</h3>\n",
+                "<p>This action fetches all AWS Regions to execute Step 1👇. This action will only execute if no <code>region</code> is provided.</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>None</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following ouput: <code>region</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 11,
-            "id": "fb3f8fda-44f0-4549-b9c2-edbd725df10f",
+            "execution_count": 8,
+            "id": "37e140d6-35b5-411a-86fc-3a1ef0fb9c8d",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
@@ -57,141 +61,130 @@
                 "actionRequiredLinesInCode": [],
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
-                "action_uuid": "eb57da3b21aec38d005bf0355a48ba53937c7ac62f98e9c968c9501412d72008",
-                "continueOnError": false,
+                "action_modified": false,
+                "action_uuid": "708ea4af5f8fe7096a15b3a52c4a657606bab9e177386fad7a847341ed607d64",
+                "collapsed": true,
+                "condition_enabled": true,
                 "createTime": "1970-01-01T00:00:00Z",
-                "credentialsJson": {},
                 "currentVersion": "0.1.0",
-                "description": "Apply a New AWS Policy for S3 Bucket",
+                "description": "List all available AWS Regions",
                 "execution_data": {
-                    "last_date_success_run_cell": "2022-09-29T13:13:17.290Z"
+                    "last_date_success_run_cell": "2023-02-02T15:38:51.218Z"
                 },
-                "id": 135,
-                "index": 135,
-                "inputData": [
-                    {
-                        "region": {
-                            "constant": false,
-                            "value": "Region"
-                        }
-                    }
-                ],
+                "id": 215,
+                "index": 215,
                 "inputschema": [
                     {
-                        "properties": {
-                            "region": {
-                                "default": "",
-                                "description": "AWS region of the bucket.",
-                                "title": "Region",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "name",
-                            "policy",
-                            "region"
-                        ],
-                        "title": "aws_put_bucket_policy",
+                        "properties": {},
+                        "title": "aws_list_all_regions",
                         "type": "object"
                     }
                 ],
                 "jupyter": {
+                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_AWS",
-                "name": "List  of S3 Buckets",
+                "name": "AWS List All Regions",
                 "nouns": [
-                    "aws",
-                    "policy",
-                    "bucket"
+                    "regions",
+                    "aws"
                 ],
-                "orderProperties": [
-                    "region"
-                ],
+                "orderProperties": [],
                 "output": {
                     "type": ""
                 },
                 "outputParams": {
-                    "output_name": "bucketlist",
+                    "output_name": "region",
                     "output_name_enabled": true
                 },
+                "printOutput": true,
+                "startcondition": "not region",
                 "tags": [
-                    "aws_put_bucket_policy"
+                    "aws_list_all_regions"
                 ],
-                "title": "List  of S3 Buckets",
                 "trusted": true,
                 "verbs": [
-                    "apply"
+                    "list"
                 ]
             },
             "outputs": [],
             "source": [
-                "##\n",
-                "##  Copyright (c) 2021 unSkript, Inc\n",
-                "##  All rights reserved.\n",
-                "##\n",
-                "from pydantic import BaseModel, Field\n",
-                "from typing import List\n",
-                "import pprint\n",
+                "#\n",
+                "# Copyright (c) 2021 unSkript.com\n",
+                "# All rights reserved.\n",
+                "#\n",
                 "\n",
+                "from pydantic import BaseModel, Field\n",
+                "from typing import Dict, List\n",
+                "import pprint\n",
                 "\n",
                 "from beartype import beartype\n",
                 "@beartype\n",
-                "def aws_get_s3_buckets_printer(output):\n",
+                "def aws_list_all_regions_printer(output):\n",
                 "    if output is None:\n",
                 "        return\n",
                 "    pprint.pprint(output)\n",
                 "\n",
                 "\n",
                 "@beartype\n",
-                "def aws_get_s3_buckets(handle, region: str) -> List:\n",
-                "    \"\"\"aws_get_s3_buckets List all the S3 buckets.\n",
+                "def aws_list_all_regions(handle) -> List:\n",
+                "    \"\"\"aws_list_all_regions lists all the AWS regions\n",
                 "\n",
-                "          :type region: string\n",
-                "          :param region: location of the bucket\n",
+                "        :type handle: object\n",
+                "        :param handle: Object returned from Task Validate\n",
                 "\n",
-                "          :rtype: List all the S3 buckets\n",
-                "      \"\"\"\n",
-                "    s3Session = handle.resource(\"s3\", region_name=region)\n",
-                "    response = s3Session.buckets.all()\n",
-                "    result = []\n",
-                "    for bucket in response:\n",
-                "        result.append(bucket.name)\n",
-                "    return result\n",
+                "        :rtype: Result List of result\n",
+                "    \"\"\"\n",
                 "\n",
+                "    result = handle.aws_cli_command(\"aws ec2 describe-regions --all-regions --query 'Regions[].{Name:RegionName}' --output text\")\n",
+                "    if result is None or result.returncode != 0:\n",
+                "        print(\"Error while executing command : {}\".format(result))\n",
+                "        return str()\n",
+                "    result_op = list(result.stdout.split(\"\\n\"))\n",
+                "    list_region = [x for x in result_op if x != '']\n",
+                "    return list_region\n",
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
-                "task.configure(inputParamsJson='''{\n",
-                "    \"region\": \"Region\"\n",
+                "task.configure(conditionsJson='''{\n",
+                "    \"condition_enabled\": true,\n",
+                "    \"condition_cfg\": \"not region\",\n",
+                "    \"condition_result\": true\n",
                 "    }''')\n",
-                "task.configure(outputName=\"bucketlist\")\n",
                 "\n",
+                "task.configure(outputName=\"region\")\n",
+                "\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
-                "    task.execute(aws_get_s3_buckets, lego_printer=aws_get_s3_buckets_printer, hdl=hdl, args=args)"
+                "    task.execute(aws_list_all_regions, lego_printer=aws_list_all_regions_printer, hdl=hdl, args=args)"
             ]
         },
         {
             "cell_type": "markdown",
-            "id": "03b9d095-02ab-4149-b963-eca1fce9b3d6",
+            "id": "f6cfb169-e57e-4e88-8cf2-e85e828b6a2c",
             "metadata": {
-                "jupyter": {
-                    "source_hidden": false
-                },
-                "name": "Get Public S3 Bucket List",
+                "name": "Step 1",
                 "orderProperties": [],
                 "tags": [],
-                "title": "Get Public S3 Bucket List"
+                "title": "Step 1"
             },
             "source": [
-                "Here we will use unSkript Get Public S3 Bucket List Lego. This lego takes Bucket_List: list, Permission: str, region: str as input. Thi inputs is used to list S3 buckets which has public ACL permissions."
+                "<h3 id=\"List-expiring-ACM-certificates\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>Filter S3 buckets with ACL Permissiosn<a class=\"jp-InternalAnchorLink\" href=\"#List-expiring-ACM-certificates\" target=\"_self\">&para;</a></h3>\n",
+                "<p>This action will fetch all public S3 buckets with the chosen permissions- <em>\"READ\",\"READ_ACP\",\"WRITE\",\"WRITE_ACP\", and \"FULL_CONTROL\"</em>, If no permissions are given, the action will execute for <span style=\"color: blue;\"> READ</span> and <span style=\"color: blue;\"> WRITE</span>.</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>bucket_permission(Optional)</code>, <code>region(Optional)</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following output: <code>public_buckets</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 18,
-            "id": "91794857-60c2-4ac5-b3f9-cebf65e6b8a3",
+            "execution_count": 10,
+            "id": "68306e61-f5de-44a9-9ed6-957b0f840246",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
@@ -199,93 +192,108 @@
                 "actionRequiredLinesInCode": [],
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
-                "action_uuid": "db69445f5c9c2578e76beafe10607e2ebe8c7b7857c4d2ffdd82d1377b353f19",
-                "continueOnError": false,
+                "action_modified": false,
+                "action_uuid": "b13d82d445e9064eb3cb88ca6247696ee3e7bfceb02b617833992f8552bf48fb",
+                "continueOnError": true,
                 "createTime": "1970-01-01T00:00:00Z",
-                "credentialsJson": {},
                 "currentVersion": "0.1.0",
-                "description": " Apply CORS Policy for S3 Bucket",
+                "description": "Get AWS public S3 Buckets using ACL",
                 "execution_data": {
-                    "last_date_success_run_cell": "2022-09-29T13:16:52.973Z"
+                    "last_date_success_run_cell": "2023-02-02T15:41:26.012Z"
                 },
-                "id": 162,
-                "index": 162,
+                "id": 225,
+                "index": 225,
                 "inputData": [
                     {
-                        "Bucket_List": {
-                            "constant": false,
-                            "value": "bucketlist"
-                        },
-                        "Permission": {
-                            "constant": false,
-                            "value": "Permission"
+                        "permission": {
+                            "constant": true,
+                            "value": ""
                         },
                         "region": {
                             "constant": false,
-                            "value": "Region"
+                            "value": "iter_item"
                         }
                     }
                 ],
                 "inputschema": [
                     {
-                        "properties": {
-                            "Bucket_List": {
-                                "default": "",
-                                "description": "Bucket List",
-                                "title": "Bucket_List",
-                                "type": "array"
-                            },
-                            "Permission": {
-                                "default": "",
-                                "description": "Permission",
-                                "title": "Permission",
+                        "definitions": {
+                            "BucketACLPermissions": {
+                                "description": "An enumeration.",
+                                "enum": [
+                                    "READ",
+                                    "WRITE",
+                                    "READ_ACP",
+                                    "WRITE_ACP",
+                                    "FULL_CONTROL"
+                                ],
+                                "title": "BucketACLPermissions",
                                 "type": "string"
+                            }
+                        },
+                        "properties": {
+                            "permission": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/BucketACLPermissions"
+                                    }
+                                ],
+                                "description": "Set of permissions that AWS S3 supports in an ACL for buckets and objects",
+                                "title": "S3 Bucket's ACL Permission"
                             },
                             "region": {
                                 "default": "",
-                                "description": "AWS region of the bucket.",
+                                "description": "Name of the AWS Region",
                                 "title": "Region",
                                 "type": "string"
                             }
                         },
-                        "required": [
-                            "name",
-                            "corsRules",
-                            "region"
-                        ],
-                        "title": "aws_put_bucket_cors",
+                        "title": "aws_get_public_s3_buckets",
                         "type": "object"
+                    }
+                ],
+                "iterData": [
+                    {
+                        "iter_enabled": true,
+                        "iter_item": "region",
+                        "iter_list": {
+                            "constant": false,
+                            "objectItems": false,
+                            "value": "region"
+                        }
                     }
                 ],
                 "jupyter": {
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_AWS",
-                "name": "Get Public S3 Bucket List",
+                "name": "Get AWS public S3 Buckets using ACL",
                 "nouns": [
-                    "cors",
-                    "policy",
-                    "bucket"
+                    "aws",
+                    "s3",
+                    "public",
+                    "buckets",
+                    "by",
+                    "acl"
                 ],
                 "orderProperties": [
                     "region",
-                    "Bucket_List",
-                    "Permission"
+                    "permission"
                 ],
                 "output": {
                     "type": ""
                 },
                 "outputParams": {
-                    "output_name": "PublicBucket",
+                    "output_name": "public_buckets",
                     "output_name_enabled": true
                 },
+                "printOutput": true,
                 "tags": [
-                    "aws_put_bucket_cors"
+                    "aws_get_public_s3_buckets"
                 ],
-                "title": "Get Public S3 Bucket List",
                 "trusted": true,
                 "verbs": [
-                    "apply"
+                    "filter"
                 ]
             },
             "outputs": [],
@@ -295,7 +303,11 @@
                 "##  All rights reserved.\n",
                 "##\n",
                 "from pydantic import BaseModel, Field\n",
-                "from typing import List\n",
+                "from typing import List, Optional, Tuple\n",
+                "from unskript.legos.utils import CheckOutput, CheckOutputStatus\n",
+                "from unskript.legos.aws.aws_list_all_regions.aws_list_all_regions import aws_list_all_regions\n",
+                "from unskript.legos.aws.aws_get_s3_bucket_list.aws_get_s3_bucket_list import aws_get_s3_buckets\n",
+                "from unskript.enums.aws_acl_permissions_enums import BucketACLPermissions\n",
                 "import pprint\n",
                 "\n",
                 "\n",
@@ -304,47 +316,93 @@
                 "def aws_get_public_s3_buckets_printer(output):\n",
                 "    if output is None:\n",
                 "        return\n",
-                "    pprint.pprint(output)\n",
-                "\n",
+                "    if isinstance(output, CheckOutput):\n",
+                "        print(output.json())\n",
+                "    else:\n",
+                "        pprint.pprint(output)\n",
                 "\n",
                 "@beartype\n",
-                "def aws_get_public_s3_buckets(handle, Bucket_List: list, Permission: str, region: str) -> List:\n",
-                "    \"\"\"aws_get_public_s3_buckets get list of public buckets.\n",
-                "\n",
-                "          :type Bucket_List: list\n",
-                "          :param Bucket_List: list of S3 buckets.\n",
-                "\n",
-                "          :type region: string\n",
-                "          :param region: location of the bucket.\n",
-                "\n",
-                "          :rtype: Dict with the response info.\n",
-                "      \"\"\"\n",
-                "\n",
-                "    s3Client = handle.client('s3',\n",
-                "                             region_name=region)\n",
+                "def check_publicly_accessible_buckets(s3Client,b,all_permissions):\n",
                 "    public_check = [\"http://acs.amazonaws.com/groups/global/AuthenticatedUsers\",\n",
                 "                   \"http://acs.amazonaws.com/groups/global/AllUsers\"]\n",
-                "    # filter public S3 buckets\n",
-                "    result = []\n",
-                "    for bucket in Bucket_List:\n",
-                "        try:\n",
-                "            res = s3Client.get_bucket_acl(Bucket=bucket)\n",
+                "    public_buckets = False\n",
+                "    try:\n",
+                "        res = s3Client.get_bucket_acl(Bucket=b)\n",
+                "        for perm in all_permissions:\n",
                 "            for grant in res[\"Grants\"]:\n",
-                "                if 'Permission' in grant.keys() and Permission == grant[\"Permission\"]:\n",
+                "                if 'Permission' in grant.keys() and perm == grant[\"Permission\"]:\n",
                 "                    if 'URI' in grant[\"Grantee\"] and grant[\"Grantee\"][\"URI\"] in public_check:\n",
-                "                        result.append(bucket)\n",
-                "        except Exception as e:\n",
-                "            continue\n",
+                "                        public_buckets = True\n",
+                "    except Exception as e:\n",
+                "        pass\n",
+                "    return public_buckets\n",
                 "\n",
-                "    return result\n",
+                "@beartype\n",
+                "def aws_get_public_s3_buckets(handle, permission:BucketACLPermissions=None, region: str=None) -> CheckOutput:\n",
+                "    \"\"\"aws_get_public_s3_buckets get list of public buckets.\n",
+                "\n",
+                "        Note- By default(if no permissions are given) READ and WRITE ACL Permissioned S3 buckets are checked for public access. Other ACL Permissions are - \"READ_ACP\"|\"WRITE_ACP\"|\"FULL_CONTROL\"\n",
+                "        :type handle: object\n",
+                "        :param handle: Object returned from task.validate(...)\n",
+                "\n",
+                "        :type permission: Enum\n",
+                "        :param permission: Set of permissions that AWS S3 supports in an ACL for buckets and objects.\n",
+                "\n",
+                "        :type region: string\n",
+                "        :param region: location of the bucket.\n",
+                "\n",
+                "        :rtype: Object with status, list of public S3 buckets with READ/WRITE ACL Permissions, and errors\n",
+                "    \"\"\"\n",
+                "    all_permissions = [permission]\n",
+                "    if permission is None or len(permission)==0:\n",
+                "        all_permissions = [\"READ\",\"WRITE\"]\n",
+                "    result = []\n",
+                "    all_buckets = []\n",
+                "    all_regions = [region]\n",
+                "    if region is None or len(region)==0:\n",
+                "        all_regions = aws_list_all_regions(handle=handle)\n",
+                "    try:\n",
+                "        for r in all_regions:\n",
+                "            s3Client = handle.client('s3',region_name=r)\n",
+                "            output = aws_get_s3_buckets(handle=handle, region=r)\n",
+                "            if len(output)!= 0:\n",
+                "                for o in output:\n",
+                "                    all_buckets_dict = {}\n",
+                "                    all_buckets_dict[\"region\"]=r\n",
+                "                    all_buckets_dict[\"bucket\"]=o\n",
+                "                    all_buckets.append(all_buckets_dict)\n",
+                "    except Exception as e:\n",
+                "        return CheckOutput(status=CheckOutputStatus.RUN_EXCEPTION,\n",
+                "                           objects=[],\n",
+                "                           error=e.__str__())\n",
+                "    for bucket in all_buckets:\n",
+                "        s3Client = handle.client('s3',region_name= bucket['region'])\n",
+                "        flag = check_publicly_accessible_buckets(s3Client,bucket['bucket'], all_permissions)\n",
+                "        if flag:\n",
+                "            result.append(bucket)\n",
+                "    if len(result)!=0:\n",
+                "        return CheckOutput(status=CheckOutputStatus.FAILED,\n",
+                "                   objects=result,\n",
+                "                   error=str(\"\"))\n",
+                "    else:\n",
+                "        return CheckOutput(status=CheckOutputStatus.SUCCESS,\n",
+                "                   objects=result,\n",
+                "                   error=str(\"\"))\n",
+                "\n",
+                "\n",
                 "task = Task(Workflow())\n",
+                "task.configure(continueOnError=True)\n",
                 "task.configure(inputParamsJson='''{\n",
-                "    \"Bucket_List\": \"bucketlist\",\n",
-                "    \"Permission\": \"Permission\",\n",
-                "    \"region\": \"Region\"\n",
+                "    \"region\": \"iter_item\"\n",
                 "    }''')\n",
-                "task.configure(outputName=\"PublicBucket\")\n",
-                "\n",
+                "task.configure(iterJson='''{\n",
+                "    \"iter_enabled\": true,\n",
+                "    \"iter_list_is_const\": false,\n",
+                "    \"iter_list\": \"region\",\n",
+                "    \"iter_parameter\": \"region\"\n",
+                "    }''')\n",
+                "task.configure(outputName=\"public_buckets\")\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
                 "    task.execute(aws_get_public_s3_buckets, lego_printer=aws_get_public_s3_buckets_printer, hdl=hdl, args=args)"
@@ -352,24 +410,82 @@
         },
         {
             "cell_type": "markdown",
-            "id": "5e8de80b-5e36-4869-84b1-e383e7f5810c",
+            "id": "24c71589-028b-4d3b-908f-ce867b462f7a",
             "metadata": {
-                "jupyter": {
-                    "source_hidden": false
-                },
-                "name": "Change ACL Permissions of AWS Bucket",
+                "name": "Step 2A",
                 "orderProperties": [],
                 "tags": [],
-                "title": "Change ACL Permissions of AWS Bucket"
+                "title": "Step 2A"
             },
             "source": [
-                "Here we will use unSkript Change ACL Permissions of AWS Bucket Lego. This lego takes name: str, acl: str, region: str as input. This input is used to change the public ACL permissions to private."
+                "<h3 id=\"Create-List-of-Expiring-Certificates\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>Create List of public S3 Buckets<a class=\"jp-InternalAnchorLink\" href=\"#Create-List-of-Expiring-Certificates\" target=\"_self\">&para;</a></h3>\n",
+                "<p>This action filters regions that have no public buckets and creates a list of public buckets that have are to be made private.</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>None</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following output: <code>all_public_buckets</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 19,
-            "id": "cbe86b8e-040d-481f-bca3-6b9fc63a6cc0",
+            "execution_count": 25,
+            "id": "fa0655b5-e142-445c-9a39-312b4ee9f3f6",
+            "metadata": {
+                "collapsed": true,
+                "customAction": true,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-02T15:56:00.421Z"
+                },
+                "jupyter": {
+                    "outputs_hidden": true,
+                    "source_hidden": true
+                },
+                "name": "Create List of public S3 buckets",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Create List of public S3 buckets",
+                "trusted": true
+            },
+            "outputs": [],
+            "source": [
+                "all_public_buckets = []\n",
+                "\n",
+                "for k,v in public_buckets.items():\n",
+                "    if v.status==CheckOutputStatus.FAILED:\n",
+                "        if len(v.objects)!=0:\n",
+                "            dummy = v.objects\n",
+                "            for x in dummy:\n",
+                "                all_public_buckets.append(x)\n",
+                "print(all_public_buckets)\n",
+                "task.configure(outputName=\"all_public_buckets\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "b49c03e9-2951-4fab-b5f5-5338b8a955f9",
+            "metadata": {
+                "name": "Step 2",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step 2"
+            },
+            "source": [
+                "<h3 id=\"List-expiring-ACM-certificates\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>Change permission to private<a class=\"jp-InternalAnchorLink\" href=\"#List-expiring-ACM-certificates\" target=\"_self\">&para;</a></h3>\n",
+                "<p>Using unSkript's AWS Change ACL Permission of public S3 Bucket action, we will fchange the permissions of the bucket to <em>private, public-read, public-read-write, authenticated-read.&nbsp;</em>If no canned_acl_permission is selected, <span style=\"color: blue;\"> private</span> will be set by default.&nbsp;</p>\n",
+                "<blockquote>\n",
+                "<p>This action takes the following parameters: <code>bucket_name</code>, <code>region,canned_acl_permission</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p>This action captures the following output: <code>None</code></p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "aa32bf79-4f5b-4cc3-a994-c6bf5b7f0d77",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
@@ -377,98 +493,110 @@
                 "actionRequiredLinesInCode": [],
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
-                "action_uuid": "46cc40dfc3023480cfb612dfd6bec7f4e60a7c8bfc366fe62bec40637b112b03",
-                "condition_enabled": true,
-                "continueOnError": false,
+                "action_modified": false,
+                "action_uuid": "305fe6a6f0512eb2d91b71c508b3a192e5b7021bf8196f4deeec5397f2b85e84",
+                "collapsed": true,
+                "continueOnError": true,
                 "createTime": "1970-01-01T00:00:00Z",
-                "credentialsJson": {},
                 "currentVersion": "0.1.0",
-                "description": "Create a new AWS S3 Bucket",
-                "execution_data": {
-                    "last_date_success_run_cell": "2022-09-29T13:17:15.527Z"
-                },
-                "id": 144,
-                "index": 144,
+                "description": "AWS Change ACL Permission public S3 Bucket",
+                "id": 261,
+                "index": 261,
                 "inputData": [
                     {
                         "acl": {
-                            "constant": false,
-                            "value": "ACL_Permission"
+                            "constant": true,
+                            "value": ""
                         },
-                        "name": {
+                        "bucket_name": {
                             "constant": false,
-                            "value": "iter_item"
+                            "value": "\"iter.get(\\\\\"bucket\\\\\")\""
                         },
                         "region": {
                             "constant": false,
-                            "value": "Region"
+                            "value": "\"iter.get(\\\\\"region\\\\\")\""
                         }
                     }
                 ],
                 "inputschema": [
                     {
+                        "definitions": {
+                            "CannedACLPermissions": {
+                                "description": "An enumeration.",
+                                "enum": [
+                                    "Private",
+                                    "PublicRead",
+                                    "PublicReadWrite",
+                                    "AuthenticatedRead"
+                                ],
+                                "title": "CannedACLPermissions",
+                                "type": "string"
+                            }
+                        },
                         "properties": {
                             "acl": {
-                                "description": "The Canned ACL to apply to the bucket. Possible values: private, public-read, public-read-write, authenticated-read.",
-                                "title": "ACL",
-                                "type": "string"
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/CannedACLPermissions"
+                                    }
+                                ],
+                                "description": "Canned ACL Permission type - 'private'|'public-read'|'public-read-write'|'authenticated-read'.",
+                                "title": "Canned ACL Permission"
                             },
-                            "name": {
-                                "description": "Name of the bucket to be created.",
+                            "bucket_name": {
+                                "description": "AWS S3 Bucket Name.",
                                 "title": "Bucket Name",
                                 "type": "string"
                             },
                             "region": {
-                                "description": "AWS Region of the bucket.",
+                                "description": "AWS Region.",
                                 "title": "Region",
                                 "type": "string"
                             }
                         },
                         "required": [
-                            "name",
-                            "acl"
+                            "region",
+                            "bucket_name"
                         ],
-                        "title": "aws_create_bucket",
+                        "title": "aws_put_bucket_acl",
                         "type": "object"
                     }
                 ],
                 "iterData": [
                     {
                         "iter_enabled": true,
-                        "iter_item": "name",
+                        "iter_item": {
+                            "bucket_name": "bucket",
+                            "region": "region"
+                        },
                         "iter_list": {
                             "constant": false,
-                            "objectItems": false,
-                            "value": "PublicBucket"
+                            "objectItems": true,
+                            "value": "all_public_buckets"
                         }
                     }
                 ],
                 "jupyter": {
+                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_AWS",
-                "name": "Change ACL Permissions of AWS Bucket",
-                "nouns": [
-                    "aws",
-                    "bucket"
-                ],
+                "name": "AWS Change ACL Permission of public S3 Bucket",
+                "nouns": [],
                 "orderProperties": [
-                    "name",
-                    "acl",
-                    "region"
+                    "region",
+                    "bucket_name",
+                    "acl"
                 ],
                 "output": {
                     "type": ""
                 },
-                "startcondition": "len(PublicBucket)>0",
+                "printOutput": true,
                 "tags": [
-                    "aws_create_bucket"
+                    "aws_put_bucket_acl"
                 ],
-                "title": "Change ACL Permissions of AWS Bucket",
-                "trusted": true,
-                "verbs": [
-                    "create"
-                ]
+                "title": "AWS Change ACL Permission of public S3 Bucket",
+                "verbs": []
             },
             "outputs": [],
             "source": [
@@ -477,11 +605,11 @@
                 "# All rights reserved.\n",
                 "##\n",
                 "from pydantic import BaseModel, Field\n",
+                "from unskript.enums.aws_canned_acl_enums import CannedACLPermissions\n",
                 "from typing import Optional, Dict\n",
                 "import pprint\n",
                 "\n",
                 "from beartype import beartype\n",
-                "\n",
                 "@beartype\n",
                 "def aws_put_bucket_acl_printer(output):\n",
                 "    if output is None:\n",
@@ -490,49 +618,52 @@
                 "\n",
                 "\n",
                 "@beartype\n",
-                "def aws_put_bucket_acl(handle, name: str, acl: str, region: str = None) -> Dict:\n",
+                "def aws_put_bucket_acl(handle, bucket_name: str, acl: CannedACLPermissions=None, region: str = None) -> Dict:\n",
                 "    \"\"\" aws_put_bucket_acl get Dict of buckets ACL change info.\n",
                 "\n",
                 "            :type handle: Session\n",
-                "            :param handle: S3 boto3 client\n",
+                "            :param handle: Object returned by the task.validate(...) method\n",
                 "\n",
-                "            :type handle: str\n",
-                "            :param bucket: S3 bucket name where to set ACL on\n",
+                "            :type bucket_name: string\n",
+                "            :param bucket_name: S3 bucket name where to set ACL on.\n",
                 "\n",
-                "            :type handle: str\n",
-                "            :param acl: canned ACL type - 'private'|'public-read'|'public-read-write'|'authenticated-read'.\n",
+                "            :type acl: CannedACLPermissions\n",
+                "            :param acl: Canned ACL Permission type - 'private'|'public-read'|'public-read-write'|'authenticated-read'.\n",
                 "\n",
-                "            :rtype: nothing\n",
+                "            :type region: string\n",
+                "            :param region: location of the bucket.\n",
+                "\n",
+                "            :rtype: Dict of buckets ACL change info\n",
                 "    \"\"\"\n",
+                "    # connect to the S3 using client\n",
+                "    all_permissions = acl\n",
+                "    if acl is None or len(acl)==0:\n",
+                "        all_permissions = \"private\"\n",
                 "    s3Client = handle.client('s3',\n",
                 "                             region_name=region)\n",
                 "\n",
+                "    # Put bucket ACL for the permissions grant\n",
                 "    response = s3Client.put_bucket_acl(\n",
-                "                    Bucket=name,\n",
-                "                    ACL=acl )\n",
+                "                    Bucket=bucket_name,\n",
+                "                    ACL=all_permissions )\n",
                 "\n",
                 "    return response\n",
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
-                "task.configure(continueOnError=False)\n",
+                "task.configure(continueOnError=True)\n",
                 "task.configure(inputParamsJson='''{\n",
-                "    \"acl\": \"ACL_Permission\",\n",
-                "    \"name\": \"iter_item\",\n",
-                "    \"region\": \"Region\"\n",
+                "    \"bucket_name\": \"iter.get(\\\\\"bucket\\\\\")\",\n",
+                "    \"region\": \"iter.get(\\\\\"region\\\\\")\"\n",
                 "    }''')\n",
                 "task.configure(iterJson='''{\n",
                 "    \"iter_enabled\": true,\n",
                 "    \"iter_list_is_const\": false,\n",
-                "    \"iter_list\": \"PublicBucket\",\n",
-                "    \"iter_parameter\": \"name\"\n",
-                "    }''')\n",
-                "task.configure(conditionsJson='''{\n",
-                "    \"condition_enabled\": true,\n",
-                "    \"condition_cfg\": \"len(PublicBucket)>0\",\n",
-                "    \"condition_result\": true\n",
+                "    \"iter_list\": \"all_public_buckets\",\n",
+                "    \"iter_parameter\": [\"bucket_name\",\"region\"]\n",
                 "    }''')\n",
                 "\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
                 "    task.execute(aws_put_bucket_acl, lego_printer=aws_put_bucket_acl_printer, hdl=hdl, args=args)"
@@ -540,38 +671,35 @@
         },
         {
             "cell_type": "markdown",
-            "id": "c9e25b20-2869-4bd0-8eba-7db2490b7fe4",
+            "id": "eada3017-32cf-46e2-b02c-4eb60256a3a9",
             "metadata": {
-                "jupyter": {
-                    "source_hidden": false
-                },
                 "name": "Conclusion",
                 "orderProperties": [],
                 "tags": [],
                 "title": "Conclusion"
             },
             "source": [
-                "In this Runbook, we demonstrated the use of unSkript's AWS legos to Restrict S3 Buckets with READ/WRITE Permissions to all Authenticated Users. To view the full platform capabilities of unSkript please visit https://unskript.com"
+                "<h3 id=\"Conclusion\">Conclusion<a class=\"jp-InternalAnchorLink\" href=\"#Conclusion\" target=\"_self\">&para;</a></h3>\n",
+                "<p>In this Runbook, we were able to restrict S3 buckets having read and write permissions to private. To view the full platform capabilities of unSkript please visit&nbsp;<a href=\"https://us.app.unskript.io\" target=\"_blank\" rel=\"noopener\">us.app.unskript.io</a></p>"
             ]
         }
     ],
     "metadata": {
         "execution_data": {
-            "environment_id": "1499f27c-6406-4fbd-bd1b-c6f92800018f",
-            "environment_name": "Staging",
+            "environment_name": "SingleAMIInstance",
+            "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "e70d6d27-33ef-4101-8040-babf8d402df7.ipynb",
-            "parameters": [
-                "Region"
-            ],
+            "notebook_id": "cdcccc36-1594-4914-8bd5-5f07a4769418.ipynb",
+            "parameters": null,
+            "proxy_id": "1b032d60-0671-498f-a117-6c2f355648fe",
             "runbook_name": "Restrict S3 Buckets with READ/WRITE Permissions",
             "search_string": "",
             "show_tool_tip": false,
-            "tenant_id": "982dba5f-d9df-48ae-a5bf-ec1fc94d4882",
-            "tenant_url": "https://tenant-staging.alpha.unskript.io",
-            "user_email_id": "harshal.bangre@unskript.com",
-            "workflow_id": "49ad8e48-c21e-460f-b8a5-f2793d7dad6b"
+            "tenant_id": "117718cf-b601-4a00-9164-3e4311468e45",
+            "tenant_url": "https://tenant-jayasimha.dev.unskript.io",
+            "user_email_id": "jayasimha@unskript.com",
+            "workflow_id": "73a672af-c6b9-4e4a-8e95-8a89e538a37d"
         },
         "kernelspec": {
             "display_name": "Python 3.9.6 64-bit",
@@ -587,49 +715,41 @@
         },
         "parameterSchema": {
             "properties": {
-                "ACL_Permission": {
-                    "default": "private",
-                    "description": "canned ACL type - 'private'|'public-read'|'public-read-write'|'authenticated-read'.",
+                "acl_permission": {
+                    "description": "Canned ACL Permission type - Eg: 'private'|'public-read'|'public-read-write'|'authenticated-read'",
                     "enum": [
                         "private",
                         "public-read",
-                        "public-read-write",
-                        "authenticated-read"
+                        "public-read-write"
                     ],
                     "enumNames": [
                         "private",
                         "public-read",
-                        "public-read-write",
-                        "authenticated-read"
+                        "public-read-write"
                     ],
-                    "title": "ACL_Permission",
+                    "title": "acl_permission",
                     "type": "string"
                 },
-                "Permission": {
-                    "default": "READ",
-                    "description": "ACL type - \"READ\"|\"WRITE\"|\"READ_ACP\"|\"WRITE_ACP\"|\"FULL_CONTROL\".",
+                "bucket_permission": {
+                    "description": "Set of permissions that AWS S3 supports in an ACL for buckets and objects. Eg:\"READ\",\"WRITE_ACP\",\"FULL_CONTROL\"",
                     "enum": [
                         "READ",
                         "WRITE",
-                        "READ_ACP",
-                        "WRITE_ACP",
-                        "FULL_CONTROL"
+                        "READ_ACP"
                     ],
                     "enumNames": [
                         "READ",
                         "WRITE",
-                        "READ_ACP",
-                        "WRITE_ACP",
-                        "FULL_CONTROL"
+                        "READ_ACP"
                     ],
-                    "title": "Permission",
+                    "title": "bucket_permission",
                     "type": "string"
                 },
-                "Region": {
-                    "default": "us-west-2",
-                    "description": "Region",
-                    "title": "Region",
-                    "type": "string"
+                "region": {
+                    "default": "[]",
+                    "description": "AWS Region to get the buckets from. Eg: [\"us-west-2\",\"ap-south-1\"]",
+                    "title": "region",
+                    "type": "array"
                 }
             },
             "required": [],
@@ -637,9 +757,7 @@
             "type": "object"
         },
         "parameterValues": {
-            "ACL_Permission": "private",
-            "Permission": "READ",
-            "Region": "us-west-2"
+            "region": "[]"
         },
         "vscode": {
             "interpreter": {


### PR DESCRIPTION
## Description
Added check lego and changed descriptions. 

Reference- Relay


### Testing


https://user-images.githubusercontent.com/110628398/216388667-fe3978bb-2866-44e9-b053-605a7932eadf.mov


### Checklist:
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
