### PR TITLE
Fix the get_server_status check

### DIFF
--- a/Mongo/legos/mongodb_get_server_status/mongodb_get_server_status.py
+++ b/Mongo/legos/mongodb_get_server_status/mongodb_get_server_status.py
@@ -28,7 +28,7 @@ def mongodb_get_server_status_printer(output):
         print("No MongoDB server status information available.")
         return
 
-    status, analysis = output
+    status, listAnalysis = output
 
     print("\nMongoDB Server Status:")
     if status:
@@ -36,22 +36,20 @@ def mongodb_get_server_status_printer(output):
     else:
         print("Status: Unhealthy")
 
-    for key, value in analysis.items():
-        if key == 'wiredTiger_cache':
-            print("WiredTiger Cache:")
-            for subkey, subvalue in value.items():
-                print(f"  {subkey}: {subvalue}")
-        elif key == 'replication_info':
-            print("Replication Info:")
-            for subkey, subvalue in value.items():
-                print(f"  {subkey}: {subvalue}")
-        elif key == 'locks':
-            print("Locks:")
-            for subkey, subvalue in value.items():
-                print(f"  {subkey}: {subvalue}")
-        else:
-            print(f"{key}: {value}")
-
+    for analysis in listAnalysis:
+        for key, value in analysis.items():
+            if key == 'wiredTiger_cache':
+                print("WiredTiger Cache:")
+                for subkey, subvalue in value.items():
+                    print(f"  {subkey}: {subvalue}")
+            elif key == 'replication_info':
+                print(f"Replication Hosts:{value}")
+            elif key == 'locks':
+                print("Locks:")
+                for subkey, subvalue in value.items():
+                    print(f"  {subkey}: {subvalue}")
+            else:
+                print(f"{key}: {value}")
 
 
 def mongodb_get_server_status(handle, connection_threshold: int = 100, memory_threshold: int = 2048, cache_usage_threshold: int = 80) -> Tuple:
@@ -73,7 +71,7 @@ def mongodb_get_server_status(handle, connection_threshold: int = 100, memory_th
     """
     server_status_info = {}
     abnormal_metrics = []
-    
+
     try:
         server_status = handle.admin.command("serverStatus")
 
@@ -82,11 +80,8 @@ def mongodb_get_server_status(handle, connection_threshold: int = 100, memory_th
         server_status_info['uptime'] = server_status['uptime']
         server_status_info['connections'] = server_status.get('connections', {}).get('current')
         server_status_info['resident_memory'] = server_status.get('mem', {}).get('resident')
-        server_status_info['operation_counts'] = server_status['opcounters']
         server_status_info['asserts'] = server_status['asserts']
-        server_status_info['wiredTiger_cache'] = server_status.get('wiredTiger', {}).get('cache')
-        server_status_info['replication_info'] = server_status.get('repl')
-        server_status_info['locks'] = server_status.get('locks')
+        server_status_info['replication_info'] = server_status.get('repl').get('hosts')
 
         # Check if connections exceed the threshold
         if server_status_info['connections'] > connection_threshold:
@@ -97,7 +92,7 @@ def mongodb_get_server_status(handle, connection_threshold: int = 100, memory_th
             abnormal_metrics.append(f"Resident memory utilization is above {memory_threshold} MB: {server_status_info['resident_memory']}")
 
         # Check if WiredTiger cache usage exceeds the threshold
-        wired_tiger_cache = server_status_info['wiredTiger_cache']
+        wired_tiger_cache = server_status.get('wiredTiger', {}).get('cache')
         if wired_tiger_cache:
             used_bytes = wired_tiger_cache.get('bytes currently in the cache')
             total_bytes = wired_tiger_cache.get('maximum bytes configured')
@@ -110,7 +105,7 @@ def mongodb_get_server_status(handle, connection_threshold: int = 100, memory_th
         # Append abnormal metrics if any are found
         if abnormal_metrics:
             server_status_info['abnormal_metrics'] = abnormal_metrics
-            return False, server_status_info
+            return False, [server_status_info]
 
         return True, None
 


### PR DESCRIPTION
## Description
Two issues:
- This check is not returning a list
- Mongo status had objects which were not serializable

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

<img width="1280" alt="Screen Shot 2023-08-30 at 11 20 08 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/79171703/5a12a3bc-21c6-4ce3-976c-e4d798eb524b">

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
