### PR TITLE
EN-4286: Jira add comment lego

### DIFF
--- a/Jira/legos/jira_add_comment/README.md
+++ b/Jira/legos/jira_add_comment/README.md
@@ -1,0 +1,31 @@
+[<img align="left" src="https://unskript.com/assets/favicon.png" width="100" height="100" style="padding-right: 5px">](https://unskript.com/assets/favicon.png) 
+<h2>Get Jira Add Comment</h2>
+
+<br>
+
+## Description
+This Lego adds a comment to a Jira Issue.
+
+
+## Lego Details
+
+    jira_add_comment(handle: JIRA, issue_id: str, comment: str, visibility: Dict[str, str] = None)
+
+        handle: Object of type unSkript jira Connector
+        issue_id: Issue ID.
+        comment: Comment to add in Jira Issue.
+        visibility: a dict containing two entries: "type" and "value".
+              "type" is 'role' (or 'group' if the Jira server has configured comment visibility for groups)
+              "value" is the name of the role (or group) to which viewing of this comment will be restricted.
+        is_internal: True marks the comment as 'Internal' in Jira Service Desk (Default: ``False``)
+
+## Lego Input
+This Lego take 4 input handle, issue_id, comment, visibility.
+
+## Lego Output
+Here is a sample output.
+<img src="./1.png">
+
+## See it in Action
+
+You can see this Lego in action following this link [unSkript Live](https://us.app.unskript.io)

--- a/Jira/legos/jira_add_comment/jira_add_comment.json
+++ b/Jira/legos/jira_add_comment/jira_add_comment.json
@@ -1,0 +1,11 @@
+{
+    "action_title": "Jira Add Comment",
+    "action_description": "Add a Jira Comment",
+    "action_type": "LEGO_TYPE_JIRA",
+    "action_entry_function": "jira_add_comment",
+    "action_needs_credential": true,
+    "action_output_type": "ACTION_OUTPUT_TYPE_INT",
+    "action_supports_poll": true,
+    "action_supports_iteration": true
+}
+    

--- a/Jira/legos/jira_add_comment/jira_add_comment.py
+++ b/Jira/legos/jira_add_comment/jira_add_comment.py
@@ -1,0 +1,72 @@
+##
+# Copyright (c) 2021 unSkript, Inc
+# All rights reserved.
+##
+
+from jira.client import JIRA
+from pydantic import BaseModel, Field
+from typing import Dict, Optional
+import pprint
+
+
+class InputSchema(BaseModel):
+    issue_id: str = Field(
+        title='JIRA Issue ID',
+        description='Issue ID. Eg EN-1234'
+    )
+    comment: str = Field(
+        title='Comment',
+        description='Comment to add in Jira Issue'
+    )
+    visibility: Optional[Dict[str, str]] = Field(
+        None,
+        title='Visibility',
+        description='''a dict containing two entries: "type" and "value".
+              "type" is 'role' (or 'group' if the Jira server has configured comment visibility for groups)
+              "value" is the name of the role (or group) to which viewing of this comment will be restricted.'''
+    )
+    is_internal: Optional[bool] = Field(
+        False,
+        title='Internal',
+        description='True marks the comment as \'Internal\' in Jira Service Desk (Default: ``False``)'
+    )
+
+
+def jira_add_comment_printer(output):
+    if output is None:
+        return
+    pprint.pprint(output)
+
+
+def jira_add_comment(hdl: JIRA,
+                     issue_id: str,
+                     comment: str,
+                     visibility: Dict[str, str] = None,
+                     is_internal: bool = False) -> int:
+    """jira_get_issue Get Jira Issue Info
+
+        :type hdl: JIRA
+        :param hdl: Jira handle.
+
+        :type issue_id: str
+        :param issue_id: Issue ID.
+
+        :type comment: str
+        :param comment: Comment to add in Jira Issue.
+
+        :type visibility: Dict[str, str]
+        :param visibility: a dict containing two entries: "type" and "value".
+              "type" is 'role' (or 'group' if the Jira server has configured comment visibility for groups)
+              "value" is the name of the role (or group) to which viewing of this comment will be restricted.
+
+        :type is_internal: bool
+        :param is_internal: True marks the comment as \'Internal\' in Jira Service Desk (Default: ``False``)
+
+        :rtype: Jira comment id (int)
+    """
+    try:
+        issue = hdl.issue(issue_id)
+        comment = hdl.add_comment(issue, comment, visibility=visibility, is_internal=is_internal)
+    except Exception as e:
+        raise e
+    return int(comment.id)


### PR DESCRIPTION
## Description [EN-4286]

## Description

Lego to add Jira comment

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Add Jira comment

```
============================================================ test session starts ============================================================
platform linux -- Python 3.7.13, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/sagar/Unskript/unskript, configfile: setup.cfg
plugins: typeguard-2.13.3, anyio-3.5.0, cov-3.0.0
collected 1 item                                                                                                                            

test_jira_add_comment.py 11702
.
```

Add restricted jira comment

```
============================================================ test session starts ============================================================
platform linux -- Python 3.7.13, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/sagar/Unskript/unskript, configfile: setup.cfg
plugins: typeguard-2.13.3, anyio-3.5.0, cov-3.0.0
collected 2 items                                                                                                                           

test_jira_add_comment.py 11703
.Error while executing: JiraError HTTP 400 url: https://unskript.atlassian.net/rest/api/2/issue/PLAY-2/comment
  text: You are currently not a member of the project role: Administrators.
  
  response headers = {'Date': 'Wed, 22 Mar 2023 17:54:44 GMT', 'Content-Type': 'application/json;charset=UTF-8', 'Server': 'AtlassianEdge', 'Timing-Allow-Origin': '*', 'X-Arequestid': '0b8f2bd3da063452b6dae9a7c456ea14', 'X-Aaccountid': '61ad96f22278e7006b64bbee', 'Cache-Control': 'no-cache, no-store, no-transform', 'X-Content-Type-Options': 'nosniff', 'X-Xss-Protection': '1; mode=block', 'Atl-Traceid': 'af973591eec95b27', 'Report-To': '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group": "endpoint-1", "include_subdomains": true, "max_age": 600}', 'Nel': '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to": "endpoint-1"}', 'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload', 'Transfer-Encoding': 'chunked'}
  response text = {"errorMessages":[],"errors":{"commentLevel":"You are currently not a member of the project role: Administrators."}}
Execution Failed: Error: JiraError HTTP 400 url: https://unskript.atlassian.net/rest/api/2/issue/PLAY-2/comment
  text: You are currently not a member of the project role: Administrators.
  
  response headers = {'Date': 'Wed, 22 Mar 2023 17:54:44 GMT', 'Content-Type': 'application/json;charset=UTF-8', 'Server': 'AtlassianEdge', 'Timing-Allow-Origin': '*', 'X-Arequestid': '0b8f2bd3da063452b6dae9a7c456ea14', 'X-Aaccountid': '61ad96f22278e7006b64bbee', 'Cache-Control': 'no-cache, no-store, no-transform', 'X-Content-Type-Options': 'nosniff', 'X-Xss-Protection': '1; mode=block', 'Atl-Traceid': 'af973591eec95b27', 'Report-To': '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group": "endpoint-1", "include_subdomains": true, "max_age": 600}', 'Nel': '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to": "endpoint-1"}', 'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload', 'Transfer-Encoding': 'chunked'}
  response text = {"errorMessages":[],"errors":{"commentLevel":"You are currently not a member of the project role: Administrators."}}
  Task Parameters: {'issue_id': 'PLAY-2', 'comment': 'Test Comment', 'visibility': {'type': 'role', 'value': 'Administrators'}}

```


<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-4286]: https://unskript.atlassian.net/browse/EN-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ