### PR TITLE
Action: AWS Change TTL for Route53 record

### DIFF
--- a/AWS/legos/aws_update_ttl_for_route53_records/README.md
+++ b/AWS/legos/aws_update_ttl_for_route53_records/README.md
@@ -1,0 +1,26 @@
+[<img align="left" src="https://unskript.com/assets/favicon.png" width="100" height="100" style="padding-right: 5px">]
+(https://unskript.com/assets/favicon.png)
+<h1>AWS Update TTL for Route53 Record</h1>
+
+## Description
+Update TTL for an existing record in a hosted zone.
+
+## Lego Details
+	aws_update_ttl_for_route53_records(handle, hosted_zone_id: str, record_name: str, record_type:str, new_ttl:int )
+
+		handle: Object of type unSkript AWS Connector.
+		hosted_zone_id: ID of the hosted zone in Route53
+		record_name: Name of record in a hosted zone. Eg: example.com
+		record_type: Record Type of the record.
+		new_ttl: New TTL value for a record. Eg: 300
+
+## Lego Input
+This Lego takes inputs handle, hosted_zone_id, record_name, record_type, new_ttl
+
+## Lego Output
+Here is a sample output.
+<img src="./1.png">
+
+## See it in Action
+
+You can see this Lego in action following this link [unSkript Live](https://us.app.unskript.io)

--- a/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.json
+++ b/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.json
@@ -1,0 +1,11 @@
+{
+  "action_title": "AWS Update TTL for Route53 Record",
+  "action_description": "Update TTL for an existing record in a hosted zone.",
+  "action_type": "LEGO_TYPE_AWS",
+  "action_entry_function": "aws_update_ttl_for_route53_records",
+  "action_needs_credential": "true",
+  "action_output_type": "ACTION_OUTPUT_TYPE_DICT",
+  "action_is_check": "false",
+  "action_supports_iteration": "true",
+  "action_supports_poll": "true"
+}

--- a/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.json
+++ b/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.json
@@ -7,5 +7,6 @@
   "action_output_type": "ACTION_OUTPUT_TYPE_DICT",
   "action_is_check": "false",
   "action_supports_iteration": "true",
-  "action_supports_poll": "true"
+  "action_supports_poll": "true",
+  "action_categories": ["CATEGORY_TYPE_COST_OPT", "CATEGORY_TYPE_SRE","CATEGORY_TYPE_AWS","CATEGORY_TYPE_AWS_ROUTE53"]
 }

--- a/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.py
+++ b/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.py
@@ -23,7 +23,7 @@ class InputSchema(BaseModel):
         title='Record Name',
     )
     record_type: Route53RecordType = Field(
-        ..., description='Record Type of the record.', title='record_type'
+        ..., description='Record Type of the record.', title='Record Type'
     )
 
 

--- a/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.py
+++ b/AWS/legos/aws_update_ttl_for_route53_records/aws_update_ttl_for_route53_records.py
@@ -1,0 +1,75 @@
+##
+# Copyright (c) 2021 unSkript, Inc
+# All rights reserved.
+##
+from pydantic import BaseModel, Field
+from unskript.enums.aws_route53_record_type_enums import Route53RecordType
+from typing import Dict
+import pprint
+
+from pydantic import BaseModel, Field
+
+
+class InputSchema(BaseModel):
+    hosted_zone_id: str = Field(
+        ..., description='ID of the hosted zone in Route53', title='Hosted Zone ID'
+    )
+    new_ttl: int = Field(
+        ..., description='New TTL value for a record. Eg: 300', title='New TTL'
+    )
+    record_name: str = Field(
+        ...,
+        description='Name of record in a hosted zone. Eg: example.com',
+        title='Record Name',
+    )
+    record_type: Route53RecordType = Field(
+        ..., description='Record Type of the record.', title='record_type'
+    )
+
+
+def aws_update_ttl_for_route53_records_printer(output):
+    if output is None:
+        return
+    pprint.pprint(output)
+
+def aws_update_ttl_for_route53_records(handle, hosted_zone_id: str, record_name: str, record_type:Route53RecordType, new_ttl:int) -> Dict:
+    """aws_update_ttl_for_route53_records updates the TTL for a Route53 record in a hosted zone.
+
+        :type handle: object
+        :param handle: Object returned by the task.validate(...) method.
+
+        :type hosted_zone_id: string
+        :param hosted_zone_id: ID of the hosted zone in Route53
+
+        :type record_name: string
+        :param record_name: Name of record in a hosted zone. Eg: example.com
+
+        :type record_type: string
+        :param record_type: Record Type of the record.
+
+        :type new_ttl: int
+        :param new_ttl: New TTL value for a record. Eg: 300
+
+        :rtype: Response of updation on new TTL
+    """
+
+    route53Client = handle.client('route53')
+    new_ttl_value = int(new_ttl)
+
+    response = route53Client.change_resource_record_sets(
+        HostedZoneId=hosted_zone_id,
+        ChangeBatch={
+            'Changes': [
+                {
+                    'Action': 'UPSERT',
+                    'ResourceRecordSet': {
+                        'Name': record_name,
+                        'Type': record_type,
+                        'TTL': new_ttl_value
+                    }
+                }
+            ]
+        }
+    )
+    return response
+


### PR DESCRIPTION
## Description
[Issue-416](https://github.com/unskript/Awesome-CloudOps-Automation/issues/416)

### Testing
I don't have permissions to change the TTL:
<img width="918" alt="Screenshot 2023-04-10 at 4 01 53 PM" src="https://user-images.githubusercontent.com/110628398/230885320-400d8d0f-de42-4853-803f-cc9bc8dd6e72.png">


### Checklist:
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
