### PR TITLE
EN-3815 Runbook: Get unhealthy EC2 instances from ELB

### DIFF
--- a/AWS/Get_Aws_Elb_Unhealthy_Instances.ipynb
+++ b/AWS/Get_Aws_Elb_Unhealthy_Instances.ipynb
@@ -3,53 +3,115 @@
         {
             "cell_type": "markdown",
             "id": "c2072425",
-            "metadata": {},
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Runbook Overview",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Runbook Overview"
+            },
             "source": [
-                "\n",
-                "<img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\"/> \n",
-                "<h1> unSkript Runbooks </h1>\n",
+                "<center><img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\">\n",
+                "<h1 id=\"unSkript-Runbooks\">unSkript Runbooks</h1>\n",
                 "<div class=\"alert alert-block alert-success\">\n",
-                "    <b> This runbook demonstrates How to Get AWS ELB Unhealthy Instances using unSkript legos.</b>\n",
-                "</div>\n",
-                "\n",
-                "<br>\n",
-                "\n",
-                "<center><h2>Get AWS ELB Unhealthy Instances</h2></center>\n",
-                "\n",
-                "# Steps Overview\n",
-                "    1) Get all AWS ELB unhealthy instances by using elb_name as input.\n",
-                "    2) Post the AWS ELB unhealthy instances to the slack channel."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "205bd131",
-            "metadata": {},
-            "source": [
-                "Here we will use unSkript Get UnHealthy EC2 Instances for Classic ELB Lego. This lego takes elb_name as input. This input is used to discover all unHealthy EC2 instances for Classic ELB."
+                "<h3 id=\"Objective\"><strong>Objective</strong></h3>\n",
+                "<strong>To get AWS ELB unhealthy instances using unSkript actions.</strong></div>\n",
+                "</center><center>\n",
+                "<h2 id=\"Get-AWS-ELB-Unhealthy-Instances\">Get AWS ELB Unhealthy Instances</h2>\n",
+                "</center>\n",
+                "<h1 id=\"Steps-Overview\">Steps Overview</h1>\n",
+                "<p>1. Get Unhealthy instances from ELB<br>2. Post Slack Message<code>\n",
+                "</code></p>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "7eb0dae8-c634-447b-8fa7-738b230d0015",
+            "execution_count": 13,
+            "id": "d5ec83b7-d75a-4e1b-a455-78b983a7fe50",
+            "metadata": {
+                "customAction": true,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-08T18:31:47.284Z"
+                },
+                "jupyter": {
+                    "source_hidden": true
+                },
+                "name": "Input Verification",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Input Verification"
+            },
+            "outputs": [],
+            "source": [
+                "if elb_name and not region:\n",
+                "    raise SystemExit(\"Provide region for the ELB instances!\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "eb8e7fcb-2698-4a2d-a08b-11fa48606dba",
+            "metadata": {
+                "name": "Step-1 A",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-1 A"
+            },
+            "source": [
+                "<h3 id=\"Create-a-Snapshot-Of-EBS-Volume\">Get UnHealthy EC2 Instances for Classic ELB</h3>\n",
+                "<p>In this action, we filter the instances from ELB which is unhealthy. This action only executes when the elb_name and region are given as parameters.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Input parameters:</strong> <code>elb_name</code>, <code>region</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable</strong>: <code>elb_instance</code></p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "id": "7c97c24a-0700-4e52-8354-78e9a3daf9c1",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
+                "actionCategories": [],
+                "actionIsCheck": false,
                 "actionNeedsCredential": true,
+                "actionNextHop": [],
+                "actionNextHopParameterMapping": {},
+                "actionOutputType": "",
+                "actionRequiredLinesInCode": [],
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
+                "action_modified": false,
                 "action_uuid": "88cbf370f4261c1265499dc499f983599db1e54b7e1d148c688216d4cdbbfe4d",
+                "collapsed": true,
+                "condition_enabled": true,
+                "continueOnError": true,
                 "createTime": "1970-01-01T00:00:00Z",
+                "credentialsJson": {
+                    "credential_id": "049e1bfd-59e4-44a4-9f3f-e96710a2387d",
+                    "credential_name": "DevRole",
+                    "credential_type": "CONNECTOR_TYPE_AWS"
+                },
                 "currentVersion": "0.1.0",
                 "description": "Get UnHealthy EC2 Instances for Classic ELB",
-                "id": 117,
-                "index": 117,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-09T08:14:23.324Z"
+                },
+                "id": 238,
+                "index": 238,
                 "inputData": [
                     {
                         "elb_name": {
                             "constant": false,
-                            "value": "elb_name"
+                            "value": "iter_item"
+                        },
+                        "region": {
+                            "constant": false,
+                            "value": "region[0]"
                         }
                     }
                 ],
@@ -60,37 +122,58 @@
                                 "description": "Name of the ELB. NOTE: It ONLY supports Classic.",
                                 "title": "ELB Name",
                                 "type": "string"
+                            },
+                            "region": {
+                                "description": "Name of the AWS Region",
+                                "title": "Region",
+                                "type": "string"
                             }
                         },
                         "required": [
-                            "elb_name"
+                            "elb_name",
+                            "region"
                         ],
                         "title": "aws_get_unhealthy_instances",
                         "type": "object"
                     }
                 ],
+                "iterData": [
+                    {
+                        "iter_enabled": true,
+                        "iter_item": "elb_name",
+                        "iter_list": {
+                            "constant": false,
+                            "objectItems": false,
+                            "value": "elb_name"
+                        }
+                    }
+                ],
                 "jupyter": {
+                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_AWS",
                 "name": "Get UnHealthy EC2 Instances for Classic ELB",
-                "nouns": [
-                    "aws",
-                    "ec2",
-                    "instances"
-                ],
+                "nouns": [],
                 "orderProperties": [
-                    "elb_name"
+                    "elb_name",
+                    "region"
                 ],
                 "output": {
                     "type": ""
                 },
+                "outputParams": {
+                    "output_name": "elb_instance",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
+                "probeEnabled": false,
+                "startcondition": "len(elb_name)>0",
                 "tags": [
                     "aws_get_unhealthy_instances"
                 ],
-                "verbs": [
-                    "list"
-                ]
+                "title": "Get UnHealthy EC2 Instances for Classic ELB",
+                "verbs": []
             },
             "outputs": [],
             "source": [
@@ -98,13 +181,38 @@
                 "# All rights reserved.\n",
                 "##\n",
                 "from pydantic import BaseModel, Field\n",
+                "from typing import List\n",
+                "import pprint\n",
                 "\n",
                 "\n",
                 "from beartype import beartype\n",
                 "@beartype\n",
-                "def aws_get_unhealthy_instances(handle, elb_name: str):\n",
+                "def aws_get_unhealthy_instances_printer(output):\n",
+                "    if output is None:\n",
+                "        return\n",
+                "    if output == []:\n",
+                "        print(\"All instances are healthy\")\n",
+                "    else:\n",
+                "        pprint.pprint(output)\n",
                 "\n",
-                "    elbClient = handle.client('elb')\n",
+                "\n",
+                "@beartype\n",
+                "def aws_get_unhealthy_instances(handle, elb_name: str, region: str) -> List:\n",
+                "    \"\"\"aws_get_unhealthy_instances returns array of unhealthy instances\n",
+                "\n",
+                "     :type handle: object\n",
+                "     :param handle: Object returned from task.validate(...).\n",
+                "\n",
+                "     :type elb_name: string\n",
+                "     :param elb_name: Name of the ELB. Note: It ONLY supports Classic.\n",
+                "\n",
+                "     :type region: string\n",
+                "     :param region: Name of the AWS Region.\n",
+                "\n",
+                "     :rtype: Returns array of unhealthy instances\n",
+                "    \"\"\"\n",
+                "\n",
+                "    elbClient = handle.client('elb', region_name=region)\n",
                 "    res = elbClient.describe_instance_health(\n",
                 "        LoadBalancerName=elb_name,\n",
                 "    )\n",
@@ -118,40 +226,516 @@
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
+                "task.configure(continueOnError=True)\n",
                 "task.configure(inputParamsJson='''{\n",
-                "    \"elb_name\": \"elb_name\"\n",
+                "    \"elb_name\": \"iter_item\",\n",
+                "    \"region\": \"region[0]\"\n",
                 "    }''')\n",
-                "\n",
+                "task.configure(iterJson='''{\n",
+                "    \"iter_enabled\": true,\n",
+                "    \"iter_list_is_const\": false,\n",
+                "    \"iter_list\": \"elb_name\",\n",
+                "    \"iter_parameter\": \"elb_name\"\n",
+                "    }''')\n",
+                "task.configure(conditionsJson='''{\n",
+                "    \"condition_enabled\": true,\n",
+                "    \"condition_cfg\": \"len(elb_name)>0\",\n",
+                "    \"condition_result\": true\n",
+                "    }''')\n",
+                "task.configure(outputName=\"elb_instance\")\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
-                "    task.output = task.execute(aws_get_unhealthy_instances, hdl=hdl, args=args)\n",
-                "    if task.output_name != None:\n",
-                "        globals().update({task.output_name: task.output[0]})\n",
+                "    task.execute(aws_get_unhealthy_instances, lego_printer=aws_get_unhealthy_instances_printer, hdl=hdl, args=args)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9147e140-5ca2-4593-ace3-ca9973368d0d",
+            "metadata": {
+                "name": "Gather Information ",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Gather Information "
+            },
+            "source": [
+                "<h3 id=\"AWS-List-All-Regions\">AWS List All Regions</h3>\n",
+                "<p>In this action, we list all the available regions from AWS if the user does not provide a region as a parameter.</p>\n",
+                "<blockquote>\n",
+                "<p>Output variable: <code>region</code></p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "a21851d4-4b75-4c61-ad1c-21eaa11c6b36",
+            "metadata": {
+                "accessType": "ACCESS_TYPE_UNSPECIFIED",
+                "actionBashCommand": false,
+                "actionNeedsCredential": true,
+                "actionRequiredLinesInCode": [],
+                "actionSupportsIteration": true,
+                "actionSupportsPoll": true,
+                "action_modified": false,
+                "action_uuid": "708ea4af5f8fe7096a15b3a52c4a657606bab9e177386fad7a847341ed607d64",
+                "collapsed": true,
+                "condition_enabled": true,
+                "createTime": "1970-01-01T00:00:00Z",
+                "credentialsJson": {
+                    "credential_id": "049e1bfd-59e4-44a4-9f3f-e96710a2387d",
+                    "credential_name": "DevRole",
+                    "credential_type": "CONNECTOR_TYPE_AWS"
+                },
+                "currentVersion": "0.1.0",
+                "description": "List all available AWS Regions",
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-09T08:48:01.442Z"
+                },
+                "id": 215,
+                "index": 215,
+                "inputschema": [
+                    {
+                        "properties": {},
+                        "title": "aws_list_all_regions",
+                        "type": "object"
+                    }
+                ],
+                "jupyter": {
+                    "outputs_hidden": true,
+                    "source_hidden": true
+                },
+                "legotype": "LEGO_TYPE_AWS",
+                "name": "AWS List All Regions",
+                "nouns": [
+                    "regions",
+                    "aws"
+                ],
+                "orderProperties": [],
+                "output": {
+                    "type": ""
+                },
+                "outputParams": {
+                    "output_name": "region",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
+                "startcondition": "not region",
+                "tags": [
+                    "aws_list_all_regions"
+                ],
+                "trusted": true,
+                "verbs": [
+                    "list"
+                ]
+            },
+            "outputs": [],
+            "source": [
+                "#\n",
+                "# Copyright (c) 2021 unSkript.com\n",
+                "# All rights reserved.\n",
+                "#\n",
                 "\n",
-                "if hasattr(task, 'output'):\n",
-                "    if isinstance(task.output, (list, tuple)):\n",
-                "        for item in task.output:\n",
-                "            print(f'item: {item}')\n",
-                "    elif isinstance(task.output, dict):\n",
-                "        for item in task.output.items():\n",
-                "            print(f'item: {item}')\n",
+                "from pydantic import BaseModel, Field\n",
+                "from typing import Dict, List\n",
+                "import pprint\n",
+                "\n",
+                "from beartype import beartype\n",
+                "@beartype\n",
+                "def aws_list_all_regions_printer(output):\n",
+                "    if output is None:\n",
+                "        return\n",
+                "    pprint.pprint(output)\n",
+                "\n",
+                "\n",
+                "@beartype\n",
+                "def aws_list_all_regions(handle) -> List:\n",
+                "    \"\"\"aws_list_all_regions lists all the AWS regions\n",
+                "\n",
+                "        :type handle: object\n",
+                "        :param handle: Object returned from Task Validate\n",
+                "\n",
+                "        :rtype: Result List of result\n",
+                "    \"\"\"\n",
+                "\n",
+                "    result = handle.aws_cli_command(\"aws ec2 describe-regions --all-regions --query 'Regions[].{Name:RegionName}' --output text\")\n",
+                "    if result is None or result.returncode != 0:\n",
+                "        print(\"Error while executing command : {}\".format(result))\n",
+                "        return str()\n",
+                "    result_op = list(result.stdout.split(\"\\n\"))\n",
+                "    list_region = [x for x in result_op if x != '']\n",
+                "    return list_region\n",
+                "\n",
+                "\n",
+                "task = Task(Workflow())\n",
+                "task.configure(conditionsJson='''{\n",
+                "    \"condition_enabled\": true,\n",
+                "    \"condition_cfg\": \"not region\",\n",
+                "    \"condition_result\": true\n",
+                "    }''')\n",
+                "\n",
+                "task.configure(outputName=\"region\")\n",
+                "task.configure(printOutput=True)\n",
+                "(err, hdl, args) = task.validate(vars=vars())\n",
+                "if err is None:\n",
+                "    task.execute(aws_list_all_regions, lego_printer=aws_list_all_regions_printer, hdl=hdl, args=args)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "205bd131",
+            "metadata": {
+                "name": "Step-1 B",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-1 B"
+            },
+            "source": [
+                "<h3 id=\"AWS-List-All-Regions\">Get Unhealthy instances from ELB</h3>\n",
+                "<p>Here we will use unSkript&nbsp;<strong>Get Unhealthy instances from ELB</strong> action. This action is used to get all unhealthy instances from ELB, the instances which are out of service are considered unhealthy instances.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Input parameters:</strong> <code>elb_name</code>, <code>region</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable</strong>: <code>unhealthy_instances</code></p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "2cab6a98-f086-4923-ad34-4969a690dc0e",
+            "metadata": {
+                "accessType": "ACCESS_TYPE_UNSPECIFIED",
+                "actionBashCommand": false,
+                "actionCategories": [
+                    "CATEGORY_TYPE_CLOUDOPS",
+                    "CATEGORY_TYPE_DEVOPS",
+                    "CATEGORY_TYPE_SRE"
+                ],
+                "actionIsCheck": true,
+                "actionNeedsCredential": true,
+                "actionNextHop": [
+                    "75c9298c37cd3bfd726dd5da4641e46cba98cfcb8017298e8fcbc87b7f54e632"
+                ],
+                "actionNextHopParameterMapping": {},
+                "actionOutputType": "",
+                "actionRequiredLinesInCode": [],
+                "actionSupportsIteration": true,
+                "actionSupportsPoll": true,
+                "action_modified": false,
+                "action_uuid": "6d2964252c14fd1439bdefd224d147ac75fc7fe06036c6d0956081fa45505139",
+                "collapsed": true,
+                "condition_enabled": true,
+                "continueOnError": true,
+                "createTime": "1970-01-01T00:00:00Z",
+                "credentialsJson": {
+                    "credential_id": "049e1bfd-59e4-44a4-9f3f-e96710a2387d",
+                    "credential_name": "DevRole",
+                    "credential_type": "CONNECTOR_TYPE_AWS"
+                },
+                "currentVersion": "0.1.0",
+                "description": "Get Unhealthy instances from Elastic Load Balancer",
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-09T08:48:54.906Z"
+                },
+                "id": 259,
+                "index": 259,
+                "inputData": [
+                    {
+                        "elb_name": {
+                            "constant": false,
+                            "value": ""
+                        },
+                        "region": {
+                            "constant": false,
+                            "value": "iter_item"
+                        }
+                    }
+                ],
+                "inputschema": [
+                    {
+                        "properties": {
+                            "elb_name": {
+                                "default": "",
+                                "description": "Name of the elastic load balancer.",
+                                "title": "ELB Name",
+                                "type": "string"
+                            },
+                            "region": {
+                                "default": "",
+                                "description": "AWS Region of the ELB.",
+                                "title": "Region",
+                                "type": "string"
+                            }
+                        },
+                        "title": "aws_get_unhealthy_ec2_instances_for_elb",
+                        "type": "object"
+                    }
+                ],
+                "iterData": [
+                    {
+                        "iter_enabled": true,
+                        "iter_item": "region",
+                        "iter_list": {
+                            "constant": false,
+                            "objectItems": false,
+                            "value": "region"
+                        }
+                    }
+                ],
+                "jupyter": {
+                    "outputs_hidden": true,
+                    "source_hidden": true
+                },
+                "legotype": "LEGO_TYPE_AWS",
+                "name": "Get Unhealthy instances from ELB",
+                "nouns": [],
+                "orderProperties": [
+                    "elb_name",
+                    "region"
+                ],
+                "output": {
+                    "type": ""
+                },
+                "outputParams": {
+                    "output_name": "unhealthy_instances",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
+                "probeEnabled": false,
+                "startcondition": "not elb_name",
+                "tags": [
+                    "aws_get_unhealthy_ec2_instances_for_elb"
+                ],
+                "title": "Get Unhealthy instances from ELB",
+                "trusted": true,
+                "verbs": []
+            },
+            "outputs": [],
+            "source": [
+                "##  Copyright (c) 2021 unSkript, Inc\n",
+                "##  All rights reserved.\n",
+                "##\n",
+                "from typing import Optional, Tuple\n",
+                "from pydantic import BaseModel, Field\n",
+                "from unskript.legos.utils import CheckOutput, CheckOutputStatus\n",
+                "from unskript.connectors.aws import aws_get_paginator\n",
+                "from unskript.legos.aws.aws_list_all_regions.aws_list_all_regions import aws_list_all_regions\n",
+                "import pprint\n",
+                "\n",
+                "\n",
+                "from beartype import beartype\n",
+                "@beartype\n",
+                "def aws_get_unhealthy_ec2_instances_for_elb_printer(output):\n",
+                "    if output is None:\n",
+                "        return\n",
+                "\n",
+                "    if isinstance(output, CheckOutput):\n",
+                "        pprint.pprint(output.json())\n",
                 "    else:\n",
-                "        print(f'Output for {task.name}')\n",
-                "        print(task.output)\n",
-                "    w.tasks[task.name]= task.output"
+                "        pprint.pprint(output)\n",
+                "\n",
+                "\n",
+                "@beartype\n",
+                "def aws_get_unhealthy_ec2_instances_for_elb(handle, elb_name: str = \"\", region: str = \"\") -> CheckOutput:\n",
+                "    \"\"\"aws_get_unHealthy_ec2_instances_for_elb gives unhealthy instances from ELB\n",
+                "\n",
+                "        :type elb_name: string\n",
+                "        :param elb_name: Name of the elastic load balancer.\n",
+                "\n",
+                "        :type region: string\n",
+                "        :param region: AWS region.\n",
+                "\n",
+                "        :rtype: A tuple with execution results and a list of unhealthy instances from ELB\n",
+                "    \"\"\"\n",
+                "\n",
+                "    result = []\n",
+                "    all_regions = [region]\n",
+                "    elb_list = []\n",
+                "    if not region:\n",
+                "        all_regions = aws_list_all_regions(handle)\n",
+                "\n",
+                "    if not elb_name:\n",
+                "        for reg in all_regions:\n",
+                "            try:\n",
+                "                asg_client = handle.client('elb', region_name=reg)\n",
+                "                response = aws_get_paginator(asg_client, \"describe_load_balancers\", \"LoadBalancerDescriptions\")\n",
+                "                for i in response:\n",
+                "                    elb_dict = {}\n",
+                "                    elb_dict[\"load_balancer_name\"] = i[\"LoadBalancerName\"]\n",
+                "                    elb_dict[\"region\"] = reg\n",
+                "                    elb_list.append(elb_dict)\n",
+                "            except Exception as error:\n",
+                "                pass\n",
+                "\n",
+                "    if elb_name and not region:\n",
+                "        for reg in all_regions:\n",
+                "            try:\n",
+                "                asg_client = handle.client('elb', region_name=reg)\n",
+                "                response = aws_get_paginator(asg_client, \"describe_load_balancers\", \"LoadBalancerDescriptions\")\n",
+                "                for i in response:\n",
+                "                    if elb_name in i[\"LoadBalancerName\"]:\n",
+                "                        elb_dict = {}\n",
+                "                        elb_dict[\"load_balancer_name\"] = i[\"LoadBalancerName\"]\n",
+                "                        elb_dict[\"region\"] = reg\n",
+                "                        elb_list.append(elb_dict)\n",
+                "            except Exception as error:\n",
+                "                pass\n",
+                "\n",
+                "    if elb_name and region:\n",
+                "        try:\n",
+                "            elbClient = handle.client('elb', region_name=region)\n",
+                "            res = elbClient.describe_instance_health(LoadBalancerName=elb_name)\n",
+                "            for instance in res['InstanceStates']:\n",
+                "                data_dict = {}\n",
+                "                if instance['State'] == \"OutOfService\":\n",
+                "                    data_dict[\"instance_id\"] = instance[\"InstanceId\"]\n",
+                "                    data_dict[\"region\"] = reg\n",
+                "                    data_dict[\"load_balancer_name\"] = i[\"LoadBalancerName\"]\n",
+                "                    result.append(data_dict)\n",
+                "        except Exception as e:\n",
+                "            pass\n",
+                "\n",
+                "    for elb in elb_list:\n",
+                "        try:\n",
+                "            elbClient = handle.client('elb', region_name=elb[\"region\"])\n",
+                "            res = elbClient.describe_instance_health(LoadBalancerName=elb[\"load_balancer_name\"])\n",
+                "            for instance in res['InstanceStates']:\n",
+                "                data_dict = {}\n",
+                "                if instance['State'] == \"OutOfService\":\n",
+                "                    data_dict[\"instance_id\"] = instance[\"InstanceId\"]\n",
+                "                    data_dict[\"region\"] = reg\n",
+                "                    data_dict[\"load_balancer_name\"] = i[\"LoadBalancerName\"]\n",
+                "                    result.append(data_dict)\n",
+                "        except Exception as e:\n",
+                "            pass\n",
+                "\n",
+                "    if len(result) != 0:\n",
+                "        return CheckOutput(status=CheckOutputStatus.FAILED,\n",
+                "                   objects=result,\n",
+                "                   error=str(\"\"))\n",
+                "    else:\n",
+                "        return CheckOutput(status=CheckOutputStatus.SUCCESS,\n",
+                "                   objects=result,\n",
+                "                   error=str(\"\"))\n",
+                "\n",
+                "\n",
+                "\n",
+                "\n",
+                "\n",
+                "\n",
+                "\n",
+                "task = Task(Workflow())\n",
+                "task.configure(continueOnError=True)\n",
+                "task.configure(inputParamsJson='''{\n",
+                "    \"region\": \"iter_item\"\n",
+                "    }''')\n",
+                "task.configure(iterJson='''{\n",
+                "    \"iter_enabled\": true,\n",
+                "    \"iter_list_is_const\": false,\n",
+                "    \"iter_list\": \"region\",\n",
+                "    \"iter_parameter\": \"region\"\n",
+                "    }''')\n",
+                "task.configure(conditionsJson='''{\n",
+                "    \"condition_enabled\": true,\n",
+                "    \"condition_cfg\": \"not elb_name\",\n",
+                "    \"condition_result\": true\n",
+                "    }''')\n",
+                "task.configure(outputName=\"unhealthy_instances\")\n",
+                "\n",
+                "task.configure(printOutput=True)\n",
+                "(err, hdl, args) = task.validate(vars=vars())\n",
+                "if err is None:\n",
+                "    task.execute(aws_get_unhealthy_ec2_instances_for_elb, lego_printer=aws_get_unhealthy_ec2_instances_for_elb_printer, hdl=hdl, args=args)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "8fc2968d-700c-4264-84ab-9dbbeae25d3c",
+            "metadata": {
+                "name": "Step-1 Extension",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-1 Extension"
+            },
+            "source": [
+                "<h3 id=\"Modify-Unattached-EBS-Volume-Output\">Modify Output</h3>\n",
+                "<p>In this action, we modify the output from step 1A and step 1B and return a list of dictionary items for the unhealthy instances from ELB.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable:</strong> elb_instance_list</p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 13,
+            "id": "983ce208-f598-4c1e-ab9a-282e90ba5592",
+            "metadata": {
+                "collapsed": true,
+                "customAction": true,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-09T09:03:02.949Z"
+                },
+                "jupyter": {
+                    "outputs_hidden": true,
+                    "source_hidden": true
+                },
+                "name": "Modify Output",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Modify Output",
+                "trusted": true
+            },
+            "outputs": [],
+            "source": [
+                "elb_instance_list = []\n",
+                "try:\n",
+                "    if elb_instance:\n",
+                "        for k, v in elb_instance.items():\n",
+                "            elb_dict = {}\n",
+                "            if len(v) > 0:\n",
+                "                for i in v:\n",
+                "                    elb_dict[\"instance_id\"] = i\n",
+                "                    elb_dict[\"load_balancer_name\"] = k\n",
+                "                    elb_dict[\"region\"] = region[0]\n",
+                "                    elb_instance_list.append(elb_dict)\n",
+                "    \n",
+                "except Exception as e:\n",
+                "    try:\n",
+                "        if unhealthy_instances:\n",
+                "            for k, v in unhealthy_instances.items():\n",
+                "                elb = json.loads(v.json())\n",
+                "                if elb[\"status\"] == 2:\n",
+                "                    for instance in elb[\"objects\"]:\n",
+                "                        elb_instance_list.append(instance)\n",
+                "    except Exception as error:\n",
+                "        pass"
             ]
         },
         {
             "cell_type": "markdown",
             "id": "061cdd14",
-            "metadata": {},
+            "metadata": {
+                "name": "Step-2",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-2"
+            },
             "source": [
-                "Here we will use unSkript Post Slack Message Lego. This lego takes channel: str and message: str as input. This input is used to post the message to the slack channel."
+                "<h3 id=\"Modify-Unattached-EBS-Volume-Output\">Post Slack Message</h3>\n",
+                "<p>Here we will use unSkript <strong>Post Slack Message</strong> action. This action takes channel: str and message: str as input. This input is used to post the message to the slack channel.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Input parameters:</strong> <code>message</code>, <code>channel</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable</strong>: <code>message_status</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 14,
             "id": "80e6665a-2c9a-4a33-89f8-ad221be338ec",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
@@ -160,10 +744,15 @@
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
                 "action_uuid": "6a87f83ab0ecfeecb9c98d084e2b1066c26fa64be5b4928d5573a5d60299802d",
-                "collapsed": true,
+                "condition_enabled": true,
+                "continueOnError": false,
                 "createTime": "1970-01-01T00:00:00Z",
+                "credentialsJson": {},
                 "currentVersion": "0.1.0",
                 "description": "Post Slack Message",
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-09T09:45:24.587Z"
+                },
                 "id": 44,
                 "index": 44,
                 "inputData": [
@@ -174,7 +763,7 @@
                         },
                         "message": {
                             "constant": false,
-                            "value": "f\"Unhealthy instances for elb:{elb_name} {elb_output}\""
+                            "value": "f\"Unhealthy instances for elb:{elb_instance_list}\""
                         }
                     }
                 ],
@@ -201,7 +790,6 @@
                     }
                 ],
                 "jupyter": {
-                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_SLACK",
@@ -217,9 +805,17 @@
                 "output": {
                     "type": ""
                 },
+                "outputParams": {
+                    "output_name": "message_status",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
+                "startcondition": "channel",
                 "tags": [
                     "slack_post_message"
                 ],
+                "title": "Post Slack Message",
+                "trusted": true,
                 "verbs": [
                     "post"
                 ]
@@ -276,10 +872,17 @@
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
+                "task.configure(printOutput=True)\n",
                 "task.configure(inputParamsJson='''{\n",
                 "    \"channel\": \"channel\",\n",
-                "    \"message\": \"f\\\\\"Unhealthy instances for elb:{elb_name} {elb_output}\\\\\"\"\n",
+                "    \"message\": \"f\\\\\"Unhealthy instances for elb:{elb_instance_list}\\\\\"\"\n",
                 "    }''')\n",
+                "task.configure(conditionsJson='''{\n",
+                "    \"condition_enabled\": true,\n",
+                "    \"condition_cfg\": \"channel\",\n",
+                "    \"condition_result\": true\n",
+                "    }''')\n",
+                "task.configure(outputName=\"message_status\")\n",
                 "\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
@@ -291,34 +894,42 @@
         {
             "cell_type": "markdown",
             "id": "2fbfd774",
-            "metadata": {},
+            "metadata": {
+                "name": "Conclusion",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Conclusion"
+            },
             "source": [
-                "### Conclusion\n",
-                "In this Runbook, we demonstrated the use of unSkript's AWS and slack legos.  The xRunbook fetches the unHealthy EC2 instances for Classic ELB and posts to a Slack channel. To view the full platform capabilities of unSkript please visit https://unskript.com"
+                "<h3 id=\"Conclusion\">Conclusion</h3>\n",
+                "<p>In this Runbook, we demonstrated the use of unSkript's AWS and slack legos to perform AWS action and this runbook fetches the unHealthy EC2 instances for Classic ELB and posts to a slack channel. To view the full platform capabilities of unSkript please visit <a href=\"https://us.app.unskript.io\" target=\"_blank\" rel=\"noopener\">https://us.app.unskript.io</a></p>"
             ]
         }
     ],
     "metadata": {
         "execution_data": {
             "environment_id": "dba3932f-3118-4ab0-b92c-70fa56402037",
-            "environment_name": "SingleAMI",
+            "environment_name": "SingleAMIInstance",
+            "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "workflow.ipynb",
+            "notebook_id": "d90e7699-5ab6-47de-8477-53b9153b9f21.ipynb",
             "parameters": [
                 "channel",
-                "elb_name"
+                "elb_name",
+                "region"
             ],
-            "runbook_name": "JRRunbook",
+            "proxy_id": "1b032d60-0671-498f-a117-6c2f355648fe",
+            "runbook_name": "Get unhealthy EC2 instances from ELB",
             "search_string": "",
             "show_tool_tip": false,
-            "tenant_id": "8b3c7148-2d57-4b89-84d3-d59f6c792b0c",
-            "tenant_url": "https://tenant-amit.dev.unskript.io",
-            "user_email_id": "amit@unskript.com",
-            "workflow_id": "755dbe40-22d7-4b70-a04d-31d34bb04e4a"
+            "tenant_id": "117718cf-b601-4a00-9164-3e4311468e45",
+            "tenant_url": "https://tenant-jayasimha.dev.unskript.io",
+            "user_email_id": "jayasimha@unskript.com",
+            "workflow_id": "e2b5f7f2-197f-417b-b322-64e0c9ac180f"
         },
         "kernelspec": {
-            "display_name": "Python 3.9.12 ('base')",
+            "display_name": "Python 3",
             "language": "python",
             "name": "python3"
         },
@@ -327,7 +938,7 @@
             "mimetype": "text/x-python",
             "name": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.9.12"
+            "version": "3.10.6"
         },
         "parameterSchema": {
             "properties": {
@@ -338,23 +949,24 @@
                     "type": "string"
                 },
                 "elb_name": {
-                    "default": "",
-                    "description": "ELB Name (Classic)",
+                    "description": "List of ELB Name (Classic)",
                     "title": "elb_name",
-                    "type": "string"
+                    "type": "array"
+                },
+                "region": {
+                    "description": "Region for the ELB instances",
+                    "title": "region",
+                    "type": "array"
                 }
             },
             "required": [],
             "title": "Schema",
             "type": "object"
         },
-        "parameterValues": {
-            "channel": null,
-            "elb_name": null
-        },
+        "parameterValues": null,
         "vscode": {
             "interpreter": {
-                "hash": "5e269198fab4eb2ea6fe7c886c38b87b334869f0501ab924e1d16d60aeba5d23"
+                "hash": "e8899eb02dfbc033aab5733bdae1bd213fa031d40331094008e8673d99ebab63"
             }
         }
     },

--- a/AWS/legos/aws_get_unhealthy_instances_from_elb/aws_get_unhealthy_instances_from_elb.json
+++ b/AWS/legos/aws_get_unhealthy_instances_from_elb/aws_get_unhealthy_instances_from_elb.json
@@ -2,13 +2,13 @@
     "action_title": "Get Unhealthy instances from ELB",
     "action_description": "Get Unhealthy instances from Elastic Load Balancer",
     "action_type": "LEGO_TYPE_AWS",
-    "action_entry_function": "aws_get_unhealthy_ec2_instances_for_elb",
+    "action_entry_function": "aws_get_unhealthy_instances_from_elb",
     "action_needs_credential": true,
     "action_is_check": true,
     "action_supports_poll": true,
     "action_output_type": "ACTION_OUTPUT_TYPE_OBJECT",
     "action_supports_iteration": true,
     "action_categories": [ "CATEGORY_TYPE_CLOUDOPS", "CATEGORY_TYPE_DEVOPS", "CATEGORY_TYPE_SRE" ],
-    "action_next_hop": ["75c9298c37cd3bfd726dd5da4641e46cba98cfcb8017298e8fcbc87b7f54e632"],
+    "action_next_hop": ["94707558cebedbcb77aabaec5d6d2d1bf3f4664db6e9e905d6d905a11a3ef8bc"],
     "action_next_hop_parameter_mapping": {}
 }

--- a/AWS/legos/aws_get_unhealthy_instances_from_elb/aws_get_unhealthy_instances_from_elb.py
+++ b/AWS/legos/aws_get_unhealthy_instances_from_elb/aws_get_unhealthy_instances_from_elb.py
@@ -21,7 +21,7 @@ class InputSchema(BaseModel):
         description='AWS Region of the ELB.')
 
 
-def aws_get_unhealthy_ec2_instances_for_elb_printer(output):
+def aws_get_unhealthy_instances_from_elb_printer(output):
     if output is None:
         return
 
@@ -31,8 +31,8 @@ def aws_get_unhealthy_ec2_instances_for_elb_printer(output):
         pprint.pprint(output)
 
 
-def aws_get_unhealthy_ec2_instances_for_elb(handle, elb_name: str = "", region: str = "") -> CheckOutput:
-    """aws_get_unHealthy_ec2_instances_for_elb gives unhealthy instances from ELB
+def aws_get_unhealthy_instances_from_elb(handle, elb_name: str = "", region: str = "") -> CheckOutput:
+    """aws_get_unhealthy_instances_from_elb gives unhealthy instances from ELB
 
         :type elb_name: string
         :param elb_name: Name of the elastic load balancer.


### PR DESCRIPTION
## Description
Get unhealthy EC2 instances from ELB

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
