### PR TITLE
EN-3841 Runbook: k8s: Get candidate nodes for given configuration

### DIFF
--- a/Kubernetes/K8S_Get_Candidate_Nodes_Given_Config.ipynb
+++ b/Kubernetes/K8S_Get_Candidate_Nodes_Given_Config.ipynb
@@ -3,34 +3,54 @@
         {
             "cell_type": "markdown",
             "id": "5f2fac7e",
-            "metadata": {},
+            "metadata": {
+                "jupyter": {
+                    "source_hidden": false
+                },
+                "name": "Runbook Overview",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Runbook Overview"
+            },
             "source": [
-                "\n",
-                "<img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\"/> \n",
-                "<h1> unSkript Runbooks </h1>\n",
+                "<center><img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\">\n",
+                "<h1 id=\"unSkript-Runbooks\">unSkript Runbooks</h1>\n",
                 "<div class=\"alert alert-block alert-success\">\n",
-                "    <b> This Runbook demonstrates How to Get candidate k8s nodes for given configuration using unSkript legos.</b>\n",
-                "</div>\n",
-                "\n",
-                "<br>\n",
-                "\n",
-                "<center><h2>Get Candidate k8s Nodes For Given Configuration</h2></center>\n",
-                "\n",
-                "# Steps Overview\n",
-                "    Get the matching nodes for a given configuration."
+                "<h3 id=\"Objective\"><strong>Objective</strong></h3>\n",
+                "<strong>To get candidate k8s nodes for a given configuration using unSkript actions.</strong></div>\n",
+                "</center><center>\n",
+                "<h2 id=\"Get-Candidate-k8s-Nodes-For-Given-Configuration\">Get Candidate k8s Nodes For Given Configuration</h2>\n",
+                "</center>\n",
+                "<h1 id=\"Steps-Overview\">Steps Overview</h1>\n",
+                "<p>1. Get the matching nodes for a given configuration<code>\n",
+                "</code></p>"
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "d84b6f44",
-            "metadata": {},
+            "metadata": {
+                "name": "Step-1",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-1"
+            },
             "source": [
-                "Here we will use unSkript `Get candidate k8s nodes for given configuration` Lego. This lego takes `attachable_volumes_aws_ebs`, `cpu_limit`, `memory_limit` and `coreApiClient` as input. These inputs are used to find out matching nodes for a given configuration."
+                "<h3 id=\"Get-candidate-k8s-nodes-for-the-given-configuration\">Get candidate k8s nodes for the given configuration</h3>\n",
+                "<p>Here we will use unSkript <strong>Get candidate k8s nodes for the given configuration</strong> action. This action is used to find out matching nodes for a given configuration.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Input parameters:</strong> <code>attachable_volumes_aws_ebs, cpu_limit, memory_limit, pod_limit</code></p>\n",
+                "</blockquote>\n",
+                "<blockquote>\n",
+                "<p><strong>Output variable:</strong> <code>candidate_nodes</code></p>\n",
+                "</blockquote>\n",
+                "<p>&nbsp;</p>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 43,
             "id": "faff16f3-a562-4d4e-804c-c509efee3cec",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
@@ -39,20 +59,30 @@
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
                 "action_uuid": "5326cf5d52f4d62391e32a4290dcca4ac6f023218b01aefcc5be2765391e7ea2",
+                "collapsed": true,
+                "continueOnError": false,
                 "createTime": "1970-01-01T00:00:00Z",
+                "credentialsJson": {
+                    "credential_id": "99a90d06-3166-449f-8e9b-6307468903cb",
+                    "credential_name": "K8SCreds",
+                    "credential_type": "CONNECTOR_TYPE_K8S"
+                },
                 "currentVersion": "0.1.0",
                 "description": "Get candidate k8s nodes for given configuration",
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-13T10:59:51.802Z"
+                },
                 "id": 34,
                 "index": 34,
                 "inputData": [
                     {
                         "attachable_volumes_aws_ebs": {
                             "constant": false,
-                            "value": "ebs_limit"
+                            "value": "int(ebs_limit)"
                         },
                         "cpu_limit": {
                             "constant": false,
-                            "value": "cpu_limit"
+                            "value": "int(cpu_limit)"
                         },
                         "memory_limit": {
                             "constant": false,
@@ -60,7 +90,7 @@
                         },
                         "pod_limit": {
                             "constant": false,
-                            "value": "pod_limit"
+                            "value": "int(pod_limit)"
                         }
                     }
                 ],
@@ -97,6 +127,7 @@
                     }
                 ],
                 "jupyter": {
+                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_K8S",
@@ -115,9 +146,16 @@
                 "output": {
                     "type": ""
                 },
+                "outputParams": {
+                    "output_name": "candidate_nodes",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
                 "tags": [
                     "k8s_get_candidate_nodes_for_pods"
                 ],
+                "title": "Get candidate k8s nodes for given configuration",
+                "trusted": true,
                 "verbs": [
                     "get"
                 ]
@@ -165,19 +203,21 @@
                 "        print(\"\\n\")\n",
                 "        print(tabulate(data, tablefmt=\"grid\", headers=[\"Name\", \"attachable-volumes-aws-ebs\", \"cpu\", \"ephemeral-storage\",\n",
                 "                                                       \"hugepages-1Gi\", \"hugepages-2Mi\", \"memory\", \"pods\"]))\n",
-                "        return match_nodes\n",
+                "        return match_nodes`\n",
                 "\n",
                 "    pp.pprint(\"No Matching Nodes Found for this spec\")\n",
                 "    return None\n",
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
+                "task.configure(outputName=\"candidate_nodes\")\n",
                 "task.configure(inputParamsJson='''{\n",
-                "    \"attachable_volumes_aws_ebs\": \"ebs_limit\",\n",
-                "    \"cpu_limit\": \"cpu_limit\",\n",
+                "    \"attachable_volumes_aws_ebs\": \"int(ebs_limit)\",\n",
+                "    \"cpu_limit\": \"int(cpu_limit)\",\n",
                 "    \"memory_limit\": \"memory_limit\",\n",
-                "    \"pod_limit\": \"pod_limit\"\n",
+                "    \"pod_limit\": \"int(pod_limit)\"\n",
                 "    }''')\n",
+                "task.configure(printOutput=True)\n",
                 "\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
@@ -201,71 +241,76 @@
         {
             "cell_type": "markdown",
             "id": "2a154136",
-            "metadata": {},
+            "metadata": {
+                "name": "Conclusion",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Conclusion"
+            },
             "source": [
-                "### Conclusion\n",
-                "In this Runbook, we demonstrated the use of unSkript's k8s legos to run k8s configuration and get the matching nodes for a given configuration (storage, cpu, memory, pod_limit). To view the full platform capabilities of unSkript please visit https://unskript.com"
+                "<h3 id=\"Conclusion\">Conclusion</h3>\n",
+                "<p>In this Runbook, we demonstrated the use of unSkript's k8s legos to run k8s configuration and get the matching nodes for a given configuration (storage, CPU, memory, pod_limit). To view the full platform capabilities of unSkript please visit&nbsp;<a href=\"https://us.app.unskript.io\" target=\"_blank\" rel=\"noopener\">https://us.app.unskript.io</a></p>"
             ]
         }
     ],
     "metadata": {
         "execution_data": {
             "environment_id": "dba3932f-3118-4ab0-b92c-70fa56402037",
-            "environment_name": "SingleAMI",
+            "environment_name": "SingleAMIInstance",
+            "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "workflow.ipynb",
+            "notebook_id": "c707710e-247e-4035-94f4-e2d8de04dad8.ipynb",
             "parameters": [
+                "cpu_limit",
                 "ebs_limit",
                 "memory_limit",
-                "pod_limit",
-                "cpu_limit"
+                "pod_limit"
             ],
-            "runbook_name": "JRRunbook",
+            "proxy_id": "1b032d60-0671-498f-a117-6c2f355648fe",
+            "runbook_name": "k8s: Get candidate nodes for given configuration",
             "search_string": "",
             "show_tool_tip": false,
-            "tenant_id": "8b3c7148-2d57-4b89-84d3-d59f6c792b0c",
-            "tenant_url": "https://tenant-amit.dev.unskript.io",
-            "user_email_id": "amit@unskript.com",
-            "workflow_id": "755dbe40-22d7-4b70-a04d-31d34bb04e4a"
+            "tenant_id": "117718cf-b601-4a00-9164-3e4311468e45",
+            "tenant_url": "https://tenant-jayasimha.dev.unskript.io",
+            "user_email_id": "jayasimha@unskript.com",
+            "workflow_id": "4f81bc20-28fb-4d08-a3af-e5dd2a2a7cc9"
         },
         "kernelspec": {
-            "display_name": "Python 3.9.6 64-bit",
-            "language": "python",
-            "name": "python3"
+            "display_name": "unSkript (Build: 839)",
+            "name": "python_kubernetes"
         },
         "language_info": {
             "file_extension": ".py",
             "mimetype": "text/x-python",
             "name": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.6"
+            "pygments_lexer": "ipython3"
         },
         "parameterSchema": {
             "properties": {
                 "cpu_limit": {
-                    "default": 0,
+                    "default": 1,
                     "description": "CPU Limit. Eg 2",
                     "title": "cpu_limit",
-                    "type": "integer"
+                    "type": "number"
                 },
                 "ebs_limit": {
-                    "default": 0,
+                    "default": 1,
                     "description": "EBS Volume Limit in Gb. Eg 25",
                     "title": "ebs_limit",
-                    "type": "integer"
+                    "type": "number"
                 },
                 "memory_limit": {
-                    "default": 0,
+                    "default": "65Mi",
                     "description": "Memory limits and requests are measured in bytes. Eg 64Mi",
                     "title": "memory_limit",
-                    "type": "integer"
+                    "type": "string"
                 },
                 "pod_limit": {
-                    "default": 0,
+                    "default": 1,
                     "description": "Limit on pods",
                     "title": "pod_limit",
-                    "type": "integer"
+                    "type": "number"
                 }
             },
             "required": [],
@@ -273,15 +318,10 @@
             "type": "object"
         },
         "parameterValues": {
-            "cpu_limit": null,
-            "ebs_limit": null,
-            "memory_limit": null,
-            "pod_limit": null
-        },
-        "vscode": {
-            "interpreter": {
-                "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
-            }
+            "cpu_limit": 1,
+            "ebs_limit": 1,
+            "memory_limit": "65Mi",
+            "pod_limit": 1
         }
     },
     "nbformat": 4,


### PR DESCRIPTION
## Description
1. k8s: Get candidate nodes for the given configuration

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing

https://user-images.githubusercontent.com/63058785/218448347-f38561d5-da05-4b72-b57b-98f0c609c69b.mp4



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
