### PR TITLE
Fix the 2 other ssh legos

### DIFF
--- a/SSH/legos/ssh_find_large_files/ssh_find_large_files.py
+++ b/SSH/legos/ssh_find_large_files/ssh_find_large_files.py
@@ -13,6 +13,10 @@ class InputSchema(BaseModel):
         title='Host',
         description='Host to connect to. Eg 10.10.10.10'
     )
+    proxy_host: Optional[str] = Field(
+        title='Proxy host',
+        description='Override the proxy host provided in the credentials. It still uses the proxy_user and port from the credentials.'
+    )
     inspect_folder: str = Field(
         title='Inspect Folder',
         description='''Folder to inspect on the remote host. Folders are scanned using "find inspect_folder -type f -exec du -sk '{}' + | sort -rh | head -n count"'''
@@ -44,17 +48,21 @@ def ssh_find_large_files(
     sshClient,
     host: str,
     inspect_folder: str,
+    proxy_host: str = None,
     threshold: int = 0,
     sudo: bool = False,
     count: int = 10) -> dict:
 
     """ssh_find_large_files scans the file system on a given host
 
-        :type hosts: List[str]
-        :param hosts: Host to connect to. Eg 10.10.10.10.
+        :type host: str
+        :param host: Host to connect to. Eg 10.10.10.10.
 
         :type inspect_folder: str
         :param inspect_folder: Folder to inspect on the remote host.
+
+        :type proxy_host: str
+        :param proxy_host: Proxy Host to connect host via. Eg 10.10.10.10.
 
         :type sudo: bool
         :param sudo: Run the scan with sudo.
@@ -68,7 +76,7 @@ def ssh_find_large_files(
         :rtype:
     """
 
-    client = sshClient([host])
+    client = sshClient([host], proxy_host)
 
     # find size in Kb
     command = "find " + inspect_folder + \

--- a/SSH/legos/ssh_restart_service_using_sysctl/ssh_restart_service_using_sysctl.py
+++ b/SSH/legos/ssh_restart_service_using_sysctl/ssh_restart_service_using_sysctl.py
@@ -12,6 +12,10 @@ class InputSchema(BaseModel):
         title='Hosts',
         description='List of hosts to connect to. For eg. ["host1", "host2"].'
     )
+    proxy_host: Optional[str] = Field(
+        title='Proxy host',
+        description='Override the proxy host provided in the credentials. It still uses the proxy_user and port from the credentials.'
+    )
     service_name: str = Field(
         title='Service Name',
         description='Service name to restart.'
@@ -29,7 +33,7 @@ def ssh_restart_service_using_sysctl_printer(output):
     pprint.pprint(output)
 
 
-def ssh_restart_service_using_sysctl(sshClient, hosts: List[str], service_name: str, sudo: bool = False) -> Dict:
+def ssh_restart_service_using_sysctl(sshClient, hosts: List[str], service_name: str, sudo: bool = False, proxy_host: str = None) -> Dict:
 
     """ssh_restart_service_using_sysctl restart Service Using sysctl
 
@@ -42,9 +46,12 @@ def ssh_restart_service_using_sysctl(sshClient, hosts: List[str], service_name: 
         :type sudo: bool
         :param sudo: Restart service with sudo.
 
-        :rtype: 
+        :type proxy_host: str
+        :param proxy_host: Optional proxy host to use.
+
+        :rtype:
     """
-    client = sshClient(hosts)
+    client = sshClient(hosts, proxy_host)
     runCommandOutput = client.run_command(command="systemctl restart %s" % service_name, sudo=sudo)
     client.join()
     res = {}


### PR DESCRIPTION
## Description
Fix all ssh legos to support proxy_host as optional field too


### Testing
```
(connectors) Amits-MacBook-Pro-2:unskript amit$ pytest -s tests/ssh/test_ssh_scp.py
==================================================================================================== test session starts =====================================================================================================
platform darwin -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /Users/amit/workspace/src/unskript, configfile: setup.cfg
plugins: anyio-3.5.0, Faker-13.15.1
collected 1 item

tests/ssh/test_ssh_scp.py Execution Summary:
   Number of Execution(s): 2
   Iterator values:
        {'remote': '/home/ec2-user/.ssh/authorized_keys', 'local': '/tmp/authorized_keys_10'}		: ✓
        {'remote': '/home/ec2-user/.ssh/id_rsa', 'local': '/tmp/id_rsa_10'}		: ✓
.
```
### Checklist:
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
