### PR TITLE
updated action name in json

### DIFF
--- a/AWS/legos/aws_terminate_ec2_instances/aws_terminate_ec2_instances.json
+++ b/AWS/legos/aws_terminate_ec2_instances/aws_terminate_ec2_instances.json
@@ -1,6 +1,6 @@
 {
-    "action_title": "Terminate AWS Instances",
-    "action_description": "Terminate AWS Instances",
+    "action_title": "Terminate AWS EC2 Instances",
+    "action_description": "This Action will Terminate AWS EC2 Instances",
     "action_type": "LEGO_TYPE_AWS",
     "action_entry_function": "aws_terminate_ec2_instances",
     "action_needs_credential": true,


### PR DESCRIPTION
The action terminate AWS EC2 instances appears in the tool as "Terminate AWS Instances"

I changed the string to "Terminate AWS EC2 Instances" becuase that is clearer indication of what the action does.