### PR TITLE
EN-4458: Action Next Hop Parameters with JQ expressions

### DIFF
--- a/AWS/legos/aws_filter_unencrypted_s3_buckets/aws_filter_unencrypted_s3_buckets.json
+++ b/AWS/legos/aws_filter_unencrypted_s3_buckets/aws_filter_unencrypted_s3_buckets.json
@@ -10,6 +10,6 @@
     "action_supports_iteration": true,
     "action_categories":[ "CATEGORY_TYPE_CLOUDOPS","CATEGORY_TYPE_SECOPS", "CATEGORY_TYPE_AWS","CATEGORY_TYPE_AWS_S3" ],
     "action_next_hop":["50d9c6abd7dce3ff9183d4135353e82859bc5a9639455b35bd229331be6048df"],
-    "action_next_hop_parameter_mapping":{"region": ".[].region", "bucket_name":".[].bucket"}
+    "action_next_hop_parameter_mapping":{"region": ".[0].region", "bucket_name":".[].bucket"}
 
 }


### PR DESCRIPTION
## Fix [EN-4458]

## Description

Changed JQ expression in Filter AWS Unencrypted S3 Buckets to output a single value for region in next hop parameter mapping

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing

Output after JQ expression parsing

```
{
  "respHdr": {
    "tid": "e33d5875-d9a2-4fcb-ade6-93685cda6915",
    "requestTid": "C8xOVdqdyZCCR67by58PX"
  },
  "output": {
    "checkUuid": "b6473655-af19-4adf-83fb-c6dafb421e42",
    "executionId": "c398a2fd-ba59-42d5-a0c1-826e851dda14",
    "environmentName": "HealthCheck",
    "failureReason": "",
    "executionStatus": "EXECUTION_STATUS_SUCCEEDED",
    "checks": {
      "2fa5c0d3a9ed5951fbf2a1390610941af8e145521c244fa07b597d6ca6665a43": {
        "checkStatus": "CHECK_STATUS_FAILED",
        "checkOutput": "[{\"region\": \"us-west-2\", \"bucket\": \"cf-templates-1abionuoj18q2-ap-northeast-1\"}, {\"region\": \"us-west-2\", \"bucket\": \"cf-templates-1abionuoj18q2-us-east-2\"}, {\"region\": \"us-west-2\", \"bucket\": \"data-ai-ml\"}]",
        "trigger": {
          "0b332e58-9546-46d3-b31d-523d8dfdc043": {
            "actionNextHop": [
              "50d9c6abd7dce3ff9183d4135353e82859bc5a9639455b35bd229331be6048df"
            ],
            "actionNextHopParameterMapping": "{\"bucket_name\":[\"cf-templates-1abionuoj18q2-ap-northeast-1\",\"cf-templates-1abionuoj18q2-us-east-2\",\"data-ai-ml\"],\"region\":[\"us-west-2\"]}"
          }
        }
      }
    }
  }
}
```

[EN-4458]: https://unskript.atlassian.net/browse/EN-4458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ