### PR TITLE
Raise GCP actions error messages

### DIFF
--- a/GCP/legos/gcp_add_member_to_iam_role/gcp_add_member_to_iam_role.py
+++ b/GCP/legos/gcp_add_member_to_iam_role/gcp_add_member_to_iam_role.py
@@ -81,6 +81,6 @@ def gcp_add_member_to_iam_role(handle, project_id: str, role: str, member_email:
         result = add_member
 
     except Exception as error:
-        result = {"error": error}
+        raise error
 
     return result

--- a/GCP/legos/gcp_add_role_to_service_account/gcp_add_role_to_service_account.py
+++ b/GCP/legos/gcp_add_role_to_service_account/gcp_add_role_to_service_account.py
@@ -75,6 +75,6 @@ def gcp_add_role_to_service_account(handle, project_id: str, role: str, member_e
         result = policy_output
 
     except Exception as error:
-        result = {"error": error}
+        raise error
 
     return result

--- a/GCP/legos/gcp_create_bucket/gcp_create_bucket.py
+++ b/GCP/legos/gcp_create_bucket/gcp_create_bucket.py
@@ -62,5 +62,5 @@ def gcp_create_bucket(handle, bucket_name: str, location: str, project_name: str
         result["location"]= new_bucket.location
         result["storage_class"]= new_bucket.storage_class
     except Exception as e:
-        result["error"]= e
+        raise e
     return result

--- a/GCP/legos/gcp_create_filestore_instance/gcp_create_filestore_instance.py
+++ b/GCP/legos/gcp_create_filestore_instance/gcp_create_filestore_instance.py
@@ -89,5 +89,5 @@ def gcp_create_filestore_instance(handle, instance_id:str, project_name:str, loc
         response = operation.result()
         result_dict = MessageToDict(response._pb)
     except Exception as e:
-        result_dict= {"Error": e}
+        raise e
     return result_dict

--- a/GCP/legos/gcp_create_gke_cluster/gcp_create_gke_cluster.py
+++ b/GCP/legos/gcp_create_gke_cluster/gcp_create_gke_cluster.py
@@ -55,6 +55,6 @@ def gcp_create_gke_cluster(handle, project_id: str, zone: str, cluster_name: str
                                               'initial_node_count':node_count})
         response = MessageToDict(res._pb)
     except Exception as error:
-        response = {"error":error}
+        raise error
 
     return response

--- a/GCP/legos/gcp_create_service_account/gcp_create_service_account.py
+++ b/GCP/legos/gcp_create_service_account/gcp_create_service_account.py
@@ -57,6 +57,6 @@ def gcp_create_service_account(handle, project_id: str, accountId: str, display_
         result = response
 
     except Exception as error:
-        result = {"error": error}
+        raise error
 
     return result

--- a/GCP/legos/gcp_delete_bucket/gcp_delete_bucket.py
+++ b/GCP/legos/gcp_delete_bucket/gcp_delete_bucket.py
@@ -35,5 +35,5 @@ def gcp_delete_bucket(handle, bucket_name: str) -> Dict:
         result["deleted_bucket"]= bucket.name
         bucket.delete()
     except Exception as e:
-        result["error"]= e
+        raise e
     return result

--- a/GCP/legos/gcp_delete_filestore_instance/gcp_delete_filestore_instance.py
+++ b/GCP/legos/gcp_delete_filestore_instance/gcp_delete_filestore_instance.py
@@ -50,5 +50,5 @@ def gcp_delete_filestore_instance(handle, instance_id:str, project_name:str, loc
         operation.result()
         result_dict={"Message":"Filestore Instance deleted"}
     except Exception as e:
-        result_dict= {"Error": e}
+        raise e
     return result_dict

--- a/GCP/legos/gcp_delete_object_from_bucket/gcp_delete_object_from_bucket.py
+++ b/GCP/legos/gcp_delete_object_from_bucket/gcp_delete_object_from_bucket.py
@@ -41,5 +41,5 @@ def gcp_delete_object_from_bucket(handle,blob_name: str, bucket_name: str) -> Di
         blob.delete()
         result["blob_name"]= blob_name
     except Exception as e:
-        result["error"]= e
+        raise e
     return result

--- a/GCP/legos/gcp_delete_service_account/gcp_delete_service_account.py
+++ b/GCP/legos/gcp_delete_service_account/gcp_delete_service_account.py
@@ -39,6 +39,6 @@ def gcp_delete_service_account(handle, sa_id: str) -> Dict:
 
 
     except Exception as error:
-        result = {"error": error}
+        raise error
 
     return result

--- a/GCP/legos/gcp_fetch_objects_from_bucket/gcp_fetch_objects_from_bucket.py
+++ b/GCP/legos/gcp_fetch_objects_from_bucket/gcp_fetch_objects_from_bucket.py
@@ -36,5 +36,5 @@ def gcp_fetch_objects_from_bucket(handle, bucket_name: str) -> List:
         for blob in blobs:
             result.append(blob)
     except Exception as e:
-        result["error"]= e
+        raise e
     return result

--- a/GCP/legos/gcp_get_instances_without_label/gcp_get_instances_without_label.py
+++ b/GCP/legos/gcp_get_instances_without_label/gcp_get_instances_without_label.py
@@ -48,6 +48,6 @@ def gcp_get_instances_without_label(handle, project: str, zone:str) -> List:
             if not result.labels:
                 output.append(instance_name)
     except Exception as error:
-        output.append(error)
+        raise error
 
     return output

--- a/GCP/legos/gcp_list_buckets/gcp_list_buckets.py
+++ b/GCP/legos/gcp_list_buckets/gcp_list_buckets.py
@@ -29,5 +29,5 @@ def gcp_list_buckets(handle) -> List:
         for bucket in buckets:
             result.append(bucket.name)
     except Exception as e:
-        result["error"]= e
+        raise e
     return result

--- a/GCP/legos/gcp_list_compute_instances_by_label/gcp_list_compute_instances_by_label.py
+++ b/GCP/legos/gcp_list_compute_instances_by_label/gcp_list_compute_instances_by_label.py
@@ -69,6 +69,6 @@ def gcp_list_compute_instances_by_label(
                 if value in result.labels.values():
                     output.append(result.name)
     except Exception as error:
-        output.append(error)
+        raise error
 
     return output

--- a/GCP/legos/gcp_list_nodes_in_gke_cluster/gcp_list_nodes_in_gke_cluster.py
+++ b/GCP/legos/gcp_list_nodes_in_gke_cluster/gcp_list_nodes_in_gke_cluster.py
@@ -46,6 +46,6 @@ def gcp_list_nodes_in_gke_cluster(handle, project_id: str, zone: str, cluster_na
         for nodes in response.node_pools:
             node_list.append(nodes.name)
     except Exception as error:
-        node_list.append(error)
+        raise error
 
     return node_list

--- a/GCP/legos/gcp_list_public_buckets/gcp_list_public_buckets.py
+++ b/GCP/legos/gcp_list_public_buckets/gcp_list_public_buckets.py
@@ -33,5 +33,5 @@ def gcp_list_public_buckets(handle) -> List:
                 if binding['members']=={'allUsers'}:
                         result.append(bucket.name)
     except Exception as e:
-        result["error"]= e
+        raise e
     return result

--- a/GCP/legos/gcp_list_service_accounts/gcp_list_service_accounts.py
+++ b/GCP/legos/gcp_list_service_accounts/gcp_list_service_accounts.py
@@ -38,6 +38,6 @@ def gcp_list_service_accounts(handle, project_id: str) -> List:
             result.append(account["name"])
 
     except Exception as error:
-        result.append(error)
+        raise error
 
     return result

--- a/GCP/legos/gcp_remove_member_from_iam_role/gcp_remove_member_from_iam_role.py
+++ b/GCP/legos/gcp_remove_member_from_iam_role/gcp_remove_member_from_iam_role.py
@@ -78,6 +78,6 @@ def gcp_remove_member_from_iam_role(
         result = remove_member
 
     except Exception as error:
-        result = {"error": error}
+        raise error
 
     return result

--- a/GCP/legos/gcp_remove_role_from_service_account/gcp_remove_role_from_service_account.py
+++ b/GCP/legos/gcp_remove_role_from_service_account/gcp_remove_role_from_service_account.py
@@ -65,6 +65,6 @@ def gcp_remove_role_from_service_account(
         policy_output = set_policy.execute()
         result = policy_output
     except Exception as error:
-        result = {"error": error}
+        raise error
 
     return result

--- a/GCP/legos/gcp_resize_gke_cluster/gcp_resize_gke_cluster.py
+++ b/GCP/legos/gcp_resize_gke_cluster/gcp_resize_gke_cluster.py
@@ -75,6 +75,6 @@ def gcp_resize_gke_cluster(
         response = MessageToDict(res._pb)
 
     except Exception as error:
-        response = {"error":error}
+        raise error
 
     return response

--- a/GCP/legos/gcp_restart_compute_instances/gcp_restart_compute_instances.py
+++ b/GCP/legos/gcp_restart_compute_instances/gcp_restart_compute_instances.py
@@ -58,6 +58,6 @@ def gcp_restart_compute_instances(
         output['name'] = result.name
         output['status'] = result.status
     except Exception as error:
-        output["error"] = error
+        raise error
 
     return output

--- a/GCP/legos/gcp_stop_compute_instances/gcp_stop_compute_instances.py
+++ b/GCP/legos/gcp_stop_compute_instances/gcp_stop_compute_instances.py
@@ -53,6 +53,6 @@ def gcp_stop_compute_instances(handle, project_name: str, zone:str, instance_nam
         output['name'] = result.name
         output['status'] = result.status
     except Exception as error:
-        output["error"] = error
+        raise error
 
     return output

--- a/GCP/legos/gcp_upload_file_to_bucket/gcp_upload_file_to_bucket.py
+++ b/GCP/legos/gcp_upload_file_to_bucket/gcp_upload_file_to_bucket.py
@@ -50,5 +50,5 @@ def gcp_upload_file_to_bucket(handle,blob_name: str, bucket_name: str, data: str
         result["blob_name"] = blob_name
         result["bucket_name"] = bucket_name
     except Exception as e:
-        result["error"]= e
+        raise e
     return result


### PR DESCRIPTION
## Description
### [Issue-803](https://github.com/unskript/Awesome-CloudOps-Automation/issues/803)
The execution flow is stopped now, if its an error, with the correct message.

### Testing
<img width="919" alt="image" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/4f086e8d-8e74-4b39-a524-52362dcb05d0">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
