### PR TITLE
Changes to take care of credential caching that is packaged in the sn…

### DIFF
--- a/unskript-ctl/unskript-client.py
+++ b/unskript-ctl/unskript-client.py
@@ -516,7 +516,13 @@ task.configure(credentialsJson=\'\'\'{
         try:
             c = check.get('code')
             idx = c.index("task = Task(Workflow())")
-            c = c[:idx+1] + task_lines.split('\n') + c[idx+1:]
+            if c[idx+1].startswith("task.configure(credentialsJson"):
+                # With credential caching now packged in, we need to
+                # Skip the credential line and let the normal credential
+                # logic work.
+                c = c[:idx+1] + task_lines.split('\n') + c[idx+2:]
+            else:
+                c = c[:idx+1] + task_lines.split('\n') + c[idx+1:]
             check['code'] = []
             for line in c[:]:
                 check['code'].append(str(line + "\n"))


### PR DESCRIPTION
## Description
With Credential Caching, unskript-ctl.sh should take care of not calling task.configure twice, once with credential and the other with cached value. 

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

```
(base) root@02cc4afe08fd:~# unskript-ctl.sh -rc k8s
Executing Runbook -> /unskript/execution/workspace/44fea05a-90e4-4259-88df-295e47746ea1.ipynb


╒═══════════════════════════════════════════════════════╤══════════╤════════════════╤═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╕
│ Checks Name                                           │ Result   │   Failed Count │ Error                                                                                                                                                                                                                                                                                                           │
╞═══════════════════════════════════════════════════════╪══════════╪════════════════╪═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╡
│ Get expiring K8s certificates                         │  ERROR   │              0 │ list index out of range                                                                                                                                                                                                                                                                                         │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get K8S OOMKilled Pods                                │  ERROR   │              0 │ Checks output should be a Tuple                                                                                                                                                                                                                                                                                 │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get K8s offline nodes                                 │  PASS    │              0 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Check K8s worker CPU Utilization                      │  FAIL    │              1 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get frequently restarting K8s pods                    │  ERROR   │              0 │ 'containerStatuses'                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get all K8s Pods in Terminating State                 │  PASS    │              0 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get Kubernetes Error PODs from All Jobs               │  PASS    │              0 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get all K8s Pods in CrashLoopBackOff State            │  FAIL    │              1 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get Kubernetes Unbound PVCs                           │  FAIL    │              2 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Check K8s services endpoint health                    │  ERROR   │              0 │ Checks output should be a Tuple                                                                                                                                                                                                                                                                                 │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get Kubernetes Nodes that have insufficient resources │  PASS    │              0 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get All Evicted PODS From Namespace                   │  PASS    │              0 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get Deployment Status                                 │  FAIL    │              3 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get memory utilization for K8s services               │  ERROR   │              0 │ Checks output should be a Tuple                                                                                                                                                                                                                                                                                 │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get Kubernetes PODs in not Running State              │  FAIL    │              1 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get Kubernetes Failed Deployments                     │  ERROR   │              0 │ @beartyped k8s_get_failed_deployments() return (False, [{'name': 'nginx-server', 'namespace': 'dev'}, {'name': 'prometheus-server', 'namesp...'}]) violates type hint typing.List, as (False, [{'name': 'nginx-server', 'namespace': 'dev'}, {'name': 'prometheus-server', 'namesp...'}]) not instance of list. │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get Kubernetes PODS with high restart                 │  FAIL    │             14 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get K8S Service with no associated endpoints          │  FAIL    │              8 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get all K8s Pods in ImagePullBackOff State            │  PASS    │              0 │ N/A                                                                                                                                                                                                                                                                                                             │
├───────────────────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Get K8s get pending pods                              │  FAIL    │              2 │ N/A                                                                                                                                                                                                                                                                                                             │
╘═══════════════════════════════════════════════════════╧══════════╧════════════════╧═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╛

FAILED RESULTS
Check K8s worker CPU Utilization
Failed Objects:
[{'cpu': 75.0, 'node': 'gke-trace-e2-standard-4-2525f905-1tsa'}]
 
Get all K8s Pods in CrashLoopBackOff State
Failed Objects:
[{'monitoring': ['prometheus-server-bc7cbd8c-bsvvg']}]
 
Get Kubernetes Unbound PVCs
Failed Objects:
[{'name': 'my-pvc', 'namespace': 'dgraph'},
 {'name': 'storage-my-prometheus-alertmanager-0', 'namespace': 'default'}]
 
Get Deployment Status
Failed Objects:
[{'deployment_name': 'nginx-server', 'namespace': 'dev'},
 {'deployment_name': 'remote-tunnel-server', 'namespace': 'staging'},
 {'deployment_name': 'remote-tunnel-server', 'namespace': 'staging'}]
 
Get Kubernetes PODs in not Running State
Failed Objects:
[{'name': 'nginx-server-5c55fd8786-s4cdc', 'namespace': 'dev'}]
 
Get Kubernetes PODS with high restart
Failed Objects:
[{'name': 'slack-app-86c99d5d4c-zj2ch', 'namespace': 'dev'},
 {'name': 'prometheus-server-bc7cbd8c-bsvvg', 'namespace': 'monitoring'},
 {'name': 'audit-5478f68847-2hxb2', 'namespace': 'onprem-tr'},
 {'name': 'calendar-68f89695c6-pdl8v', 'namespace': 'onprem-tr'},
 {'name': 'connectors-7fcb598884-ztzwg', 'namespace': 'onprem-tr'},
 {'name': 'events-7b976cfcb9-cd2t4', 'namespace': 'onprem-tr'},
 {'name': 'lambda-5ccc5776fc-9xltf', 'namespace': 'onprem-tr'},
 {'name': 'notifications-6c58c6c8b4-phz2t', 'namespace': 'onprem-tr'},
 {'name': 'privileges-858fd44b86-sdhq2', 'namespace': 'onprem-tr'},
 {'name': 'skynet-5799585cd8-6jxn9', 'namespace': 'onprem-tr'},
 {'name': 'tenantmgr-566685458d-9t22z', 'namespace': 'onprem-tr'},
 {'name': 'workflows-54cdf7666b-qg8rv', 'namespace': 'onprem-tr'},
 {'name': 'tenantmgr-684db9cf59-h5nw8', 'namespace': 'sbox-jr'},
 {'name': 'tenantmgr-5c57fdc8db-z4kk5', 'namespace': 'sbox-vlad'}]
 
Get K8S Service with no associated endpoints
Failed Objects:
[{'name': 'prometheus-server-ext', 'namespace': 'default'},
 {'name': 'letsencrypt-unskript-challenge', 'namespace': 'onprem-tr-2'},
 {'name': 'unskript-eac22f96-8cbb-11ed-a1eb-0242ac120200-res',
  'namespace': 'onprem-tr-2'},
 {'name': 'awesome-root-awesome-runbooks', 'namespace': 'onprem-tr'},
 {'name': 'unskript-b10e4c39-7ffa-49fe-9b15-a2d4b21433dc-res',
  'namespace': 'sbox-vlad'},
 {'name': 'web', 'namespace': 'sbox-vlad'},
 {'name': 'unskript-f4f48352-4bba-435a-8d20-4b509c4fc983-res',
  'namespace': 'sbox-yura'},
 {'name': 'remote-tunnel-server', 'namespace': 'staging'}]
 
Get K8s get pending pods
Failed Objects:
[['nginx-server-5c55fd8786-s4cdc', 'dev'],
 ['nginx-server-5c55fd8786-xlxvs', 'dev']]
 

~~ Summary ~~
╒═══════════════════════════════════════════════════════╤═══════════════════╤═══════════════════╤════════════════════╕
│  Checks Name                                          │  Passed Checks    │  Failed Checks    │  Errored Checks    │
╞═══════════════════════════════════════════════════════╪═══════════════════╪═══════════════════╪════════════════════╡
│ Get expiring K8s certificates                         │ N/A               │ N/A               │  ERROR             │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get K8S OOMKilled Pods                                │ N/A               │ N/A               │  ERROR             │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get K8s offline nodes                                 │  PASS             │ N/A               │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Check K8s worker CPU Utilization                      │ N/A               │  FAIL             │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get frequently restarting K8s pods                    │ N/A               │ N/A               │  ERROR             │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get all K8s Pods in Terminating State                 │  PASS             │ N/A               │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get Kubernetes Error PODs from All Jobs               │  PASS             │ N/A               │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get all K8s Pods in CrashLoopBackOff State            │ N/A               │  FAIL             │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get Kubernetes Unbound PVCs                           │ N/A               │  FAIL             │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Check K8s services endpoint health                    │ N/A               │ N/A               │  ERROR             │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get Kubernetes Nodes that have insufficient resources │  PASS             │ N/A               │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get All Evicted PODS From Namespace                   │  PASS             │ N/A               │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get Deployment Status                                 │ N/A               │  FAIL             │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get memory utilization for K8s services               │ N/A               │ N/A               │  ERROR             │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get Kubernetes PODs in not Running State              │ N/A               │  FAIL             │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get Kubernetes Failed Deployments                     │ N/A               │ N/A               │  ERROR             │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get Kubernetes PODS with high restart                 │ N/A               │  FAIL             │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get K8S Service with no associated endpoints          │ N/A               │  FAIL             │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get all K8s Pods in ImagePullBackOff State            │  PASS             │ N/A               │ N/A                │
├───────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────┤
│ Get K8s get pending pods                              │ N/A               │  FAIL             │ N/A                │
╘═══════════════════════════════════════════════════════╧═══════════════════╧═══════════════════╧════════════════════╛

╒══════════════════════════════════════════════════════════════════════════╤═══════════════════════════════════════════════════╕
│  Runbook Name                                                            │  Checks Count (Pass/Fail/Error) (Total checks)    │
╞══════════════════════════════════════════════════════════════════════════╪═══════════════════════════════════════════════════╡
│ /unskript/execution/workspace/44fea05a-90e4-4259-88df-295e47746ea1.ipynb │ 6 / 8 / 6 ( 20 )                                  │
╘══════════════════════════════════════════════════════════════════════════╧═══════════════════════════════════════════════════╛
(base) root@02cc4afe08fd:~# 
```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
