### PR TITLE
Fix the untagged ec2 logic

### DIFF
--- a/AWS/legos/aws_filter_untagged_ec2_instances/aws_filter_untagged_ec2_instances.py
+++ b/AWS/legos/aws_filter_untagged_ec2_instances/aws_filter_untagged_ec2_instances.py
@@ -25,19 +25,13 @@ def aws_filter_untagged_ec2_instances_printer(output):
 def check_untagged_instance(res, r):
     instance_list = []
     for reservation in res:
-            for instance in reservation['Instances']:
-                instances_dict = {}
-                try:
-                    tagged_instance = instance['Tags']
-                    if len(tagged_instance) == 0:
-                        instances_dict['region']= r
-                        instances_dict['instances']= instance['InstanceId']
-                        instance_list.append(instances_dict)
-                except Exception as e:
-                    if len(tagged_instance) == 0:
-                        instances_dict['region']= r
-                        instances_dict['instances']= instance['InstanceId']
-                        instance_list.append(instances_dict)
+        for instance in reservation['Instances']:
+            instances_dict = {}
+            tags = instance.get('Tags', None)
+            if tags is None:
+                instances_dict['region']= r
+                instances_dict['instanceID']= instance['InstanceId']
+                instance_list.append(instances_dict)
     return instance_list
 
 

--- a/infra/legos/infra_execute_runbook/infra_execute_runbook.py
+++ b/infra/legos/infra_execute_runbook/infra_execute_runbook.py
@@ -47,7 +47,7 @@ def infra_execute_runbook_printer(output):
     if output is not None:
         pprint.pprint(f"Runbook execution status: {output}")
 
-def infra_execute_runbook(handle, runbook_id: str, params: str) -> str:
+def infra_execute_runbook(handle, runbook_id: str, params: str = None) -> str:
     """execute_runbook executes particular runbook annd return execution status
 
         :type runbook_id: str.


### PR DESCRIPTION
Make params default value as None for the execute runbook lego.

## Description
Fix the untagged ec2 lego logic.
Make the params parameter to the execute runbook lego optional.


### Testing
```
(connectors) amits-mbp-2:unskript amit$ pytest -s tests/aws/test_aws_filter_untagged_ec2_instances.py
=================================================================================================================== test session starts ====================================================================================================================
platform darwin -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /Users/amit/workspace/src/unskript, configfile: setup.cfg
plugins: anyio-3.5.0, Faker-13.15.1
collected 1 item

tests/aws/test_aws_filter_untagged_ec2_instances.py (False,
 [{'instanceID': 'i-0b517725565c7fde5', 'region': 'us-west-2'},
  {'instanceID': 'i-0f134d4f5c0eaf6fd', 'region': 'us-west-2'}])
((False, [{'region': 'us-west-2', 'instanceID': 'i-0b517725565c7fde5'}, {'region': 'us-west-2', 'instanceID': 'i-0f134d4f5c0eaf6fd'}]), '')
.

```
### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
