### PR TITLE
Fix urllib3 issue

### DIFF
--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
         with:
-          python-version: '3.9'
+          python-version: '3.8'
           
       - name: Install system dependencies
         run: |

--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -174,8 +174,8 @@ jobs:
         run: |
           pip install shyaml
           sudo apt-get install -y --allow-downgrades unixodbc-dev=2.3.7 unixodbc=2.3.7 odbcinst1debian2=2.3.7 odbcinst=2.3.7
-          /usr/bin/env python -m pip install --upgrade urllib3
-          /usr/bin/env python -m pip install beartype
+          /usr/bin/env python -m pip install --upgrade urllib3==1.26.6 
+          /usr/bin/env python -m pip install --upgrade types-urllib3==1.26.13
           /usr/bin/env python -m pip list | grep url
 
 

--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -189,7 +189,6 @@ jobs:
           /usr/bin/env python -m pip install --upgrade protobuf
           /usr/bin/env python -m pip install --upgrade urllib3==1.26.6 
           /usr/bin/env python -m pip install --upgrade types-urllib3==1.26.13
-          /usr/bin/env python -m pip list | grep url
           /usr/bin/env python -m pip install google-api-python-client==2.77.0
           make awesome-submodule
           cd awesome

--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
         with:
-          python-version: '3.8'
+          python-version: '3.9'
           
       - name: Install system dependencies
         run: |

--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
         with:
+          # Restricting python version to 3.9 
           python-version: '3.9'
           
       - name: Install system dependencies
@@ -185,8 +186,16 @@ jobs:
           cd unskript
           git checkout ${{ inputs.unskript_branch }}
           /usr/bin/env python -m pip install /tmp/elyra/*.tar.gz
+          # We use the --upgrade-strage only-if-needed and --use-deprecated=legacy-resolver to avoid
+          # PIP dependency loop. Since we are asking the git runner to be of ubuntu-latest, it becomes
+          # a moving target for us hence we want to restrict the packages that are needed for unskript
+          # to compile to be fixed. 
           /usr/bin/env python -m pip install -r ./requirements.txt --upgrade --upgrade-strategy only-if-needed --use-deprecated=legacy-resolver
           /usr/bin/env python -m pip install --upgrade protobuf
+          # We need to restrict URLLIB3 to 1.26.6 because Version 2.x.y onwards the DEFAULT_CIPHERS
+          # variable is deprecrated. Unfortunately our boto3 and botocore that is needed for our
+          # unskript package does not work with the latest version of URLLIB3. Hence we need to
+          # restrict it to a fixed version of 1.26.6
           /usr/bin/env python -m pip install --upgrade urllib3==1.26.6 
           /usr/bin/env python -m pip install --upgrade types-urllib3==1.26.13
           /usr/bin/env python -m pip install google-api-python-client==2.77.0

--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -168,14 +168,15 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
         with:
-          python-version: '3.10'
+          python-version: '3.9'
           
       - name: Install system dependencies
         run: |
           pip install shyaml
           sudo apt-get install -y --allow-downgrades unixodbc-dev=2.3.7 unixodbc=2.3.7 odbcinst1debian2=2.3.7 odbcinst=2.3.7
-          python -m pip install --upgrade urllib3
-          python -m pip install beartype
+          /usr/bin/env python -m pip install --upgrade urllib3
+          /usr/bin/env python -m pip install beartype
+          /usr/bin/env python -m pip list | grep url
 
 
       - name: Checkout Code

--- a/.github/workflows/build-and-release-docker.yml
+++ b/.github/workflows/build-and-release-docker.yml
@@ -174,9 +174,6 @@ jobs:
         run: |
           pip install shyaml
           sudo apt-get install -y --allow-downgrades unixodbc-dev=2.3.7 unixodbc=2.3.7 odbcinst1debian2=2.3.7 odbcinst=2.3.7
-          /usr/bin/env python -m pip install --upgrade urllib3==1.26.6 
-          /usr/bin/env python -m pip install --upgrade types-urllib3==1.26.13
-          /usr/bin/env python -m pip list | grep url
 
 
       - name: Checkout Code
@@ -190,8 +187,10 @@ jobs:
           /usr/bin/env python -m pip install /tmp/elyra/*.tar.gz
           /usr/bin/env python -m pip install -r ./requirements.txt --upgrade --upgrade-strategy only-if-needed --use-deprecated=legacy-resolver
           /usr/bin/env python -m pip install --upgrade protobuf
+          /usr/bin/env python -m pip install --upgrade urllib3==1.26.6 
+          /usr/bin/env python -m pip install --upgrade types-urllib3==1.26.13
+          /usr/bin/env python -m pip list | grep url
           /usr/bin/env python -m pip install google-api-python-client==2.77.0
-          /usr/bin/env python -m pip install --upgrade urllib3
           make awesome-submodule
           cd awesome
           git checkout ${{ inputs.awesome_branch }}


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Fixed Python version to 3.8
* Fixed urllib3 version to 1.26.6
* Fixed types-urllib3 version to 1.26.13

The issue by urllib3 version 2.x.y or higher has deprecated support for DEFAULT_CIPHERS. This is being used by boto3 and botocore libraries. The solution proposed over the internet to get over the DEFAULT_CIPHERS issue is to restrict the URLLIB to 1.26.6.  


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Test run from fix-urllib3-issue branch
<img width="1700" alt="Screenshot 2023-05-08 at 11 35 26 AM" src="https://user-images.githubusercontent.com/87547684/236904497-d582fcdc-68fc-4472-8903-1d5ea715ba7c.png">

Workflow URL: https://github.com/unskript/Awesome-CloudOps-Automation/actions/runs/4918223530 

#### Failed Runs before this fix
<img width="1711" alt="Screenshot 2023-05-08 at 11 40 07 AM" src="https://user-images.githubusercontent.com/87547684/236905166-cef9faaa-ddfb-4040-8259-b590b1df0a5c.png">

Failed Workflow URL:  https://github.com/unskript/Awesome-CloudOps-Automation/actions/runs/4897777331/jobs/8756084658

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 
