### PR TITLE
EN-3843 Runbook: Display Postgresql Long Running Queries

### DIFF
--- a/Postgresql/Display_Postgresql_Long_Running.ipynb
+++ b/Postgresql/Display_Postgresql_Long_Running.ipynb
@@ -3,54 +3,89 @@
         {
             "cell_type": "markdown",
             "id": "133bee4c",
-            "metadata": {},
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Runbook Overview",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Runbook Overview"
+            },
             "source": [
-                "\n",
-                "<img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\"/> \n",
-                "<h1> unSkript Runbooks </h1>\n",
+                "<center><img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\">\n",
+                "<h1 id=\"unSkript-Runbooks\">unSkript Runbooks<a class=\"jp-InternalAnchorLink\" href=\"#unSkript-Runbooks\" target=\"_self\">&para;</a></h1>\n",
                 "<div class=\"alert alert-block alert-success\">\n",
-                "    <b> This runbook demonstrates How to get PostgreSQL long running queries using unSkript legos.</b>\n",
-                "</div>\n",
-                "\n",
-                "<br>\n",
-                "\n",
-                "<center><h2>Display PostgreSQL Long Running Queries</h2></center>\n",
-                "\n",
-                "# Steps Overview\n",
-                "    1) Get postgres long running queries by passing the interval as input\n",
-                "    2) Collecting PostgreSQL queries and post that to the slack channel"
+                "<h3 id=\"Objective\"><strong>Objective</strong><a class=\"jp-InternalAnchorLink\" href=\"#Objective\" target=\"_self\">&para;</a></h3>\n",
+                "<strong>To get PostgreSQL long-running queries using unSkript actions.</strong></div>\n",
+                "</center><center>\n",
+                "<h2 id=\"Display-PostgreSQL-Long-Running-Queries\">Display PostgreSQL Long Running Queries<a class=\"jp-InternalAnchorLink\" href=\"#Display-PostgreSQL-Long-Running-Queries\" target=\"_self\">&para;</a></h2>\n",
+                "</center>\n",
+                "<h1 id=\"Steps-Overview\">Steps Overview<a class=\"jp-InternalAnchorLink\" href=\"#Steps-Overview\" target=\"_self\">&para;</a></h1>\n",
+                "<p>1. Long Running PostgreSQL Queries<br>2. Post Slack Message<code>\n",
+                "</code></p>"
             ]
         },
         {
             "cell_type": "markdown",
             "id": "086ace3b",
-            "metadata": {},
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Step-1",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-1"
+            },
             "source": [
-                "Here we will use unSkript Long Running PostgreSQL Queries Lego. This lego takes interval: int as input. This inputs is used to findout all the Long running queries available on the PostgreSQL database."
+                "<h3 id=\"Long-Running-PostgreSQL-Queries\">Long Running PostgreSQL Queries<a class=\"jp-InternalAnchorLink\" href=\"#Long-Running-PostgreSQL-Queries\" target=\"_self\">&para;</a></h3>\n",
+                "<p>Here we will use unSkript <strong>Long Running PostgreSQL Queries</strong> action. This action finds out all the long-running queries on the PostgreSQL database.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Input parameters:</strong> <code>interval</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable:</strong> <code>postgresql_queries</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": null,
-            "id": "d3781717-70fc-40d2-9eed-183ff55a1726",
+            "execution_count": 8,
+            "id": "c8565b85-30c3-43f7-9f4b-b8a3bd271861",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
                 "actionBashCommand": false,
+                "actionCategories": [],
+                "actionIsCheck": false,
                 "actionNeedsCredential": true,
+                "actionNextHop": [],
+                "actionNextHopParameterMapping": {},
+                "actionOutputType": "",
+                "actionRequiredLinesInCode": [],
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
+                "action_modified": false,
                 "action_uuid": "ef9f0f3dd00ef0972895ea006375f1a4496dca1b7266bc60fdfbd8ab4feee6c3",
+                "continueOnError": false,
                 "createTime": "1970-01-01T00:00:00Z",
-                "credentialsJson": {},
+                "credentialsJson": {
+                    "credential_id": "dfb53992-077a-45d5-89aa-40cd063ccb1b",
+                    "credential_name": "segment",
+                    "credential_type": "CONNECTOR_TYPE_POSTGRESQL"
+                },
                 "currentVersion": "0.1.0",
                 "description": "Long Running PostgreSQL Queries",
-                "id": 193,
-                "index": 193,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-10T14:22:09.568Z"
+                },
+                "id": 332,
+                "index": 332,
                 "inputData": [
                     {
                         "interval": {
                             "constant": false,
-                            "value": "5"
+                            "value": "int(interval)"
                         }
                     }
                 ],
@@ -60,7 +95,7 @@
                             "interval": {
                                 "default": 5,
                                 "description": "Return queries running longer than interval",
-                                "title": "Interval(in seconds)",
+                                "title": "Interval(in minutes)",
                                 "type": "integer"
                             }
                         },
@@ -73,19 +108,24 @@
                 },
                 "legotype": "LEGO_TYPE_POSTGRESQL",
                 "name": "Long Running PostgreSQL Queries",
-                "nouns": [
-                    "postgresql",
-                    "queries"
-                ],
+                "nouns": [],
                 "orderProperties": [
                     "interval"
                 ],
                 "output": {
                     "type": ""
                 },
+                "outputParams": {
+                    "output_name": "postgresql_queries",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
+                "probeEnabled": false,
                 "tags": [
                     "postgresql_long_running_queries"
                 ],
+                "title": "Long Running PostgreSQL Queries",
+                "trusted": true,
                 "verbs": []
             },
             "outputs": [],
@@ -94,35 +134,32 @@
                 "# Copyright (c) 2021 unSkript, Inc\n",
                 "# All rights reserved.\n",
                 "##\n",
-                "from typing import List, Any, Union\n",
-                "\n",
+                "from typing import List, Any, Optional\n",
+                "from unskript.legos.utils import CheckOutput, CheckOutputStatus\n",
                 "from tabulate import tabulate\n",
                 "from pydantic import BaseModel, Field\n",
                 "\n",
                 "\n",
                 "from beartype import beartype\n",
-                "def legoPrinter(func):\n",
-                "    def Printer(*args, **kwargs):\n",
-                "        output = func(*args, **kwargs)\n",
-                "        print(\"\\n\")\n",
-                "        print(output)\n",
-                "        return output\n",
-                "    return Printer\n",
-                "\n",
-                "\n",
-                "@legoPrinter\n",
                 "@beartype\n",
-                "def postgresql_long_running_queries(handle, interval: int = 5) -> Union[List[Any], str]:\n",
+                "def postgresql_long_running_queries_printer(output):\n",
+                "    if output is None:\n",
+                "        return\n",
+                "    if isinstance(output, CheckOutput):\n",
+                "        print(output.json())\n",
+                "    else:\n",
+                "        pprint.pprint(output)\n",
+                "\n",
+                "\n",
+                "@beartype\n",
+                "def postgresql_long_running_queries(handle, interval: int = 5) -> CheckOutput:\n",
                 "    \"\"\"postgresql_long_running_queries Runs postgres query with the provided parameters.\n",
                 "\n",
-                "          :type nbParamsObj: object\n",
-                "          :param nbParamsObj: Object containing global params for the notebook.\n",
+                "          :type handle: object\n",
+                "          :param handle: Object returned from task.validate(...).\n",
                 "\n",
-                "          :type credentialsDict: dict\n",
-                "          :param credentialsDict: Dictionary of credentials info.\n",
-                "\n",
-                "          :type inputParamsJson: string\n",
-                "          :param inputParamsJson: Json string of the input params\n",
+                "          :type interval: int\n",
+                "          :param interval: Interval(in seconds).\n",
                 "\n",
                 "          :rtype: All the results of the query.\n",
                 "      \"\"\"\n",
@@ -130,15 +167,13 @@
                 "\n",
                 "    # Multi-line will create an issue when we package the Legos.\n",
                 "    # Hence concatinating it into a single line.\n",
-                "\n",
                 "    query = \"SELECT pid, user, pg_stat_activity.query_start, now() - pg_stat_activity.query_start AS query_time, query, state \" \\\n",
-                "        \" FROM pg_stat_activity WHERE state = 'active' AND (now() - pg_stat_activity.query_start) > interval '%d seconds';\" % interval\n",
+                "        \" FROM pg_stat_activity WHERE state = 'active' AND (now() - pg_stat_activity.query_start) > interval '%d minutes';\" % interval\n",
                 "\n",
                 "    cur = handle.cursor()\n",
                 "    cur.execute(query)\n",
                 "    output = []\n",
                 "    res = cur.fetchall()\n",
-                "\n",
                 "    data = []\n",
                 "    for records in res:\n",
                 "        result = {\n",
@@ -160,33 +195,98 @@
                 "    handle.commit()\n",
                 "    cur.close()\n",
                 "    handle.close()\n",
-                "    return output\n",
+                "    if len(output) != 0:\n",
+                "        return CheckOutput(status=CheckOutputStatus.FAILED,\n",
+                "                   objects=output,\n",
+                "                   error=str(\"\"))\n",
+                "    else:\n",
+                "        return CheckOutput(status=CheckOutputStatus.SUCCESS,\n",
+                "                   objects=output,\n",
+                "                   error=str(\"\"))\n",
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
-                "task.configure(inputParamsJson='''{\n",
-                "    \"interval\": \"5\"\n",
-                "    }''')\n",
-                "task.configure(outputName=\"sql_queries\")\n",
                 "\n",
+                "task.configure(inputParamsJson='''{\n",
+                "    \"interval\": \"int(interval)\"\n",
+                "    }''')\n",
+                "task.configure(outputName=\"postgresql_queries\")\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
-                "    task.output = task.execute(postgresql_long_running_queries, hdl=hdl, args=args)\n",
-                "    if task.output_name != None:\n",
-                "        globals().update({task.output_name: task.output[0]})"
+                "    task.execute(postgresql_long_running_queries, lego_printer=postgresql_long_running_queries_printer, hdl=hdl, args=args)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "5b8a6162-5475-422d-98c6-7d756956ed8f",
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Step-1 Extension",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-1 Extension"
+            },
+            "source": [
+                "<h3 id=\"Modify-Output\">Modify Output</h3>\n",
+                "<p>In this action, we modify the output from step 1 and return a list of dictionary items for all the long-running queries on the PostgreSQL database.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable: </strong>postgresql_queries</p>\n",
+                "</blockquote>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "id": "e8b0d7b7-03a5-456c-971a-a638b2435eeb",
+            "metadata": {
+                "customAction": true,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-10T14:22:18.994Z"
+                },
+                "name": "Modify Output",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Modify Output",
+                "trusted": true
+            },
+            "outputs": [],
+            "source": [
+                "sql_queries = []\n",
+                "if postgresql_queries.status == CheckOutputStatus.FAILED:\n",
+                "    for queries in postgresql_queries.objects:\n",
+                "        sql_queries.append(queries)"
             ]
         },
         {
             "cell_type": "markdown",
             "id": "1256bbdf",
-            "metadata": {},
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Step-2",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-2"
+            },
             "source": [
-                "Here we will use unSkript Post Slack Message Lego. This lego takes channel: str and message: str as input. This inputs is used to post the message to the slack channel."
+                "<h3 id=\"Post-Slack-Message\">Post Slack Message<a class=\"jp-InternalAnchorLink\" href=\"#Post-Slack-Message\" target=\"_self\">&para;</a></h3>\n",
+                "<p>Here we will use unSkript <strong>Post Slack Message</strong> action. This action posts the message to the slack channel about the long-running queries on the PostgreSQL database.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Input parameters:</strong> <code>channel,&nbsp;message</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable:</strong> <code>message_status</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 7,
             "id": "84b2379b-c11c-42a8-8575-8b75efe52574",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
@@ -195,7 +295,6 @@
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
                 "action_uuid": "6a87f83ab0ecfeecb9c98d084e2b1066c26fa64be5b4928d5573a5d60299802d",
-                "collapsed": true,
                 "createTime": "1970-01-01T00:00:00Z",
                 "credentialsJson": {},
                 "currentVersion": "0.1.0",
@@ -237,7 +336,6 @@
                     }
                 ],
                 "jupyter": {
-                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_SLACK",
@@ -253,9 +351,16 @@
                 "output": {
                     "type": ""
                 },
+                "outputParams": {
+                    "output_name": "message_status",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
                 "tags": [
                     "slack_post_message"
                 ],
+                "title": "Post Slack Message",
+                "trusted": true,
                 "verbs": [
                     "post"
                 ]
@@ -312,15 +417,13 @@
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
+                "task.configure(printOutput=True)\n",
                 "task.configure(inputParamsJson='''{\n",
                 "    \"channel\": \"channel\",\n",
                 "    \"message\": \"f\\\\\"Long Running Queries : {sql_queries}\\\\\"\"\n",
                 "    }''')\n",
-                "task.configure(conditionsJson='''{\n",
-                "    \"condition_enabled\": true,\n",
-                "    \"condition_cfg\": \"len(sql_queries) >0\",\n",
-                "    \"condition_result\": true\n",
-                "    }''')\n",
+                "task.configure(outputName=\"message_status\")\n",
+                "\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
                 "    task.output = task.execute(slack_post_message, hdl=hdl, args=args)\n",
@@ -331,34 +434,43 @@
         {
             "cell_type": "markdown",
             "id": "f45b5e96",
-            "metadata": {},
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Conclusion",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Conclusion"
+            },
             "source": [
-                "### Conclusion\n",
-                "In this Runbook, we demonstrated the use of unSkript's PostgreSQL legos to run PostgreSQL Query and displays collects the long running queries from a database and sends the message to a slack channel. To view the full platform capabilities of unSkript please visit https://unskript.com"
+                "<h3 id=\"Conclusion\">Conclusion</h3>\n",
+                "<p>In this Runbook, we demonstrated the use of unSkript's PostgreSQL legos to run PostgreSQL Query and display and collect the long-running queries from a database and send the message to a slack channel. To view the full platform capabilities of unSkript please visit <a href=\"https://us.app.unskript.io\">https://us.app.unskript.io</a></p>"
             ]
         }
     ],
     "metadata": {
         "execution_data": {
-            "environment_id": "dba3932f-3118-4ab0-b92c-70fa56402037",
-            "environment_name": "SingleAMI",
+            "environment_name": "SingleAMIInstance",
+            "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "workflow.ipynb",
+            "notebook_id": "1b3e0403-ecf0-4c8c-bff2-6f0f8c4f8c4e.ipynb",
             "parameters": [
                 "channel",
                 "interval"
             ],
-            "runbook_name": "JRRunbook",
+            "proxy_id": "1b032d60-0671-498f-a117-6c2f355648fe",
+            "runbook_name": "Display long running queries in a PostgreSQL database",
             "search_string": "",
             "show_tool_tip": false,
-            "tenant_id": "8b3c7148-2d57-4b89-84d3-d59f6c792b0c",
-            "tenant_url": "https://tenant-amit.dev.unskript.io",
-            "user_email_id": "amit@unskript.com",
-            "workflow_id": "755dbe40-22d7-4b70-a04d-31d34bb04e4a"
+            "tenant_id": "117718cf-b601-4a00-9164-3e4311468e45",
+            "tenant_url": "https://tenant-jayasimha.dev.unskript.io",
+            "user_email_id": "jayasimha@unskript.com",
+            "workflow_id": "bb2e1417-4cca-42d1-ab5a-592f810b9050"
         },
         "kernelspec": {
-            "display_name": "Python 3.9.12 ('base')",
+            "display_name": "base",
             "language": "python",
             "name": "python3"
         },
@@ -372,13 +484,12 @@
         "parameterSchema": {
             "properties": {
                 "channel": {
-                    "default": "",
                     "description": "Slack channel to post to",
                     "title": "channel",
                     "type": "string"
                 },
                 "interval": {
-                    "default": "5",
+                    "default": "10",
                     "description": "Time interval to check for long queries",
                     "title": "interval",
                     "type": "string"
@@ -388,10 +499,7 @@
             "title": "Schema",
             "type": "object"
         },
-        "parameterValues": {
-            "channel": null,
-            "interval": "5"
-        },
+        "parameterValues": null,
         "vscode": {
             "interpreter": {
                 "hash": "5e269198fab4eb2ea6fe7c886c38b87b334869f0501ab924e1d16d60aeba5d23"

--- a/Postgresql/Display_Postgresql_Long_Running.ipynb
+++ b/Postgresql/Display_Postgresql_Long_Running.ipynb
@@ -51,7 +51,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 8,
+            "execution_count": 10,
             "id": "c8565b85-30c3-43f7-9f4b-b8a3bd271861",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
@@ -67,6 +67,7 @@
                 "actionSupportsPoll": true,
                 "action_modified": false,
                 "action_uuid": "ef9f0f3dd00ef0972895ea006375f1a4496dca1b7266bc60fdfbd8ab4feee6c3",
+                "collapsed": true,
                 "continueOnError": false,
                 "createTime": "1970-01-01T00:00:00Z",
                 "credentialsJson": {
@@ -77,7 +78,7 @@
                 "currentVersion": "0.1.0",
                 "description": "Long Running PostgreSQL Queries",
                 "execution_data": {
-                    "last_date_success_run_cell": "2023-02-10T14:22:09.568Z"
+                    "last_date_success_run_cell": "2023-02-15T18:50:41.391Z"
                 },
                 "id": 332,
                 "index": 332,
@@ -104,6 +105,7 @@
                     }
                 ],
                 "jupyter": {
+                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_POSTGRESQL",
@@ -134,25 +136,22 @@
                 "# Copyright (c) 2021 unSkript, Inc\n",
                 "# All rights reserved.\n",
                 "##\n",
-                "from typing import List, Any, Optional\n",
-                "from unskript.legos.utils import CheckOutput, CheckOutputStatus\n",
+                "from typing import List, Any, Optional, Tuple\n",
                 "from tabulate import tabulate\n",
                 "from pydantic import BaseModel, Field\n",
-                "\n",
+                "import pprint\n",
                 "\n",
                 "from beartype import beartype\n",
                 "@beartype\n",
                 "def postgresql_long_running_queries_printer(output):\n",
                 "    if output is None:\n",
                 "        return\n",
-                "    if isinstance(output, CheckOutput):\n",
-                "        print(output.json())\n",
-                "    else:\n",
-                "        pprint.pprint(output)\n",
+                "    \n",
+                "    pprint.pprint(output)\n",
                 "\n",
                 "\n",
                 "@beartype\n",
-                "def postgresql_long_running_queries(handle, interval: int = 5) -> CheckOutput:\n",
+                "def postgresql_long_running_queries(handle, interval: int = 5) -> Tuple:\n",
                 "    \"\"\"postgresql_long_running_queries Runs postgres query with the provided parameters.\n",
                 "\n",
                 "          :type handle: object\n",
@@ -196,13 +195,9 @@
                 "    cur.close()\n",
                 "    handle.close()\n",
                 "    if len(output) != 0:\n",
-                "        return CheckOutput(status=CheckOutputStatus.FAILED,\n",
-                "                   objects=output,\n",
-                "                   error=str(\"\"))\n",
+                "        return (False, output)\n",
                 "    else:\n",
-                "        return CheckOutput(status=CheckOutputStatus.SUCCESS,\n",
-                "                   objects=output,\n",
-                "                   error=str(\"\"))\n",
+                "        return (True, None)\n",
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
@@ -240,12 +235,17 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 9,
+            "execution_count": 12,
             "id": "e8b0d7b7-03a5-456c-971a-a638b2435eeb",
             "metadata": {
+                "collapsed": true,
                 "customAction": true,
                 "execution_data": {
-                    "last_date_success_run_cell": "2023-02-10T14:22:18.994Z"
+                    "last_date_success_run_cell": "2023-02-15T18:58:06.161Z"
+                },
+                "jupyter": {
+                    "outputs_hidden": true,
+                    "source_hidden": true
                 },
                 "name": "Modify Output",
                 "orderProperties": [],
@@ -256,8 +256,8 @@
             "outputs": [],
             "source": [
                 "sql_queries = []\n",
-                "if postgresql_queries.status == CheckOutputStatus.FAILED:\n",
-                "    for queries in postgresql_queries.objects:\n",
+                "if postgresql_queries[0] == False:\n",
+                "    for queries in postgresql_queries[1]:\n",
                 "        sql_queries.append(queries)"
             ]
         },
@@ -360,7 +360,6 @@
                     "slack_post_message"
                 ],
                 "title": "Post Slack Message",
-                "trusted": true,
                 "verbs": [
                     "post"
                 ]
@@ -455,7 +454,7 @@
             "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "1b3e0403-ecf0-4c8c-bff2-6f0f8c4f8c4e.ipynb",
+            "notebook_id": "84421054-2faf-4106-bee0-f911b040d5c9.ipynb",
             "parameters": [
                 "channel",
                 "interval"
@@ -470,16 +469,14 @@
             "workflow_id": "bb2e1417-4cca-42d1-ab5a-592f810b9050"
         },
         "kernelspec": {
-            "display_name": "base",
-            "language": "python",
-            "name": "python3"
+            "display_name": "unSkript (Build: 891)",
+            "name": "python_kubernetes"
         },
         "language_info": {
             "file_extension": ".py",
             "mimetype": "text/x-python",
             "name": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.12"
+            "pygments_lexer": "ipython3"
         },
         "parameterSchema": {
             "properties": {
@@ -499,12 +496,7 @@
             "title": "Schema",
             "type": "object"
         },
-        "parameterValues": null,
-        "vscode": {
-            "interpreter": {
-                "hash": "5e269198fab4eb2ea6fe7c886c38b87b334869f0501ab924e1d16d60aeba5d23"
-            }
-        }
+        "parameterValues": null
     },
     "nbformat": 4,
     "nbformat_minor": 5


### PR DESCRIPTION
## Description
Display Postgresql Long Running Queries

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
https://user-images.githubusercontent.com/63058785/218130606-a121c74e-ab0e-410b-8834-54dc5ea460b3.mp4

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
