### PR TITLE
Runbook: Change AWS Route53 TTL

### DIFF
--- a/AWS/Change_AWS_Route53_TTL.ipynb
+++ b/AWS/Change_AWS_Route53_TTL.ipynb
@@ -44,7 +44,8 @@
     "name": "Input Verification",
     "orderProperties": [],
     "tags": [],
-    "title": "Input Verification"
+    "title": "Input Verification",
+    "credentialsJson": {}
    },
    "outputs": [],
    "source": [
@@ -62,7 +63,8 @@
     "    raise SystemExit(\"Provide a Record Type!\")\n",
     "elif hosted_zone_id and record_type and not record_name:\n",
     "    raise SystemExit(\"Provide a Record Name!\")"
-   ]
+   ],
+   "output": {}
   },
   {
    "cell_type": "markdown",
@@ -159,7 +161,8 @@
      "aws_get_ttl_under_given_hours"
     ],
     "uuid": "a885ef62f7614e282856fdc37f0654f67b4ec7e7651350ea0dbb123788e705df",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "credentialsJson": {}
    },
    "outputs": [],
    "source": [
@@ -235,7 +238,8 @@
     "(err, hdl, args) = task.validate(vars=vars())\n",
     "if err is None:\n",
     "    task.execute(aws_get_ttl_under_given_hours, lego_printer=aws_get_ttl_under_given_hours_printer, hdl=hdl, args=args)"
-   ]
+   ],
+   "output": {}
   },
   {
    "cell_type": "markdown",
@@ -275,7 +279,8 @@
     "name": "Create List of Lower TTL records",
     "orderProperties": [],
     "tags": [],
-    "title": "Create List of Lower TTL records"
+    "title": "Create List of Lower TTL records",
+    "credentialsJson": {}
    },
    "outputs": [],
    "source": [
@@ -297,7 +302,8 @@
     "    all_lower_ttl_records.append(data_dict)\n",
     "print(all_lower_ttl_records)\n",
     "task.configure(outputName=\"all_lower_ttl_records\")"
-   ]
+   ],
+   "output": {}
   },
   {
    "cell_type": "markdown",
@@ -467,7 +473,8 @@
      "aws_update_ttl_for_route53_records"
     ],
     "uuid": "a79077024e9d76970c61eb8d40f26129820fbed3cbec6b03e5610dbace0d2224",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "credentialsJson": {}
    },
    "outputs": [],
    "source": [
@@ -557,7 +564,8 @@
     "(err, hdl, args) = task.validate(vars=vars())\n",
     "if err is None:\n",
     "    task.execute(aws_update_ttl_for_route53_records, lego_printer=aws_update_ttl_for_route53_records_printer, hdl=hdl, args=args)"
-   ]
+   ],
+   "output": {}
   },
   {
    "cell_type": "markdown",
@@ -579,7 +587,7 @@
  ],
  "metadata": {
   "execution_data": {
-   "environment_name": "Staging",
+   "environment_name": "",
    "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
    "execution_id": "",
    "inputs_for_searched_lego": "",
@@ -589,10 +597,11 @@
    "runbook_name": "Change AWS Route53 TTL",
    "search_string": "",
    "show_tool_tip": false,
-   "tenant_id": "982dba5f-d9df-48ae-a5bf-ec1fc94d4882",
-   "tenant_url": "https://tenant-staging.alpha.unskript.io",
-   "user_email_id": "shloka@unskript.com",
-   "workflow_id": "2b184767-1b8f-46e4-a191-b2b062148978"
+   "tenant_id": "",
+   "tenant_url": "",
+   "user_email_id": "",
+   "workflow_id": "2b184767-1b8f-46e4-a191-b2b062148978",
+   "environment_id": ""
   },
   "kernelspec": {
    "display_name": "unSkript (Build: 1084)",

--- a/AWS/Change_AWS_Route53_TTL.ipynb
+++ b/AWS/Change_AWS_Route53_TTL.ipynb
@@ -1,0 +1,691 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "82eebdfd-c880-40df-bd6d-5b546c92164b",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false
+    },
+    "name": "Steps Overview",
+    "orderProperties": [],
+    "tags": [],
+    "title": "Steps Overview"
+   },
+   "source": [
+    "<center><img src=\"https://unskript.com/assets/favicon.png\" alt=\"unSkript.com\" width=\"100\" height=\"100\">\n",
+    "<h1 id=\"unSkript-Runbooks&para;\">unSkript Runbooks</h1>\n",
+    "<div class=\"alert alert-block alert-success\">\n",
+    "<h3 id=\"Objective&para;\">Objective</h3>\n",
+    "<br><strong style=\"color: #000000;\"><em>Find Lower TTL(Time To Live) for Route53 records and change it to a higher TTL value</em></strong></div>\n",
+    "</center>\n",
+    "<p>&nbsp;</p>\n",
+    "<center>\n",
+    "<h2 id=\"Change-AWS-Route53-TTL-value\"><strong><u>Change AWS Route53 TTL value</u></strong></h2>\n",
+    "</center>\n",
+    "<h1 id=\"Steps-Overview\">Steps Overview</h1>\n",
+    "<p>1)<a href=\"#1\" target=\"_self\" rel=\"noopener\"> Get TTL under X hours</a><br>2)<a href=\"#2\" target=\"_self\" rel=\"noopener\"> Change the TTL value</a></p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "889af0ca-5f1f-45e2-8f24-d779c8cc0086",
+   "metadata": {
+    "collapsed": true,
+    "customAction": true,
+    "execution_data": {
+     "last_date_success_run_cell": "2023-04-20T13:10:49.826Z"
+    },
+    "jupyter": {
+     "outputs_hidden": true,
+     "source_hidden": true
+    },
+    "name": "Input Verification",
+    "orderProperties": [],
+    "tags": [],
+    "title": "Input Verification"
+   },
+   "outputs": [],
+   "source": [
+    "if hosted_zone_id and not record_name and not record_type:\n",
+    "    raise SystemExit(\"Provide a Record Name and Record Type!\")\n",
+    "elif record_name and not hosted_zone_id and not record_type:\n",
+    "    raise SystemExit(\"Provide a Hosted Zone ID and Record Type!\")\n",
+    "elif record_type and not hosted_zone_id and not record_name:\n",
+    "    raise SystemExit(\"Provide a Hosted Zone ID and Record Name!\")\n",
+    "elif record_type and hosted_zone_id and not record_name:\n",
+    "    raise SystemExit(\"Provide a Record Name!\")\n",
+    "elif record_name and hosted_zone_id and not record_type:\n",
+    "    raise SystemExit(\"Provide a Record Type!\")\n",
+    "elif hosted_zone_id and record_name and not record_type:\n",
+    "    raise SystemExit(\"Provide a Record Type!\")\n",
+    "elif hosted_zone_id and record_type and not record_name:\n",
+    "    raise SystemExit(\"Provide a Record Name!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2020e8d0-ba3b-4c71-84b2-10917465a27e",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false
+    },
+    "name": "Step 1",
+    "orderProperties": [],
+    "tags": [],
+    "title": "Step 1"
+   },
+   "source": [
+    "<h3 id=\"Get-TTLs-under-X-hours\"><a id=\"1\" target=\"_self\" rel=\"nofollow\"></a>Get TTLs under X hours</h3>\n",
+    "<p>Using unSkript's Get Route53 TTL Under Hours , we will find the hosted zones and records that have a TTL under given threshold hours. A lower TTL means more queries arrive at the name servers because the cached values expire sooner.</p>\n",
+    "<blockquote>\n",
+    "<p>This action takes the following parameters: <code>threshold(in hours)</code></p>\n",
+    "</blockquote>\n",
+    "<blockquote>\n",
+    "<p>This action captures the following output: <code>lower_ttl_records</code></p>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8372128f-d195-47f3-b3a7-4482ae7e9764",
+   "metadata": {
+    "actionBashCommand": false,
+    "actionCategories": [
+     "CATEGORY_TYPE_COST_OPT",
+     "CATEGORY_TYPE_SRE",
+     "CATEGORY_TYPE_AWS",
+     "CATEGORY_TYPE_AWS_ROUTE53"
+    ],
+    "actionDescription": "AWS: Check for short Route 53 TTL",
+    "actionEntryFunction": "aws_get_ttl_under_given_hours",
+    "actionIsCheck": true,
+    "actionIsRemediation": false,
+    "actionNeedsCredential": true,
+    "actionNextHop": [],
+    "actionNextHopParameterMapping": {},
+    "actionNouns": null,
+    "actionOutputType": "ACTION_OUTPUT_TYPE_LIST",
+    "actionSupportsIteration": true,
+    "actionSupportsPoll": true,
+    "actionTitle": "AWS: Check for short Route 53 TTL",
+    "actionType": "LEGO_TYPE_AWS",
+    "actionVerbs": null,
+    "actionVersion": "1.0.0",
+    "action_modified": false,
+    "action_uuid": "a885ef62f7614e282856fdc37f0654f67b4ec7e7651350ea0dbb123788e705df",
+    "condition_enabled": true,
+    "continueOnError": false,
+    "description": "AWS: Check for short Route 53 TTL",
+    "id": 2,
+    "index": 2,
+    "inputData": [
+     {
+      "threshold": {
+       "constant": false,
+       "value": "int(threshold_ttl)"
+      }
+     }
+    ],
+    "inputschema": [
+     {
+      "properties": {
+       "threshold": {
+        "default": 1,
+        "description": "(In hours) A threshold in hours to verify route 53 TTL is within the threshold.",
+        "title": "Threshold (In hours)",
+        "type": "integer"
+       }
+      },
+      "required": [],
+      "title": "aws_get_ttl_under_given_hours",
+      "type": "object"
+     }
+    ],
+    "jupyter": {
+     "source_hidden": true
+    },
+    "language": "python",
+    "legotype": "LEGO_TYPE_AWS",
+    "name": "AWS: Check for short Route 53 TTL",
+    "orderProperties": [
+     "threshold"
+    ],
+    "printOutput": true,
+    "startcondition": "not hosted_zone_id and not record_name and not record_type",
+    "tags": [
+     "aws_get_ttl_under_given_hours"
+    ],
+    "uuid": "a885ef62f7614e282856fdc37f0654f67b4ec7e7651350ea0dbb123788e705df",
+    "version": "1.0.0"
+   },
+   "outputs": [],
+   "source": [
+    "##\n",
+    "# Copyright (c) 2021 unSkript, Inc\n",
+    "# All rights reserved.\n",
+    "##\n",
+    "from pydantic import BaseModel, Field\n",
+    "from typing import Tuple, Optional\n",
+    "import pprint\n",
+    "from unskript.connectors.aws import aws_get_paginator\n",
+    "from unskript.legos.aws.aws_get_ttl_for_route53_records.aws_get_ttl_for_route53_records import aws_get_ttl_for_route53_records\n",
+    "\n",
+    "\n",
+    "from beartype import beartype\n",
+    "@beartype\n",
+    "def aws_get_ttl_under_given_hours_printer(output):\n",
+    "    if output is None:\n",
+    "        return\n",
+    "    pprint.pprint(output)\n",
+    "\n",
+    "\n",
+    "@beartype\n",
+    "def aws_get_ttl_under_given_hours(handle, threshold: int = 1) -> Tuple:\n",
+    "    \"\"\"aws_get_ttl_under_x_hours Returns TTL for records in a hosted zone\n",
+    "\n",
+    "        :type handle: object\n",
+    "        :param handle: Object returned by the task.validate(...) method.\n",
+    "\n",
+    "        :type threshold: str\n",
+    "        :param threshold: (In hours) A threshold in hours to verify route 53 TTL is within the threshold.\n",
+    "\n",
+    "        :rtype: List of details with the record type, record name and record TTL.\n",
+    "    \"\"\"\n",
+    "    result = []\n",
+    "    try:\n",
+    "        route_client = handle.client('route53')\n",
+    "        seconds = threshold * 3600\n",
+    "        hosted_zones = aws_get_paginator(route_client, \"list_hosted_zones\", \"HostedZones\")\n",
+    "        for zone in hosted_zones:\n",
+    "            record_ttl_data = aws_get_ttl_for_route53_records(handle, zone['Id'])\n",
+    "            for record_ttl in record_ttl_data:\n",
+    "                if isinstance(record_ttl['record_ttl'], str):\n",
+    "                    continue\n",
+    "                elif record_ttl['record_ttl'] < seconds:\n",
+    "                    records = {}\n",
+    "                    records[\"hosted_zone_id\"] = zone['Id']\n",
+    "                    records[\"record_name\"] = record_ttl['record_name']\n",
+    "                    records[\"record_type\"] = record_ttl['record_type']\n",
+    "                    records[\"record_ttl\"] = record_ttl['record_ttl']\n",
+    "                    result.append(records)\n",
+    "    except Exception as e:\n",
+    "        pass\n",
+    "\n",
+    "    if len(result) != 0:\n",
+    "        return (False, result)\n",
+    "    else:\n",
+    "        return (True, None)\n",
+    "\n",
+    "\n",
+    "\n",
+    "task = Task(Workflow())\n",
+    "task.configure(inputParamsJson='''{\n",
+    "    \"threshold\": \"int(threshold_ttl)\"\n",
+    "    }''')\n",
+    "task.configure(conditionsJson='''{\n",
+    "    \"condition_enabled\": true,\n",
+    "    \"condition_cfg\": \"not hosted_zone_id and not record_name and not record_type\",\n",
+    "    \"condition_result\": true\n",
+    "    }''')\n",
+    "\n",
+    "task.configure(printOutput=True)\n",
+    "(err, hdl, args) = task.validate(vars=vars())\n",
+    "if err is None:\n",
+    "    task.execute(aws_get_ttl_under_given_hours, lego_printer=aws_get_ttl_under_given_hours_printer, hdl=hdl, args=args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a311041f-620a-4b6b-914f-e52c6c3a71f4",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false
+    },
+    "name": "Step 2A",
+    "orderProperties": [],
+    "tags": [],
+    "title": "Step 2A"
+   },
+   "source": [
+    "<h3 id=\"Create-List-of-Unused-Log-Streams&para;\">Create List of Lower TTL records</h3>\n",
+    "<p>This action filters the output from Step 1 to get the non empty values</p>\n",
+    "<blockquote>\n",
+    "<p>This action takes the following parameters: <code>None</code></p>\n",
+    "</blockquote>\n",
+    "<blockquote>\n",
+    "<p>This action captures the following output: <code>all_lower_ttl_records</code></p>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b85ce542-bdf0-44d2-9e75-213002d5c036",
+   "metadata": {
+    "customAction": true,
+    "execution_data": {
+     "last_date_success_run_cell": "2023-04-20T13:11:08.506Z"
+    },
+    "jupyter": {
+     "source_hidden": true
+    },
+    "name": "Create List of Lower TTL records",
+    "orderProperties": [],
+    "tags": [],
+    "title": "Create List of Lower TTL records"
+   },
+   "outputs": [],
+   "source": [
+    "# print(lower_ttl_records)\n",
+    "all_lower_ttl_records = []\n",
+    "dummy = []\n",
+    "try:\n",
+    "    for res in range(len(lower_ttl_records)):\n",
+    "        if lower_ttl_records[0]==False:\n",
+    "            if len(lower_ttl_records[1])!=0:\n",
+    "                dummy = lower_ttl_records[1]\n",
+    "                for x in dummy:\n",
+    "                    all_lower_ttl_records.append(x)\n",
+    "except Exception:\n",
+    "    data_dict = {}\n",
+    "    data_dict[\"hosted_zone_id\"] = hosted_zone_id\n",
+    "    data_dict[\"record_name\"] = record_name\n",
+    "    data_dict[\"record_type\"] = record_type\n",
+    "    all_lower_ttl_records.append(data_dict)\n",
+    "print(all_lower_ttl_records)\n",
+    "task.configure(outputName=\"all_lower_ttl_records\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fb3704a-9b19-49c4-96ab-a982217bbcd3",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false
+    },
+    "name": "Step 2",
+    "orderProperties": [],
+    "tags": [],
+    "title": "Step 2"
+   },
+   "source": [
+    "<h3 id=\"Change-TTL-Value\"><a id=\"2\" target=\"_self\" rel=\"nofollow\"></a>Change TTL Value</h3>\n",
+    "<p>This action changes the TTL value for a record that has a lower value to a higher one. By default<span style=\"color: rgb(45, 194, 107);\"> 86400 </span>seconds is considered if no value is given,</p>\n",
+    "<blockquote>\n",
+    "<p>This action takes the following parameters:&nbsp;<code>hosted_zone_id, record_name, record_type, new_ttl</code></p>\n",
+    "</blockquote>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70e72194-c276-4f44-a9a9-d90b37488a94",
+   "metadata": {
+    "actionBashCommand": false,
+    "actionCategories": [
+     "CATEGORY_TYPE_COST_OPT",
+     "CATEGORY_TYPE_SRE",
+     "CATEGORY_TYPE_AWS",
+     "CATEGORY_TYPE_AWS_ROUTE53"
+    ],
+    "actionDescription": "Update TTL for an existing record in a hosted zone.",
+    "actionEntryFunction": "aws_update_ttl_for_route53_records",
+    "actionIsCheck": false,
+    "actionIsRemediation": false,
+    "actionNeedsCredential": true,
+    "actionNextHop": null,
+    "actionNextHopParameterMapping": null,
+    "actionNouns": null,
+    "actionOutputType": "ACTION_OUTPUT_TYPE_DICT",
+    "actionSupportsIteration": true,
+    "actionSupportsPoll": true,
+    "actionTitle": "AWS Update TTL for Route53 Record",
+    "actionType": "LEGO_TYPE_AWS",
+    "actionVerbs": null,
+    "actionVersion": "1.0.0",
+    "action_modified": false,
+    "action_uuid": "a79077024e9d76970c61eb8d40f26129820fbed3cbec6b03e5610dbace0d2224",
+    "condition_enabled": true,
+    "continueOnError": true,
+    "description": "Update TTL for an existing record in a hosted zone.",
+    "id": 1,
+    "index": 1,
+    "inputData": [
+     {
+      "hosted_zone_id": {
+       "constant": false,
+       "value": "\"iter.get(\\\\\"hosted_zone_id\\\\\")\""
+      },
+      "new_ttl": {
+       "constant": false,
+       "value": "int(new_ttl)"
+      },
+      "record_name": {
+       "constant": false,
+       "value": "\"iter.get(\\\\\"record_name\\\\\")\""
+      },
+      "record_type": {
+       "constant": false,
+       "value": "\"iter.get(\\\\\"record_type\\\\\")\""
+      }
+     }
+    ],
+    "inputschema": [
+     {
+      "definitions": {
+       "Route53RecordType": {
+        "description": "An enumeration.",
+        "enum": [
+         "A",
+         "AAAA",
+         "CAA",
+         "CNAME",
+         "DS",
+         "MX",
+         "NAPTR",
+         "NS",
+         "PTR",
+         "SOA",
+         "SPF",
+         "SRV",
+         "TXT"
+        ],
+        "title": "Route53RecordType",
+        "type": "string"
+       }
+      },
+      "properties": {
+       "hosted_zone_id": {
+        "description": "ID of the hosted zone in Route53",
+        "title": "Hosted Zone ID",
+        "type": "string"
+       },
+       "new_ttl": {
+        "description": "New TTL value for a record. Eg: 300",
+        "title": "New TTL",
+        "type": "integer"
+       },
+       "record_name": {
+        "description": "Name of record in a hosted zone. Eg: example.com",
+        "title": "Record Name",
+        "type": "string"
+       },
+       "record_type": {
+        "allOf": [
+         {
+          "$ref": "#/definitions/Route53RecordType"
+         }
+        ],
+        "description": "Record Type of the record.",
+        "title": "Record Type",
+        "type": "enum"
+       }
+      },
+      "required": [
+       "hosted_zone_id",
+       "new_ttl",
+       "record_name",
+       "record_type"
+      ],
+      "title": "aws_update_ttl_for_route53_records",
+      "type": "object"
+     }
+    ],
+    "iterData": [
+     {
+      "iter_enabled": true,
+      "iter_item": {
+       "hosted_zone_id": "hosted_zone_id",
+       "record_name": "record_name",
+       "record_type": "record_type"
+      },
+      "iter_list": {
+       "constant": false,
+       "objectItems": true,
+       "value": "all_lower_ttl_records"
+      }
+     }
+    ],
+    "jupyter": {
+     "source_hidden": true
+    },
+    "language": "python",
+    "legotype": "LEGO_TYPE_AWS",
+    "name": "AWS Update TTL for Route53 Record",
+    "orderProperties": [
+     "hosted_zone_id",
+     "new_ttl",
+     "record_name",
+     "record_type"
+    ],
+    "printOutput": true,
+    "startcondition": "len(all_lower_ttl_records)!=0",
+    "tags": [
+     "aws_update_ttl_for_route53_records"
+    ],
+    "uuid": "a79077024e9d76970c61eb8d40f26129820fbed3cbec6b03e5610dbace0d2224",
+    "version": "1.0.0"
+   },
+   "outputs": [],
+   "source": [
+    "##\n",
+    "# Copyright (c) 2021 unSkript, Inc\n",
+    "# All rights reserved.\n",
+    "##\n",
+    "from pydantic import BaseModel, Field\n",
+    "from unskript.enums.aws_route53_record_type_enums import Route53RecordType\n",
+    "from typing import Dict\n",
+    "import pprint\n",
+    "\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "\n",
+    "from beartype import beartype\n",
+    "@beartype\n",
+    "def aws_update_ttl_for_route53_records_printer(output):\n",
+    "    if output is None:\n",
+    "        return\n",
+    "    pprint.pprint(output)\n",
+    "\n",
+    "@beartype\n",
+    "def aws_update_ttl_for_route53_records(handle, hosted_zone_id: str, record_name: str, record_type:Route53RecordType, new_ttl:int) -> Dict:\n",
+    "    \"\"\"aws_update_ttl_for_route53_records updates the TTL for a Route53 record in a hosted zone.\n",
+    "\n",
+    "        :type handle: object\n",
+    "        :param handle: Object returned by the task.validate(...) method.\n",
+    "\n",
+    "        :type hosted_zone_id: string\n",
+    "        :param hosted_zone_id: ID of the hosted zone in Route53\n",
+    "\n",
+    "        :type record_name: string\n",
+    "        :param record_name: Name of record in a hosted zone. Eg: example.com\n",
+    "\n",
+    "        :type record_type: string\n",
+    "        :param record_type: Record Type of the record.\n",
+    "\n",
+    "        :type new_ttl: int\n",
+    "        :param new_ttl: New TTL value for a record. Eg: 300\n",
+    "\n",
+    "        :rtype: Response of updation on new TTL\n",
+    "    \"\"\"\n",
+    "\n",
+    "    route53Client = handle.client('route53')\n",
+    "    new_ttl_value = int(new_ttl)\n",
+    "\n",
+    "    response = route53Client.change_resource_record_sets(\n",
+    "        HostedZoneId=hosted_zone_id,\n",
+    "        ChangeBatch={\n",
+    "            'Changes': [\n",
+    "                {\n",
+    "                    'Action': 'UPSERT',\n",
+    "                    'ResourceRecordSet': {\n",
+    "                        'Name': record_name,\n",
+    "                        'Type': record_type,\n",
+    "                        'TTL': new_ttl_value\n",
+    "                    }\n",
+    "                }\n",
+    "            ]\n",
+    "        }\n",
+    "    )\n",
+    "    return response\n",
+    "\n",
+    "\n",
+    "\n",
+    "task = Task(Workflow())\n",
+    "task.configure(continueOnError=True)\n",
+    "task.configure(inputParamsJson='''{\n",
+    "    \"hosted_zone_id\": \"\\\\\"iter.get(\\\\\\\\\\\\\"hosted_zone_id\\\\\\\\\\\\\")\\\\\"\",\n",
+    "    \"new_ttl\": \"int(new_ttl)\",\n",
+    "    \"record_name\": \"\\\\\"iter.get(\\\\\\\\\\\\\"record_name\\\\\\\\\\\\\")\\\\\"\",\n",
+    "    \"record_type\": \"\\\\\"iter.get(\\\\\\\\\\\\\"record_type\\\\\\\\\\\\\")\\\\\"\"\n",
+    "    }''')\n",
+    "task.configure(iterJson='''{\n",
+    "    \"iter_enabled\": true,\n",
+    "    \"iter_list_is_const\": false,\n",
+    "    \"iter_list\": \"all_lower_ttl_records\",\n",
+    "    \"iter_parameter\": [\"hosted_zone_id\",\"record_name\",\"record_type\"]\n",
+    "    }''')\n",
+    "task.configure(conditionsJson='''{\n",
+    "    \"condition_enabled\": true,\n",
+    "    \"condition_cfg\": \"len(all_lower_ttl_records)!=0\",\n",
+    "    \"condition_result\": true\n",
+    "    }''')\n",
+    "\n",
+    "(err, hdl, args) = task.validate(vars=vars())\n",
+    "if err is None:\n",
+    "    task.execute(aws_update_ttl_for_route53_records, lego_printer=aws_update_ttl_for_route53_records_printer, hdl=hdl, args=args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c7430c8-3660-45bd-90ef-9ceab77e3daa",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false
+    },
+    "name": "Conclusion",
+    "orderProperties": [],
+    "tags": [],
+    "title": "Conclusion"
+   },
+   "source": [
+    "<h3 id=\"Conclusion\">Conclusion<a class=\"jp-InternalAnchorLink\" href=\"#Conclusion\" target=\"_self\">&para;</a></h3>\n",
+    "<p>In this Runbook, we were able change the TTL(time to live) to a higher value. As a result, there are fewer queries received by the name servers which will help in saving your AWS costs. To view the full platform capabilities of unSkript please visit&nbsp;<a href=\"https://us.app.unskript.io\" target=\"_blank\" rel=\"noopener\">us.app.unskript.io</a></p>"
+   ]
+  }
+ ],
+ "metadata": {
+  "execution_data": {
+   "environment_name": "Staging",
+   "environment_type": "ENVIRONMENT_TYPE_AWS_EC2",
+   "execution_id": "",
+   "inputs_for_searched_lego": "",
+   "notebook_id": "2f40376b-5fc2-4b1a-98c8-68993633e8f4.ipynb",
+   "parameters": null,
+   "proxy_id": "1499f27c-6406-4fbd-bd1b-c6f92800018f",
+   "runbook_name": "Change AWS Route53 TTL",
+   "search_string": "",
+   "show_tool_tip": false,
+   "tenant_id": "982dba5f-d9df-48ae-a5bf-ec1fc94d4882",
+   "tenant_url": "https://tenant-staging.alpha.unskript.io",
+   "user_email_id": "shloka@unskript.com",
+   "workflow_id": "2b184767-1b8f-46e4-a191-b2b062148978"
+  },
+  "kernelspec": {
+   "display_name": "unSkript (Build: 1084)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  },
+  "outputParameterSchema": {
+   "properties": {},
+   "required": [],
+   "title": "Schema",
+   "type": "object"
+  },
+  "parameterSchema": {
+   "properties": {
+    "hosted_zone_id": {
+     "description": "The ID of the hosted zone that contains the resource record sets that you want to change.",
+     "title": "hosted_zone_id",
+     "type": "string"
+    },
+    "new_ttl": {
+     "default": 86400,
+     "description": "New TTL value (in seconds) that needs to be updated for the records. ",
+     "title": "new_ttl",
+     "type": "number"
+    },
+    "record_name": {
+     "description": "Record name for a particular hosted zone.",
+     "title": "record_name",
+     "type": "string"
+    },
+    "record_type": {
+     "description": "Record type of the record name hosted in a particular zone",
+     "enum": [
+      "A",
+      "AAAA",
+      "CAA",
+      "CNAME ",
+      "DS",
+      "MX",
+      "NAPTR",
+      "NS",
+      "PTR",
+      "SOA",
+      "SPF",
+      "SRV"
+     ],
+     "enumNames": [
+      "A",
+      "AAAA",
+      "CAA",
+      "CNAME ",
+      "DS",
+      "MX",
+      "NAPTR",
+      "NS",
+      "PTR",
+      "SOA",
+      "SPF",
+      "SRV"
+     ],
+     "title": "record_type",
+     "type": "string"
+    },
+    "threshold_ttl": {
+     "default": 1,
+     "description": "Threshold(in hours) to check if the TTL is lower than the given value. Eg: 1, checks for all records whose TTL is less than 3600 seconds (1 hour)",
+     "title": "threshold_ttl",
+     "type": "number"
+    }
+   },
+   "required": [],
+   "title": "Schema",
+   "type": "object"
+  },
+  "parameterValues": {},
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/AWS/Change_AWS_Route53_TTL.json
+++ b/AWS/Change_AWS_Route53_TTL.json
@@ -1,0 +1,10 @@
+{
+    "name": "Change AWS Route53 TTL",
+    "description": "For a record in a hosted zone, lower TTL means that more queries arrive at the name servers because the cached values expire sooner. If you configure a higher TTL for your records, then the intermediate resolvers cache the records for longer time. As a result, there are fewer queries received by the name servers. This configuration reduces the charges corresponding to the DNS queries answered. However, higher TTL slows the propagation of record changes because the previous values are cached for longer periods. This Runbook can be used to configure a higher value of a TTL .",
+    "uuid": "a0773e52a3a3a8688e47a9e10eba1c680913d28a9a8c4466113181534bd1f972",
+    "icon": "CONNECTOR_TYPE_AWS",
+    "categories": [ "CATEGORY_TYPE_COST_OPT", "CATEGORY_TYPE_DEVOPS", "CATEGORY_TYPE_SRE" ],
+    "connector_types": [ "CONNECTOR_TYPE_AWS" ],
+    "version": "1.0.0"
+  }
+  

--- a/AWS/legos/aws_get_ttl_for_route53_records/aws_get_ttl_for_route53_records.py
+++ b/AWS/legos/aws_get_ttl_for_route53_records/aws_get_ttl_for_route53_records.py
@@ -35,11 +35,11 @@ def aws_get_ttl_for_route53_records(handle, hosted_zone_id:str) -> List:
     route53Client = handle.client('route53')
     response = aws_get_paginator(route53Client, "list_resource_record_sets", "ResourceRecordSets", HostedZoneId=hosted_zone_id)
     result = []
-    for record_set in response['ResourceRecordSets']:
+    for record in response:
         records = {}
-        record_name = record_set['Name']
-        record_type = record_set['Type']
-        record_ttl = record_set.get('TTL', 'N/A')
+        record_name = record.get('Name')
+        record_type = record.get('Type')
+        record_ttl = record.get('TTL', 'N/A')
         records["record_name"] = record_name
         records["record_type"] = record_type
         records["record_ttl"] = record_ttl

--- a/AWS/legos/aws_get_ttl_under_given_hours/aws_get_ttl_under_given_hours.json
+++ b/AWS/legos/aws_get_ttl_under_given_hours/aws_get_ttl_under_given_hours.json
@@ -8,7 +8,7 @@
   "action_supports_iteration": "true",
   "action_supports_poll": "true",
   "action_is_check": "true",
-  "action_next_hop": [],
+  "action_next_hop": ["a0773e52a3a3a8688e47a9e10eba1c680913d28a9a8c4466113181534bd1f972"],
   "action_next_hop_parameter_mapping": {},
   "action_categories": ["CATEGORY_TYPE_COST_OPT", "CATEGORY_TYPE_SRE","CATEGORY_TYPE_AWS","CATEGORY_TYPE_AWS_ROUTE53"]
 }

--- a/AWS/legos/aws_get_ttl_under_given_hours/aws_get_ttl_under_given_hours.py
+++ b/AWS/legos/aws_get_ttl_under_given_hours/aws_get_ttl_under_given_hours.py
@@ -45,7 +45,12 @@ def aws_get_ttl_under_given_hours(handle, threshold: int = 1) -> Tuple:
                 if isinstance(record_ttl['record_ttl'], str):
                     continue
                 elif record_ttl['record_ttl'] < seconds:
-                    result.append(record_ttl)
+                    records = {}
+                    records["hosted_zone_id"] = zone['Id']
+                    records["record_name"] = record_ttl['record_name']
+                    records["record_type"] = record_ttl['record_type']
+                    records["record_ttl"] = record_ttl['record_ttl']
+                    result.append(records)
     except Exception as e:
         pass
     


### PR DESCRIPTION
## Description
### [Issue-468](https://github.com/unskript/Awesome-CloudOps-Automation/issues/468)

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing

https://user-images.githubusercontent.com/110628398/233407188-cb3c5e0d-04f1-420a-a614-fa8df59c6952.mov


### Checklist:
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
