### PR TITLE
BugFix: The long runningpostgres action was missing a single '  This resolves the error

### DIFF
--- a/Postgresql/legos/postgresql_long_running_queries/postgresql_long_running_queries.py
+++ b/Postgresql/legos/postgresql_long_running_queries/postgresql_long_running_queries.py
@@ -39,7 +39,7 @@ def postgresql_long_running_queries(handle, interval: int = 5) -> Tuple:
     query = "SELECT pid, user, pg_stat_activity.query_start, now() - " \
         "pg_stat_activity.query_start AS query_time, query, state " \
         " FROM pg_stat_activity WHERE state = 'active' AND (now() - " \
-        f"pg_stat_activity.query_start) > interval {interval} seconds';"
+        f"pg_stat_activity.query_start) > interval '{interval} seconds';"
 
     cur = handle.cursor()
     cur.execute(query)


### PR DESCRIPTION
f"pg_stat_activity.query_start) > interval {interval} seconds';"

to 

f"pg_stat_activity.query_start) > interval '{interval} seconds';"


adding the ' in front of {interval} allows this action to riun