### PR TITLE
Adding Runbook Parameter Support for interactive and non-interactive Runs

### DIFF
--- a/unskript-ctl/unskript-client.py
+++ b/unskript-ctl/unskript-client.py
@@ -933,7 +933,8 @@ def non_interactive_parse_runbook_param(args) -> dict:
                 print_runbook_params(properties=properties, required=required)
                 return {}
         else:
-            raise Exception("Error Occurred parsing Runbook. The Properties value ")
+            print("\033[1m No Runbook Parameters required \033[0m")
+            return retval
         values = []
         keys = []
         for idx,k in enumerate(arg_list):

--- a/unskript-ctl/unskript-client.py
+++ b/unskript-ctl/unskript-client.py
@@ -980,7 +980,6 @@ def interactive_parse_runbook_param(args) -> dict:
         if not mdata.get('parameterSchema'):
             # This means there is no Runbook parameter defined, return empty dictionary
             print("\033[1m No Runbook Parameters required \033[0m")
-            retval['runbook_name'] = _runbook_contents.get('runbook_name')
             return retval
         properties = mdata.get('parameterSchema').get('properties')
         required = mdata.get('parameterSchema').get('required')


### PR DESCRIPTION
## Description
Fixes [EN-4306]
Adding support for `unskript-ctl` to run runbook that has parameters defined in them. 
This PR supports both `interactive` and `non-interactive` Runs. 


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Running with -h Option
```
(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr -h
usage: unskript-ctl [-h] [-lr] [-rr ...] [-rc RUN_CHECKS] [-df DISPLAY_FAILED_CHECKS] [-lc LIST_CHECKS] [-sa SHOW_AUDIT_TRAIL]

Welcome to unSkript CLI Interface VERSION: 0.1.0

optional arguments:
  -h, --help            show this help message and exit
  -lr, --list-runbooks  List Available Runbooks
  -rr ..., --run-runbook ...
                        Run the given runbook RUNBOOK_NAME [-RUNBOOK_PARM1 VALUE1] etc..
  -rc RUN_CHECKS, --run-checks RUN_CHECKS
                        Run all available checks [all | connector | failed]
  -df DISPLAY_FAILED_CHECKS, --display-failed-checks DISPLAY_FAILED_CHECKS
                        Display Failed Checks [all | connector]
  -lc LIST_CHECKS, --list-checks LIST_CHECKS
                        List available checks, [all | connector]
  -sa SHOW_AUDIT_TRAIL, --show-audit-trail SHOW_AUDIT_TRAIL
                        Show audit trail [all | connector | execution_id]
(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr OneParameter -h
 Expected Parameters to run the Runbook 
╒══════════╤══════════╤════════════════════╤═════════════╕
│  Name    │  Type    │  Description       │  Default    │
╞══════════╪══════════╪════════════════════╪═════════════╡
│ region   │ string   │ AWS Default Region │ us-west-2   │
╘══════════╧══════════╧════════════════════╧═════════════╛
(base) root@ca93f4db0bf0:/data/temp# 
```

#### Running with Interactive Mode
```
(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr OneParameter 
Input the Value for  region  (OPTIONAL, Hit enter to skip) :
Executing Runbook -> /home/jovyan/runbooks/test/OneParameter.ipynb


╒═══════════════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                               │ Result   │   Failed Count │ Error   │
╞═══════════════════════════════════════════╪══════════╪════════════════╪═════════╡
│ AWS Get Publicly Accessible RDS Instances │  FAIL    │              2 │ N/A     │
╘═══════════════════════════════════════════╧══════════╧════════════════╧═════════╛

FAILED RESULTS
AWS Get Publicly Accessible RDS Instances
Failed Objects:
[{'instance': 'database-1', 'region': 'us-west-2'},
 {'instance': 'database-2', 'region': 'us-west-2'}]
 

(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr OneParameter 
Input the Value for  region  (OPTIONAL, Hit enter to skip) :us-west-1
Executing Runbook -> /home/jovyan/runbooks/test/OneParameter.ipynb


╒═══════════════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                               │ Result   │   Failed Count │ Error   │
╞═══════════════════════════════════════════╪══════════╪════════════════╪═════════╡
│ AWS Get Publicly Accessible RDS Instances │  PASS    │              0 │ N/A     │
╘═══════════════════════════════════════════╧══════════╧════════════════╧═════════╛

(base) root@ca93f4db0bf0:/data/temp# 
```

#### Running with Non Interactive Mode

```
(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr OneParameter --region us-west-2
Executing Runbook -> /home/jovyan/runbooks/test/OneParameter.ipynb


╒═══════════════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                               │ Result   │   Failed Count │ Error   │
╞═══════════════════════════════════════════╪══════════╪════════════════╪═════════╡
│ AWS Get Publicly Accessible RDS Instances │  FAIL    │              2 │ N/A     │
╘═══════════════════════════════════════════╧══════════╧════════════════╧═════════╛

FAILED RESULTS
AWS Get Publicly Accessible RDS Instances
Failed Objects:
[{'instance': 'database-1', 'region': 'us-west-2'},
 {'instance': 'database-2', 'region': 'us-west-2'}]
 

(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr OneParameter --region us-east-1
Executing Runbook -> /home/jovyan/runbooks/test/OneParameter.ipynb


╒═══════════════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                               │ Result   │   Failed Count │ Error   │
╞═══════════════════════════════════════════╪══════════╪════════════════╪═════════╡
│ AWS Get Publicly Accessible RDS Instances │  PASS    │              0 │ N/A     │
╘═══════════════════════════════════════════╧══════════╧════════════════╧═════════╛

(base) root@ca93f4db0bf0:/data/temp# 
```

#### Running with Invalid Argument other than what the runbook expects
```
(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr OneParameter --nonexistent nonexistentvalue
 Expected Parameters to run the Runbook 
╒══════════╤══════════╤════════════════════╤═════════════╕
│  Name    │  Type    │  Description       │  Default    │
╞══════════╪══════════╪════════════════════╪═════════════╡
│ region   │ string   │ AWS Default Region │ us-west-2   │
╘══════════╧══════════╧════════════════════╧═════════════╛
 Runbook Parameter name does not match: 'nonexistent' Does not match any parameter name. Available Values are ['region'] 
(base) root@ca93f4db0bf0:/data/temp# 
```

#### Running with Insufficient parameters

```
(base) root@ca93f4db0bf0:/data/temp# ./unskript-client.py -rr OneParameter --region
 Expected Parameters to run the Runbook 
╒══════════╤══════════╤════════════════════╤═════════════╕
│  Name    │  Type    │  Description       │  Default    │
╞══════════╪══════════╪════════════════════╪═════════════╡
│ region   │ string   │ AWS Default Region │ us-west-2   │
╘══════════╧══════════╧════════════════════╧═════════════╛
(base) root@ca93f4db0bf0:/data/temp# 
```

#### More tests

<img width="1784" alt="Screenshot 2023-04-15 at 1 07 14 AM" src="https://user-images.githubusercontent.com/87547684/232199293-2a609335-20d3-41fa-9d78-ac004aecc472.png">
<img width="1306" alt="Screenshot 2023-04-15 at 1 07 37 AM" src="https://user-images.githubusercontent.com/87547684/232199297-bb3d06c8-045f-4ef2-a835-22338f5aa9c8.png">

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 



[EN-4306]: https://unskript.atlassian.net/browse/EN-4306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ