### PR TITLE
Param from string to dict

### DIFF
--- a/infra/legos/infra_execute_runbook/infra_execute_runbook.py
+++ b/infra/legos/infra_execute_runbook/infra_execute_runbook.py
@@ -6,6 +6,7 @@ import pprint
 
 from pydantic import BaseModel, Field
 from typing import Optional
+import json
 
 
 class unSkriptCustomType(str):
@@ -38,28 +39,28 @@ class InputSchema(BaseModel):
         title='Runbook ID',
         description='ID of the runbook'
     )
-    params: Optional[str] = Field(
+    params: Optional[dict] = Field(
         title='Runbook parameters',
-        description='Parameters to the runbook as json string.'
+        description='Parameters to the runbook as a dictionary.'
     )
 
 def infra_execute_runbook_printer(output):
     if output is not None:
         pprint.pprint(f"Runbook execution status: {output}")
 
-def infra_execute_runbook(handle, runbook_id: str, params: str = None) -> str:
+def infra_execute_runbook(handle, runbook_id: str, params: dict = None) -> str:
     """execute_runbook executes particular runbook annd return execution status
 
         :type runbook_id: str.
         :param runbook_id: ID of the runbook to execute.
 
-        :type params: str.
-        :param params: JSON string of runbook input parameters.
+        :type params: dict.
+        :param params: dictionary of runbook input parameters.
 
         :rtype: str.
     """
     try:
-        execution_status = handle.execute_runbook(runbook_id, params)
+        execution_status = handle.execute_runbook(runbook_id, json.dumps(params))
         return execution_status
     except Exception as e:
         raise e


### PR DESCRIPTION
## Description
The infra execute runbook lego needs to take dict as input instead of json string of the params.

### Testing
```
(connectors) Amits-MacBook-Pro-2:unskript amit$ pytest -s tests/infra/test_execute_runbook.py
==================================================================================================================== test session starts =====================================================================================================================
platform darwin -- Python 3.7.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /Users/amit/workspace/src/unskript, configfile: setup.cfg
plugins: anyio-3.5.0, Faker-13.15.1
collected 1 item

tests/infra/test_execute_runbook.py None

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /Users/amit/workspace/src/unskript/unskript/legos/infra/infra_execute_runbook/infra_execute_runbook.py(63)infra_execute_runbook()
-> try:
(Pdb) c

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB continue >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
('EXECUTION_STATUS_SUCCEEDED', '')
```
### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

