### PR TITLE
EN-3835 Runbook: Lowering AWS CloudTrail Costs by Removing Redundant Trails

### DIFF
--- a/AWS/Lowering_AWS_CloudTrail_Costs_by_Removing_Redundant_Trails.ipynb
+++ b/AWS/Lowering_AWS_CloudTrail_Costs_by_Removing_Redundant_Trails.ipynb
@@ -13,18 +13,14 @@
                 "title": "Finding Redundant Trails in AWS"
             },
             "source": [
-                "<img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\"/> \n",
-                "<h1> unSkript Runbooks </h1>\n",
-                "<div class=\"alert alert-block alert-success\">\n",
-                "    <b> This runbook demonstrates How to find Redundant Trails in AWS using unSkript legos.</b>\n",
-                "</div>\n",
-                "\n",
-                "<br>\n",
-                "\n",
-                "<center><h2>Lowering AWS CloudTrail Costs by Removing Redundant Trails</h2></center>\n",
-                "\n",
-                "# Steps Overview\n",
-                "The AWS CloudTrail service allows developers to enable policies managing compliance, governance, and auditing of their AWS account. In addition, AWS CloudTrail offers logging, monitoring, and storage of any activity around actions related to your AWS structures. The service activates from the moment you set up your AWS account and while it provides real-time activity visibility, it also means higher AWS costs. Here Finding Redundant Trails in AWS"
+                "<center><img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\">\n",
+                "<h1 id=\"-unSkript-Runbooks-\">unSkript Runbooks&nbsp;</h1>\n",
+                "<div class=\"alert alert-block alert-success\"><strong> This runbook demonstrates how to find redundant trails in AWS using unSkript actions.</strong></div>\n",
+                "</center><center>\n",
+                "<h2 id=\"Finding-Redundant-Trails-in-AWS\">Finding Redundant Trails in AWS</h2>\n",
+                "</center>\n",
+                "<h1 id=\"Steps-Overview\">Steps Overview</h1>\n",
+                "<p>1. Finding Redundant Trails in AWS</p>"
             ]
         },
         {
@@ -34,18 +30,22 @@
                 "jupyter": {
                     "source_hidden": false
                 },
-                "name": "Run Command via AWS CLI",
+                "name": "Step-1",
                 "orderProperties": [],
                 "tags": [],
-                "title": "Run Command via AWS CLI"
+                "title": "Step-1"
             },
             "source": [
-                "Here we will use unSkript Run Command via AWS CLI Lego. This lego take aws_command \"aws cloudtrail describe-trails\" as input. This input is used to find Redundant Trails in AWS."
+                "<h3 id=\"Finding-Redundant-Trails-in-AWS\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>Finding Redundant Trails in AWS</h3>\n",
+                "<p>Here we will use unSkript Finding Redundant Trails in AWS action. The AWS CloudTrail service allows developers to enable policies managing compliance, governance, and auditing of their AWS accounts. In addition, AWS CloudTrail offers logging, monitoring, and storage of any activity around actions related to your AWS structures. The service activates from the moment you set up your AWS account, and while it provides real-time activity visibility, it also means higher AWS costs. This action is used to find Redundant Trails in AWS.</p>\n",
+                "<blockquote>\n",
+                "<p><strong>Output parameters:</strong>&nbsp;<code>redundant_trails</code></p>\n",
+                "</blockquote>"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 5,
+            "execution_count": 40,
             "id": "326180b8-ea0e-4acb-bf21-59b149a12316",
             "metadata": {
                 "accessType": "ACCESS_TYPE_UNSPECIFIED",
@@ -55,14 +55,17 @@
                 "actionSupportsIteration": true,
                 "actionSupportsPoll": true,
                 "action_uuid": "1db371aff42291641eb6ba83d7acc3fe28e2468d83be1552e8258dc878c0f70d",
-                "collapsed": true,
                 "continueOnError": false,
                 "createTime": "1970-01-01T00:00:00Z",
-                "credentialsJson": {},
+                "credentialsJson": {
+                    "credential_id": "0b438eba-0627-4f6d-b998-a4c604f20e3c",
+                    "credential_name": "DevRole",
+                    "credential_type": "CONNECTOR_TYPE_AWS"
+                },
                 "currentVersion": "0.1.0",
                 "description": " Execute command using AWS CLI",
                 "execution_data": {
-                    "last_date_success_run_cell": "2022-09-28T10:13:01.951Z"
+                    "last_date_success_run_cell": "2023-02-21T10:49:16.856Z"
                 },
                 "id": 171,
                 "index": 171,
@@ -70,7 +73,7 @@
                     {
                         "aws_command": {
                             "constant": false,
-                            "value": "AWS_Command"
+                            "value": "\"aws cloudtrail describe-trails\""
                         }
                     }
                 ],
@@ -91,11 +94,10 @@
                     }
                 ],
                 "jupyter": {
-                    "outputs_hidden": true,
                     "source_hidden": true
                 },
                 "legotype": "LEGO_TYPE_AWS",
-                "name": " Run Command via AWS CLI",
+                "name": "Finding Redundant Trails in AWS",
                 "nouns": [
                     "command",
                     "aws"
@@ -106,14 +108,253 @@
                 "output": {
                     "type": ""
                 },
+                "outputParams": {
+                    "output_name": "redundant_trails",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
                 "tags": [
                     "aws_execute_cli_command"
                 ],
-                "title": " Run Command via AWS CLI",
+                "title": "Finding Redundant Trails in AWS",
                 "trusted": true,
                 "verbs": [
                     "run"
                 ]
+            },
+            "outputs": [],
+            "source": [
+                "##\n",
+                "##  Copyright (c) 2023 unSkript, Inc\n",
+                "##  All rights reserved.\n",
+                "##\n",
+                "from pydantic import BaseModel, Field\n",
+                "from typing import Tuple\n",
+                "from unskript.legos.aws.aws_list_all_regions.aws_list_all_regions import aws_list_all_regions\n",
+                "import pprint\n",
+                "\n",
+                "\n",
+                "def aws_finding_redundant_trails_printer(output):\n",
+                "    if output is None:\n",
+                "        return\n",
+                "    pprint.pprint(output)\n",
+                "\n",
+                "\n",
+                "def aws_finding_redundant_trails(handle) -> Tuple:\n",
+                "    \"\"\"aws_finding_redundant_trails Returns an array of redundant trails in AWS\n",
+                "        :type handle: object\n",
+                "        :param handle: Object returned by the task.validate(...) method.\n",
+                "        :rtype: Tuple with check status and list of redundant trails\n",
+                "    \"\"\"\n",
+                "    result = []\n",
+                "    all_regions = aws_list_all_regions(handle)\n",
+                "    for reg in all_regions:\n",
+                "        try:\n",
+                "            ec2Client = handle.client('cloudtrail', region_name=reg)\n",
+                "            response = ec2Client.describe_trails()\n",
+                "            for glob_service in response[\"trailList\"]:\n",
+                "                if glob_service[\"IncludeGlobalServiceEvents\"] is True:\n",
+                "                    for i in result:\n",
+                "                        if i[\"trail_name\"] == glob_service[\"Name\"]:\n",
+                "                            i[\"regions\"].append(reg)\n",
+                "                    else:\n",
+                "                        if not any(i[\"trail_name\"] == glob_service[\"Name\"] for i in result):\n",
+                "                            trail_dict = {}\n",
+                "                            trail_dict[\"trail_name\"] = glob_service[\"Name\"]\n",
+                "                            trail_dict[\"regions\"] = [reg]\n",
+                "                            result.append(trail_dict)\n",
+                "        except Exception as e:\n",
+                "            pass\n",
+                "\n",
+                "    if len(result) != 0:\n",
+                "        return (False, result)\n",
+                "    else:\n",
+                "        return (True, None)\n",
+                "\n",
+                "\n",
+                "task = Task(Workflow())\n",
+                "task.configure(printOutput=True)\n",
+                "task.configure(outputName=\"redundant_trails\")\n",
+                "(err, hdl, args) = task.validate(vars=vars())\n",
+                "if err is None:\n",
+                "    task.execute(aws_finding_redundant_trails, lego_printer=aws_finding_redundant_trails_printer, hdl=hdl, args=args)"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "e49d7606-52ce-4a2b-bc06-22e5470d1aeb",
+            "metadata": {
+                "name": "Step-1 Extension",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-1 Extension"
+            },
+            "source": [
+                "<h3 id=\"Modify-Output\">Modify Output</h3>\n",
+                "<p>In this action, we sort the commands on the basis of parameters given by the user as follows,</p>\n",
+                "<ol>\n",
+                "<li><code>stop_multiregion_trail = true </code>To turn off multi-region tracking of cloud trail.\n",
+                "<ol>\n",
+                "<li><code>aws cloudtrail update-trail&nbsp;<span class=\"hljs-attr\">--region</span> us-west-<span class=\"hljs-number\">2</span> <span class=\"hljs-attr\">--name</span> cc-test-trail --no-<span class=\"hljs-keyword\">is</span>-multi-region-trail</code></li>\n",
+                "</ol>\n",
+                "</li>\n",
+                "<li><code>global_event_tractiong = true </code>To turn off the global service events tracking the issue of the cloud trail.\n",
+                "<ol>\n",
+                "<li><code>aws cloudtrail update-trail&nbsp;<span class=\"hljs-attr\">--region</span> us-west-<span class=\"hljs-number\">2</span> <span class=\"hljs-attr\">--name</span> cc-test-trail --no-<span class=\"hljs-keyword\">include</span>-<span class=\"hljs-keyword\">global</span>-service-events</code></li>\n",
+                "</ol>\n",
+                "</li>\n",
+                "<li>For <code>stop_multiregion_trail = true and global_event_tractiong = true</code>&nbsp;we use both commands to update the redundant trails.</li>\n",
+                "</ol>\n",
+                "<p><strong>Output parameters:</strong>&nbsp;<code>command_list</code></p>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 41,
+            "id": "d2fe73b3-eba6-4e47-94d9-551e6533119e",
+            "metadata": {
+                "customAction": true,
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-21T10:49:20.023Z"
+                },
+                "jupyter": {
+                    "source_hidden": true
+                },
+                "name": "Modify Output",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Modify Output",
+                "trusted": true
+            },
+            "outputs": [],
+            "source": [
+                "command_list = []\n",
+                "if stop_multiregion_trail and not global_event_tractiong:\n",
+                "    if not redundant_trails[0]:\n",
+                "        for i in redundant_trails[1]:\n",
+                "            command = \"aws cloudtrail update-trail --region \" + region + \" --name \" + i[\"trail_name\"] + \" --no-is-multi-region-trail\"\n",
+                "            command_list.append(command)\n",
+                "elif not stop_multiregion_trail and global_event_tractiong:\n",
+                "    if not redundant_trails[0]:\n",
+                "        for i in redundant_trails[1]:\n",
+                "            for region_1 in i[\"regions\"]:\n",
+                "                command = \"aws cloudtrail update-trail --region \" + region_1 + \" --name \" + i[\"trail_name\"] + \" --no-include-global-service-events\"\n",
+                "                command_list.append(command)\n",
+                "elif stop_multiregion_trail and global_event_tractiong:\n",
+                "    if not redundant_trails[0]:\n",
+                "        for i in redundant_trails[1]:\n",
+                "            command_1 = \"aws cloudtrail update-trail --region \" + region + \" --name \" + i[\"trail_name\"] + \" --no-include-global-service-events\"\n",
+                "            command_2 = \"aws cloudtrail update-trail --region \" + region + \" --name \" + i[\"trail_name\"] + \" --no-is-multi-region-trail\"\n",
+                "            command_list.append(command_1)\n",
+                "            command_list.append(command_2)\n"
+            ]
+        },
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "id": "0d382061-c58d-4528-b2d4-eb9f1f4549de",
+            "metadata": {
+                "name": "Step-2",
+                "orderProperties": [],
+                "tags": [],
+                "title": "Step-2"
+            },
+            "source": [
+                "<h3 id=\"Run-Command-via-AWS-CLI\">Run Command via AWS CLI</h3>\n",
+                "<p>In this action, we execute the commands from the above actions to update the redundant cloud trails.</p>\n",
+                "<p><strong>&nbsp; &nbsp; &nbsp; &nbsp;Input parameters:</strong>&nbsp;<code>aws_command</code></p>\n",
+                "<p><strong>&nbsp; &nbsp; &nbsp; &nbsp;Output parameters:</strong>&nbsp;<code>updated_output</code></p>\n",
+                "<p>&nbsp;</p>"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 42,
+            "id": "a991f490-7bc2-43a5-80ec-cab51729d591",
+            "metadata": {
+                "accessType": "ACCESS_TYPE_UNSPECIFIED",
+                "actionBashCommand": false,
+                "actionNeedsCredential": true,
+                "actionRequiredLinesInCode": [],
+                "actionSupportsIteration": true,
+                "actionSupportsPoll": true,
+                "action_modified": false,
+                "action_uuid": "1db371aff42291641eb6ba83d7acc3fe28e2468d83be1552e8258dc878c0f70d",
+                "condition_enabled": true,
+                "continueOnError": true,
+                "createTime": "1970-01-01T00:00:00Z",
+                "credentialsJson": {
+                    "credential_id": "0b438eba-0627-4f6d-b998-a4c604f20e3c",
+                    "credential_name": "DevRole",
+                    "credential_type": "CONNECTOR_TYPE_AWS"
+                },
+                "currentVersion": "0.1.0",
+                "description": "Execute command using AWS CLI",
+                "execution_data": {
+                    "last_date_success_run_cell": "2023-02-21T10:49:24.829Z"
+                },
+                "id": 199,
+                "index": 199,
+                "inputData": [
+                    {
+                        "aws_command": {
+                            "constant": false,
+                            "value": "iter_item"
+                        }
+                    }
+                ],
+                "inputschema": [
+                    {
+                        "properties": {
+                            "aws_command": {
+                                "description": "AWS Command eg \"aws ec2 describe-instances\"",
+                                "title": "AWS Command",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "aws_command"
+                        ],
+                        "title": "aws_execute_cli_command",
+                        "type": "object"
+                    }
+                ],
+                "iterData": [
+                    {
+                        "iter_enabled": true,
+                        "iter_item": "aws_command",
+                        "iter_list": {
+                            "constant": false,
+                            "objectItems": false,
+                            "value": "command_list"
+                        }
+                    }
+                ],
+                "jupyter": {
+                    "source_hidden": true
+                },
+                "legotype": "LEGO_TYPE_AWS",
+                "name": "Run Command via AWS CLI: Update Redundant Cloud Trails",
+                "nouns": [],
+                "orderProperties": [
+                    "aws_command"
+                ],
+                "output": {
+                    "type": ""
+                },
+                "outputParams": {
+                    "output_name": "updated_output",
+                    "output_name_enabled": true
+                },
+                "printOutput": true,
+                "startcondition": "len(command_list)>0",
+                "tags": [
+                    "aws_execute_cli_command"
+                ],
+                "title": "Run Command via AWS CLI: Update Redundant Cloud Trails",
+                "trusted": true,
+                "verbs": []
             },
             "outputs": [],
             "source": [
@@ -147,17 +388,30 @@
                 "\n",
                 "\n",
                 "task = Task(Workflow())\n",
-                "task.configure(credentialsJson='''{\n",
-                "}''')\n",
+                "task.configure(continueOnError=True)\n",
                 "task.configure(inputParamsJson='''{\n",
-                "    \"aws_command\": \"AWS_Command\"\n",
+                "    \"aws_command\": \"iter_item\"\n",
                 "    }''')\n",
+                "task.configure(iterJson='''{\n",
+                "    \"iter_enabled\": true,\n",
+                "    \"iter_list_is_const\": false,\n",
+                "    \"iter_list\": \"command_list\",\n",
+                "    \"iter_parameter\": \"aws_command\"\n",
+                "    }''')\n",
+                "task.configure(conditionsJson='''{\n",
+                "    \"condition_enabled\": true,\n",
+                "    \"condition_cfg\": \"len(command_list)>0\",\n",
+                "    \"condition_result\": true\n",
+                "    }''')\n",
+                "task.configure(outputName=\"updated_output\")\n",
+                "task.configure(printOutput=True)\n",
                 "(err, hdl, args) = task.validate(vars=vars())\n",
                 "if err is None:\n",
                 "    task.execute(aws_execute_cli_command, lego_printer=aws_execute_cli_command_printer, hdl=hdl, args=args)"
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "id": "c4e37a77-7c92-43ab-80de-bb98d15d0a3a",
             "metadata": {
@@ -170,20 +424,20 @@
                 "title": "Conclusion"
             },
             "source": [
-                "In this Runbook, we demonstrated the use of unSkript's AWS to find Redundant Trails in AWS by passing \"aws cloudtrail describe-trails\" command to get a listing of all tracked Amazon CloudTrail trails so that user can take appropriate action. To view the full platform capabilities of unSkript please visit https://unskript.com"
+                "### Conclusion\n",
+                "<p>This Runbook demonstrates the use of unSkript's AWS actions to find redundant trails in AWS and update the cloud trails. To view the full platform capabilities of unSkript please visit <a href=\"https://us.app.unskript.io/\" rel=\"noopener\">https://us.app.unskript.io</a></p>"
             ]
         }
     ],
     "metadata": {
         "execution_data": {
-            "environment_id": "1499f27c-6406-4fbd-bd1b-c6f92800018f",
             "environment_name": "Staging",
+            "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
             "execution_id": "",
             "inputs_for_searched_lego": "",
-            "notebook_id": "658a4a9f-73a3-4a64-9318-fded54ccb636.ipynb",
-            "parameters": [
-                "AWS_Command"
-            ],
+            "notebook_id": "60fb80f2-94a2-44aa-bd1a-868441f22d85.ipynb",
+            "parameters": null,
+            "proxy_id": "1499f27c-6406-4fbd-bd1b-c6f92800018f",
             "runbook_name": "Lowering AWS CloudTrail Costs by Removing Redundant Trails",
             "search_string": "",
             "show_tool_tip": false,
@@ -193,7 +447,7 @@
             "workflow_id": "e94cbc59-0347-451a-87aa-61014dabb77b"
         },
         "kernelspec": {
-            "display_name": "Python 3.10.6 64-bit",
+            "display_name": "Python 3",
             "language": "python",
             "name": "python3"
         },
@@ -206,11 +460,22 @@
         },
         "parameterSchema": {
             "properties": {
-                "AWS_Command": {
-                    "default": "aws cloudtrail describe-trails",
-                    "description": "AWS Command",
-                    "title": "AWS_Command",
+                "global_event_tractiong": {
+                    "default": false,
+                    "description": "To turn off the global service events tracking the issue of the cloud trail.",
+                    "title": "global_event_tractiong",
+                    "type": "boolean"
+                },
+                "region": {
+                    "description": "To update the cloud trail multi-region tracking to a single region.",
+                    "title": "region",
                     "type": "string"
+                },
+                "stop_multiregion_trail": {
+                    "default": false,
+                    "description": "To turn off multi-region tracking of cloud trail.",
+                    "title": "stop_multiregion_trail",
+                    "type": "boolean"
                 }
             },
             "required": [],
@@ -218,7 +483,8 @@
             "type": "object"
         },
         "parameterValues": {
-            "AWS_Command": null
+            "global_event_tractiong": false,
+            "stop_multiregion_trail": false
         },
         "vscode": {
             "interpreter": {

--- a/AWS/legos/aws_finding_redundant_trails/aws_finding_redundant_trails.py
+++ b/AWS/legos/aws_finding_redundant_trails/aws_finding_redundant_trails.py
@@ -29,20 +29,16 @@ def aws_finding_redundant_trails(handle) -> Tuple:
             ec2Client = handle.client('cloudtrail', region_name=reg)
             response = ec2Client.describe_trails()
             for glob_service in response["trailList"]:
-                trail_dict = {}
                 if glob_service["IncludeGlobalServiceEvents"] is True:
-                    if len(result) > 0:
-                        for i in result:
-                            if i["trail_name"] == glob_service["Name"]:
-                                i["regions"].append(reg)
-                            else:
-                                trail_dict["trail_name"] = glob_service["Name"]
-                                trail_dict["regions"] = [reg]
-                                result.append(trail_dict)
+                    for i in result:
+                        if i["trail_name"] == glob_service["Name"]:
+                            i["regions"].append(reg)
                     else:
-                        trail_dict["trail_name"] = glob_service["Name"]
-                        trail_dict["regions"] = [reg]
-                        result.append(trail_dict)
+                        if not any(i["trail_name"] == glob_service["Name"] for i in result):
+                            trail_dict = {}
+                            trail_dict["trail_name"] = glob_service["Name"]
+                            trail_dict["regions"] = [reg]
+                            result.append(trail_dict)
         except Exception as e:
             pass
 


### PR DESCRIPTION
## Description
Lowering AWS CloudTrail Costs by Removing Redundant Trails

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing

https://user-images.githubusercontent.com/63058785/220335528-449235dc-dcb4-4da8-9984-7fa996938ef9.mp4


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
