### PR TITLE
En 4338 support for custom issue type and fix labels field

### DIFF
--- a/Jira/legos/jira_create_issue/jira_create_issue.py
+++ b/Jira/legos/jira_create_issue/jira_create_issue.py
@@ -7,7 +7,6 @@ import pprint
 from typing import Optional
 from jira import JIRA
 from pydantic import BaseModel, Field
-from unskript.enums.jira_enums import IssueType
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -38,7 +37,7 @@ class InputSchema(BaseModel):
         title="Description",
         description="Description of the issue"
     )
-    issue_type: IssueType = Field(
+    issue_type: str = Field(
         title="Issue Type",
         description="JIRA Issue Type."
     )
@@ -61,7 +60,7 @@ class InputSchema(BaseModel):
                 Select list (single choice) field is passed as: {"SelectListSingleTest": ["123"]}
                 URL Field is passed as: {"UrlFieldTest": "http://www.example.com}
                 RadioButton field is passed as: {"RadioButtonTest": "Q1"}
-            For more information about custom fields visit: https://confluence.atlassian.com/adminjiracloud/custom-fields-types-in-company-managed-projects-972327807.html
+            For more information about custom fields visit: https://support.atlassian.com/jira-cloud-administration/docs/custom-fields-types-in-company-managed-projects/
             '''
     )
 
@@ -71,7 +70,7 @@ def jira_create_issue_printer(output):
         return
     pp.pprint(output)
 
-def jira_create_issue(handle: JIRA, project_name: str, summary: str, issue_type: IssueType, description: str = "", fields: dict=None) -> str:
+def jira_create_issue(handle: JIRA, project_name: str, summary: str, issue_type: str, description: str = "", fields: dict=None) -> str:
     """create_issue creates issue in jira.
         :type project_name: str
         :param project_name: The name of the project for which the issue will be generated
@@ -80,7 +79,7 @@ def jira_create_issue(handle: JIRA, project_name: str, summary: str, issue_type:
         :type description: str
         :param description: Description of the issue
         :type issue_type: IssueType
-        :param issue_type: JIRA Issue Type. Possible values: Bug|Task|Story|Epic
+        :param issue_type: JIRA Issue Type.
         :type fields: dict
         :param fields: User needs to pass the fields in the format of dict(KEY=VALUE) pair
         :rtype: String with issues key
@@ -95,11 +94,13 @@ def jira_create_issue(handle: JIRA, project_name: str, summary: str, issue_type:
         }
 
 
-        for f in handle.fields():
-            if 'schema' not in f:
-                continue
-            for key in list(fields.keys()):
+        for key in list(fields.keys()):
+            found = False
+            for f in handle.fields():
+                if 'schema' not in f:
+                    continue
                 if f['name'] == key:
+                    found = True
                     custom_field_type = f['schema'].get("custom", "")
                     if custom_field_type == CustomFieldTypes.MULTICHECKBOXES.value:
                         issue_fields.update({f['id']: [{'value': i} for i in fields[key]]})
@@ -145,7 +146,20 @@ def jira_create_issue(handle: JIRA, project_name: str, summary: str, issue_type:
 
                     else:
                         if f['schema']['type'] == "array":
-                            issue_fields.update({f['id']: [{'name': i} for i in fields[key]]})
+                            #There can be 2 scenarios here.
+                            # For labels, its an array of strings.
+                            # {'id': 'labels', 'key': 'labels', 'name': 'Labels', 'custom': False, 'orderable': True,
+                            # 'navigable': True, 'searchable': True, 'clauseNames': ['labels'],
+                            # 'schema': {'type': 'array', 'items': 'string', 'system': 'labels'}}
+                            #
+                            # For others, its an array of dictionary.
+                            # {'id': 'components', 'key': 'components', 'name': 'Components', 'custom': False,
+                            # 'orderable': True, 'navigable': True, 'searchable': True, 'clauseNames': ['component'],
+                            # 'schema': {'type': 'array', 'items': 'component', 'system': 'components'}}
+                            if f['schema']['items'] == "string":
+                                issue_fields.update({f['id']: fields[key]})
+                            else:
+                                issue_fields.update({f['id']: [{'name': i} for i in fields[key]]})
                         elif f['schema']['type'] == "user":
                             get_user_groups = handle._get_json("groupuserpicker?query={%s}" % fields[key])
                             if get_user_groups["users"]["total"] != 0:
@@ -153,6 +167,10 @@ def jira_create_issue(handle: JIRA, project_name: str, summary: str, issue_type:
                                 issue_fields.update({f['id']: {"id": account_id}})
                         else:
                             issue_fields.update({f['id']: {'name': fields[key]}})
+
+            if found is False:
+                    raise(Exception(f'Invalid field: {key}'))
+
 
         issue = handle.create_issue(fields=issue_fields)
     else:


### PR DESCRIPTION
## Description
[EN-4338]

Please include a summary of the change, motivation and context.
Create issue didnt create the labels. The issue was labels is an array of strings, unlike other fields. So need to special handling for that.
Also, raise an exception if a field is not found on the JIRA side.
Use a different way to get the username to accountId mapping.


### Testing
```
connectors) amits-mbp-2:unskript amit$ pytest -s tests/jira/test_jira_create_issue.py::test_jira_create_issue_invalid_field
=================================================================================================================== test session starts ====================================================================================================================
platform darwin -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /Users/amit/workspace/src/unskript, configfile: setup.cfg
plugins: anyio-3.5.0, Faker-13.15.1
collected 1 item

tests/jira/test_jira_create_issue.py Error while executing: Invalid field: components
Execution Failed: Error: Invalid field: components
  Task Parameters: {'project_name': 'PLAY', 'summary': 'test issue with enum', 'description': 'test issue with enum (Story)', 'issue_type': 'Story', 'fields': {'Labels': ['foo', 'bar'], 'components': ['Dev'], 'Reporter': 'sagar.salvi'}}
.

===================================================================================================================== warnings summary =====================================================================================================================
../../../miniconda3/envs/connectors/lib/python3.7/site-packages/_pytest/config/__init__.py:1233
  /Users/amit/miniconda3/envs/connectors/lib/python3.7/site-packages/_pytest/config/__init__.py:1233: PytestConfigWarning: Unknown config option: collect_ignore

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

../../../miniconda3/envs/connectors/lib/python3.7/site-packages/minio/copy_conditions.py:29
  /Users/amit/miniconda3/envs/connectors/lib/python3.7/site-packages/minio/copy_conditions.py:29: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import MutableMapping

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================================================================== 1 passed, 2 warnings in 5.34s ===============================================================================================================
```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 



[EN-4338]: https://unskript.atlassian.net/browse/EN-4338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ