### PR TITLE
EN-4458: Action Next Hop Parameters with JQ expressions

### DIFF
--- a/AWS/legos/aws_filter_unencrypted_s3_buckets/aws_filter_unencrypted_s3_buckets.json
+++ b/AWS/legos/aws_filter_unencrypted_s3_buckets/aws_filter_unencrypted_s3_buckets.json
@@ -10,6 +10,6 @@
     "action_supports_iteration": true,
     "action_categories":[ "CATEGORY_TYPE_CLOUDOPS","CATEGORY_TYPE_SECOPS", "CATEGORY_TYPE_AWS","CATEGORY_TYPE_AWS_S3" ],
     "action_next_hop":["50d9c6abd7dce3ff9183d4135353e82859bc5a9639455b35bd229331be6048df"],
-    "action_next_hop_parameter_mapping":{}
+    "action_next_hop_parameter_mapping":{"region": ".[].region", "bucket_name":".[].bucket"}
 
 }

--- a/AWS/legos/aws_list_unhealthy_instances_in_target_group/aws_list_unhealthy_instances_in_target_group.json
+++ b/AWS/legos/aws_list_unhealthy_instances_in_target_group/aws_list_unhealthy_instances_in_target_group.json
@@ -12,5 +12,5 @@
     "action_is_check": true,
     "action_categories": [ "CATEGORY_TYPE_CLOUDOPS", "CATEGORY_TYPE_DEVOPS", "CATEGORY_TYPE_SRE", "CATEGORY_TYPE_TROUBLESHOOTING", "CATEGORY_TYPE_AWS", "CATEGORY_TYPE_AWS_ELB"],
     "action_next_hop": ["7a5cf9629c56eb979a01977330c3d2df656e965a78323be4fa49fdc3b527c9d7"],
-    "action_next_hop_parameter_mapping": {}
+    "action_next_hop_parameter_mapping": {"region": ".[].region"}
 }


### PR DESCRIPTION
## Fix [EN-4458]

## Description

Action Next Hop parameter mapping fields filled with JQ expressions for legos: 

- Filter AWS Unencrypted S3 Buckets
- AWS List Unhealthy Instances in a Target Group

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-4458]: https://unskript.atlassian.net/browse/EN-4458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ