### PR TITLE
Bug fixes for K8s checks

### DIFF
--- a/Kubernetes/legos/k8s_check_cronjob_pod_status/k8s_check_cronjob_pod_status.py
+++ b/Kubernetes/legos/k8s_check_cronjob_pod_status/k8s_check_cronjob_pod_status.py
@@ -7,6 +7,7 @@ from kubernetes import client
 from typing import Tuple, Optional
 from pydantic import BaseModel, Field
 from croniter import croniter
+import json
 
 
 class InputSchema(BaseModel):

--- a/Kubernetes/legos/k8s_check_service_pvc_utilization/README.md
+++ b/Kubernetes/legos/k8s_check_service_pvc_utilization/README.md
@@ -6,7 +6,7 @@
 This check fetches the PVC associated with a given service, determines its utilized size, and then compares it to its total capacity. If the used percentage exceeds the provided threshold, it triggers an alert.
 
 ## Lego Details
-	k8s_check_service_pvc_utilization(handle, service_name: str, namespace: str, threshold: int=80)
+	k8s_check_service_pvc_utilizationk8s_check_service_pvc_utilization(handle, service_name: str = "", namespace: str = "", threshold: int = 80)
 		handle: Object of type unSkript K8S Connector.
     	service_name: The name of the service.
     	threshold: Percentage threshold for utilized PVC disk size. E.g., a 80% threshold checks if the utilized space exceeds 80% of the total PVC capacity.

--- a/Kubernetes/legos/k8s_check_service_pvc_utilization/README.md
+++ b/Kubernetes/legos/k8s_check_service_pvc_utilization/README.md
@@ -6,7 +6,7 @@
 This check fetches the PVC associated with a given service, determines its utilized size, and then compares it to its total capacity. If the used percentage exceeds the provided threshold, it triggers an alert.
 
 ## Lego Details
-	k8s_check_service_pvc_utilizationk8s_check_service_pvc_utilization(handle, service_name: str = "", namespace: str = "", threshold: int = 80)
+	k8s_check_service_pvc_utilization(handle, service_name: str = "", namespace: str = "", threshold: int = 80)
 		handle: Object of type unSkript K8S Connector.
     	service_name: The name of the service.
     	threshold: Percentage threshold for utilized PVC disk size. E.g., a 80% threshold checks if the utilized space exceeds 80% of the total PVC capacity.

--- a/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
+++ b/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
@@ -10,8 +10,8 @@ import json
 
 
 class InputSchema(BaseModel):
-    namespace: str = Field(..., description='The namespace in which the service resides.', title='Namespace')
-    service_name: str = Field(
+    namespace: Optional[str] = Field(..., description='The namespace in which the service resides.', title='Namespace')
+    service_name: Optional[str] = Field(
         ...,
         description='The name of the service for which the used PVC size needs to be checked.',
         title='K8s Sservice name',
@@ -27,17 +27,16 @@ def k8s_check_service_pvc_utilization_printer(output):
     status, pvc_info = output
 
     if status:
-        print("Disk size for the service is within the threshold.")
-        return
+        print("Disk sizes for all checked services are within the threshold.")
     else:
-        print("ALERT: PVC disk size is below the threshold:")
+        print("ALERT: One or more PVC disk sizes are below the threshold:")
         print("-" * 40)
         for pvc in pvc_info:
             print(f"PVC: {pvc['pvc_name']} - Utilized: {pvc['used']} of {pvc['capacity']}")
         print("-" * 40)
 
 
-def k8s_check_service_pvc_utilization(handle, service_name: str, namespace: str, threshold: int=80) -> Tuple:
+def k8s_check_service_pvc_utilizationk8s_check_service_pvc_utilization(handle, service_name: str = "", namespace: str = "", threshold: int = 80) -> Tuple:
     """
     k8s_check_service_pvc_utilization checks the utilized disk size of a service's PVC against a given threshold.
 
@@ -60,153 +59,134 @@ def k8s_check_service_pvc_utilization(handle, service_name: str, namespace: str,
 
     :return: Status and dictionary with PVC name and its size information if the PVC's disk size is below the threshold.
     """
-    # Get the labels associated with the service
-    get_service_labels_command = f"kubectl get service {service_name} -n {namespace} -o=jsonpath='{{.spec.selector}}'"
-    response = handle.run_native_cmd(get_service_labels_command)
-    if not response or response.stderr:
-        raise ApiException(f"Error while executing command ({get_service_labels_command}): {response.stderr if response else 'empty response'}")
-
-    labels_dict = json.loads(response.stdout.replace("'", "\""))  # Convert to valid JSON format
-    label_selector = ",".join([f"{k}={v}" for k, v in labels_dict.items()])
-
-    # Identify a running pod that is utilizing the target PVC using the fetched labels
-    get_pod_command = f"kubectl get pods -n {namespace} -l {label_selector} -o=jsonpath='{{.items[0].metadata.name}}'"
-    response = handle.run_native_cmd(get_pod_command)
-    if not response or response.stderr:
-        raise ApiException(f"Error while executing command ({get_pod_command}): {response.stderr if response else 'empty response'}")
-    pod_name = response.stdout.strip()
-    print(f"Identified pod utilizing the PVC: {pod_name}")
-
-    # Get the PVC names mounted in the identified Pod
-    get_pvc_names_command = f"kubectl get pod {pod_name} -n {namespace} -o=jsonpath='{{.spec.volumes[*].persistentVolumeClaim.claimName}}'"
-    response = handle.run_native_cmd(get_pvc_names_command)
-    if not response or response.stderr:
-        raise ApiException(f"Error while executing command ({get_pvc_names_command}): {response.stderr if response else 'empty response'}")
-
-    pvc_names = response.stdout.strip().split()
-    print(f"PVCs associated with pod {pod_name} are: {', '.join(pvc_names)}")
-
-    # Check usage for each PVC
-    alert_pvcs = []
-    for pvc_name in pvc_names:
-        # Fetch the complete JSON configuration of the pod
-        get_pod_config_command = f"kubectl get pod {pod_name} -n {namespace} -o json"
-        response = handle.run_native_cmd(get_pod_config_command)
+    # Fetch namespace based on service name
+    if service_name and not namespace:
+        get_service_namespace_command = f"kubectl get service {service_name} -o=jsonpath='{{.metadata.namespace}}'"
+        response = handle.run_native_cmd(get_service_namespace_command)
         if not response or response.stderr:
-            raise ApiException(f"Error while executing command ({get_pod_config_command}): {response.stderr if response else 'empty response'}")
+            raise ApiException(f"Error fetching namespace for service {service_name}: {response.stderr if response else 'empty response'}")
+        namespace = response.stdout.strip()
+        print(f"Service {service_name} belongs to namespace: {namespace}")
 
-        pod_data = json.loads(response.stdout)
+    # Get current context's namespace if not provided
+    if not namespace:
+        get_ns_command = "kubectl config view --minify --output 'jsonpath={..namespace}'"
+        response = handle.run_native_cmd(get_ns_command)
+        if not response or response.stderr:
+            raise ApiException(f"Error fetching current namespace: {response.stderr if response else 'empty response'}")
+        namespace = response.stdout.strip() or "default"
+        print(f"Operating in the current namespace: {namespace}")
 
-        mount_path = ""
-        # Traverse the volumes to find our PVC and extract its mount path
-        for volume in pod_data["spec"]["volumes"]:
-            if "persistentVolumeClaim" in volume and volume["persistentVolumeClaim"]["claimName"] == pvc_name:
-                for container in pod_data["spec"]["containers"]:
-                    for volume_mount in container["volumeMounts"]:
-                        if volume_mount["name"] == volume["name"]:
-                            mount_path = volume_mount["mountPath"]
-                            break
-                if mount_path:
-                    break
+    # Get all services in the namespace if service_name is not specified
+    services_to_check = [service_name] if service_name else []
+    if not service_name:
+        get_all_services_command = f"kubectl get svc -n {namespace} -o=jsonpath='{{.items[*].metadata.name}}'"
+        response = handle.run_native_cmd(get_all_services_command)
+        if not response or response.stderr:
+            raise ApiException(f"Error fetching services in namespace {namespace}: {response.stderr if response else 'empty response'}")
+        services_to_check = response.stdout.strip().split()
 
-        print(f"Mount path for PVC inside the pod: {mount_path}")
+    utility_pod_created = False
+    alert_pvcs_all_services = []
+    services_without_pvcs = []
 
-        # Create a utility pod to calculate the actual space used on the PVC
-        utility_pod_spec = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {
-                "name": "pvc-utility-pod",
-                "namespace": namespace
-            },
-            "spec": {
-                "containers": [
-                    {
-                        "name": "util-container",
-                        "image": "busybox:latest",
-                        "command": ["/bin/sh", "-c", "sleep 3600"],
-                        "volumeMounts": [
-                            {
-                                "name": "target-pvc",
-                                "mountPath": "/data"
-                            }
-                        ]
-                    }
-                ],
-                "volumes": [
-                    {
-                        "name": "target-pvc",
-                        "persistentVolumeClaim": {
-                            "claimName": pvc_name
+    for svc in services_to_check:
+
+        # Get service's pod based on its labels
+        get_service_labels_command = f"kubectl get service {svc} -n {namespace} -o=jsonpath='{{.spec.selector}}'"
+        response = handle.run_native_cmd(get_service_labels_command)
+        if not response.stdout.strip():
+            # No labels found for a particular service. Skipping... 
+            continue
+        labels_dict = json.loads(response.stdout.replace("'", "\""))
+        label_selector = ",".join([f"{k}={v}" for k, v in labels_dict.items()])
+
+        # Fetch the pod attached to this service
+        get_pod_command = f"kubectl get pods -n {namespace} -l {label_selector} -o=jsonpath='{{.items[0].metadata.name}}'"
+        response = handle.run_native_cmd(get_pod_command)
+        if not response or response.stderr:
+            raise ApiException(f"Error while executing command ({get_pod_command}): {response.stderr if response else 'empty response'}")
+        pod_name = response.stdout.strip()
+
+        # Fetch PVCs attached to the pod
+        get_pvc_names_command = f"kubectl get pod {pod_name} -n {namespace} -o=jsonpath='{{.spec.volumes[*].persistentVolumeClaim.claimName}}'"
+        response = handle.run_native_cmd(get_pvc_names_command)
+        if not response or response.stderr:
+            raise ApiException(f"Error while executing command ({get_pvc_names_command}): {response.stderr if response else 'empty response'}")
+        pvc_names = response.stdout.strip().split()
+
+        # If there are no PVCs for this service, continue to the next one
+        if not pvc_names:
+            services_without_pvcs.append(svc)
+            continue
+        if not utility_pod_created:
+            utility_pod_created = True 
+            print(f"Creating utility pod to check {len(pvc_names)} PVC(s) for service {service_name}")
+
+            utility_pod_spec = {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": "pvc-utility-pod",
+                    "namespace": namespace
+                },
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "util-container",
+                            "image": "busybox:latest",
+                            "command": ["/bin/sh", "-c", "sleep 3600"],
+                            "volumeMounts": [{"name": f"volume-{idx}", "mountPath": f"/data-{idx}"} for idx, _ in enumerate(pvc_names)]
                         }
-                    }
-                ]
+                    ],
+                    "volumes": [{"name": f"volume-{idx}", "persistentVolumeClaim": {"claimName": name}} for idx, name in enumerate(pvc_names)]
+                }
             }
-        }
 
-        # Deploy the utility pod
-        with open("/tmp/utility-pod.yaml", "w") as f:
-            json.dump(utility_pod_spec, f)
+            with open("/tmp/utility-pod.yaml", "w") as f:
+                json.dump(utility_pod_spec, f)
+            apply_command = "kubectl apply -f /tmp/utility-pod.yaml"
+            response = handle.run_native_cmd(apply_command)
+            if not response or response.stderr:
+                raise ApiException(f"Error while applying utility pod spec: {response.stderr if response else 'empty response'}")
+            wait_command = "kubectl wait --for=condition=Ready pod/pvc-utility-pod --timeout=60s -n " + namespace
+            response = handle.run_native_cmd(wait_command)
+            if not response or response.stderr:
+                raise ApiException(f"Utility pod did not become ready: {response.stderr if response else 'empty response'}")
 
-        apply_command = "kubectl apply -f /tmp/utility-pod.yaml"
-        response = handle.run_native_cmd(apply_command)
-        if not response or response.stderr:
-            raise ApiException(f"Error while applying utility pod spec: {response.stderr if response else 'empty response'}")
-
-        # Wait for the utility pod to be running
-        wait_command = "kubectl wait --for=condition=Ready pod/pvc-utility-pod --timeout=60s -n " + namespace
-        response = handle.run_native_cmd(wait_command)
-        if not response or response.stderr:
-            raise ApiException(f"Utility pod did not become ready: {response.stderr if response else 'empty response'}")
-
-        # Execute the `du` command in the utility pod
-        du_command = f"kubectl exec -n {namespace} pvc-utility-pod -- du -sh /data"
-        du_output = handle.run_native_cmd(du_command)
-        if not du_output or du_output.stderr:
-            raise ApiException(f"Error while calculating used space: {du_output.stderr if du_output else 'empty response'}")
-
-        # Parse the output to extract size
-        used_space = du_output.stdout.split()[0]
-        # Convert to GiB
-        if used_space[-1] == "G":
-            used_space_gib = float(used_space[:-1])
-        elif used_space[-1] == "M":
-            used_space_gib = float(used_space[:-1]) / 1024
-        elif used_space[-1] == "K":
-            used_space_gib = float(used_space[:-1]) / (1024 * 1024)
-        else:
-            raise ValueError("Unexpected unit in du output")
-
-        # Delete the utility pod
+            alert_pvcs = []
+            for idx, pvc_name in enumerate(pvc_names):
+                du_command = f"kubectl exec -n {namespace} pvc-utility-pod -- du -sh /data-{idx}"
+                du_output = handle.run_native_cmd(du_command)
+                if not du_output or du_output.stderr:
+                    raise ApiException(f"Error while calculating used space for {pvc_name}: {du_output.stderr if du_output else 'empty response'}")
+                used_space = du_output.stdout.split()[0]
+                if used_space[-1] == "G":
+                    used_space_gib = float(used_space[:-1])
+                elif used_space[-1] == "M":
+                    used_space_gib = float(used_space[:-1]) / 1024
+                elif used_space[-1] == "K":
+                    used_space_gib = float(used_space[:-1]) / (1024 * 1024)
+                else:
+                    raise ValueError("Unexpected unit in du output")
+                get_pvc_capacity_command = f"kubectl get pvc {pvc_name} -n {namespace} -o=jsonpath='{{.status.capacity.storage}}'"
+                response = handle.run_native_cmd(get_pvc_capacity_command)
+                if not response or response.stderr:
+                    raise ApiException(f"Error while executing command ({get_pvc_capacity_command}): {response.stderr if response else 'empty response'}")
+                total_capacity_str = response.stdout.strip()
+                total_capacity_gib = float(re.findall(r"(\d+)", total_capacity_str)[0])
+                used_percentage = (used_space_gib / total_capacity_gib) * 100
+                if used_percentage > threshold:
+                    alert_pvcs.append({"pvc_name": pvc_name, "used": used_space, "capacity": total_capacity_str})
+            alert_pvcs_all_services.extend(alert_pvcs)
+    if utility_pod_created:
+        print("Deleting utility pod...")
         delete_command = "kubectl delete -f /tmp/utility-pod.yaml"
-        response = handle.run_native_cmd(delete_command)
-        if not response or response.stderr:
-            print(f"Warning: Error while deleting utility pod: {response.stderr if response else 'empty response'}")
+        handle.run_native_cmd(delete_command)
+    # Print out services without PVCs
+    if services_without_pvcs:
+        print("Following services do not have any PVCs attached:")
+        for service in services_without_pvcs:
+            print(f"- {service}")
 
-        # Get the total capacity of the PVC
-        get_pvc_capacity_command = f"kubectl get pvc {pvc_name} -n {namespace} -o=jsonpath='{{.status.capacity.storage}}'"
-        response = handle.run_native_cmd(get_pvc_capacity_command)
-        if not response or response.stderr:
-            raise ApiException(f"Error while executing command ({get_pvc_capacity_command}): {response.stderr if response else 'empty response'}")
-        total_capacity_str = response.stdout.strip()
-        # Extract the number from strings like "10Gi"
-        total_capacity_gib = float(re.findall(r"(\d+)", total_capacity_str)[0])
-
-        # Calculate the percentage of used space
-        used_percentage = (used_space_gib / total_capacity_gib) * 100
-        remaining_percentage = 100 - used_percentage
-
-        print(f"Total PVC capacity for {pvc_name}: {total_capacity_gib:.2f}Gi")
-        print(f"Actual used space in PVC {pvc_name}: {used_space_gib:.2f}Gi")
-        print(f"Percentage of used space for {pvc_name}: {used_percentage:.2f}%")
-        print(f"Remaining space percentage for {pvc_name}: {remaining_percentage:.2f}%")
-
-        if remaining_percentage < threshold:
-            alert_pvcs.append({"pvc_name": pvc_name, "namespace": namespace, "used": f"{used_space_gib:.2f}Gi", "capacity": f"{total_capacity_gib:.2f}Gi"})
-
-    if alert_pvcs:
-        return (False, alert_pvcs)
-
-    return (True, None)
-
-
+    return (not bool(alert_pvcs_all_services), alert_pvcs_all_services)

--- a/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
+++ b/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
@@ -36,7 +36,7 @@ def k8s_check_service_pvc_utilization_printer(output):
         print("-" * 40)
 
 
-def k8s_check_service_pvc_utilizationk8s_check_service_pvc_utilization(handle, service_name: str = "", namespace: str = "", threshold: int = 80) -> Tuple:
+def k8s_check_service_pvc_utilization(handle, service_name: str = "", namespace: str = "", threshold: int = 80) -> Tuple:
     """
     k8s_check_service_pvc_utilization checks the utilized disk size of a service's PVC against a given threshold.
 

--- a/Kubernetes/legos/k8s_get_pods_in_crashloopbackoff_state/k8s_get_pods_in_crashloopbackoff_state.py
+++ b/Kubernetes/legos/k8s_get_pods_in_crashloopbackoff_state/k8s_get_pods_in_crashloopbackoff_state.py
@@ -3,11 +3,11 @@
 # All rights reserved.
 #
 
-import pprint
 from typing import Optional, Tuple
 from pydantic import BaseModel, Field
 from kubernetes import client
 from kubernetes.client.rest import ApiException
+from tabulate import tabulate
 
 
 class InputSchema(BaseModel):
@@ -18,10 +18,14 @@ class InputSchema(BaseModel):
 
 
 def k8s_get_pods_in_crashloopbackoff_state_printer(output):
-    if output is None:
-        return
-    pprint.pprint(output)
+    status, data = output
 
+    if status:
+        print("No pods are in CrashLoopBackOff state.")
+    else:
+        headers = ["Pod Name", "Namespace", "Container Name"]
+        table_data = [(entry["pod"], entry["namespace"], entry["container"]) for entry in data]
+        print(tabulate(table_data, headers=headers, tablefmt="grid"))
 
 def k8s_get_pods_in_crashloopbackoff_state(handle, namespace: str = '') -> Tuple:
     """
@@ -41,7 +45,6 @@ def k8s_get_pods_in_crashloopbackoff_state(handle, namespace: str = '') -> Tuple
 
     v1 = client.CoreV1Api(api_client=handle)
 
-    # Check whether a namespace is provided, if not fetch all namespaces
     try:
         if namespace:
             pods = v1.list_namespaced_pod(namespace).items
@@ -53,8 +56,10 @@ def k8s_get_pods_in_crashloopbackoff_state(handle, namespace: str = '') -> Tuple
     for pod in pods:
         pod_name = pod.metadata.name
         namespace = pod.metadata.namespace
-        # Check each pod for CrashLoopBackOff state
-        for container_status in pod.status.container_statuses:
+        container_statuses = pod.status.container_statuses
+        if container_statuses is None:
+            continue
+        for container_status in container_statuses:
             container_name = container_status.name
             if container_status.state and container_status.state.waiting and container_status.state.waiting.reason == "CrashLoopBackOff":
                 result.append({"pod": pod_name, "namespace": namespace, "container": container_name})


### PR DESCRIPTION
## Description
1. k8s_check_service_pvc_utilization check now has `namespace` and `service_name` as optional params. This enables the lego to run for all services. The code is optimized to reuse the utility pod for all services in a namespace.
2. crashloopbackoff check  now checks if `container_status` is not available.
3. Cronjob pod check was using batch/v1beta1 which was incompatible with unskript dev cluster version (it was working for lightbeam). Now we are using kubectl to fetch cronjobs.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing

<img width="925" alt="Screenshot 2023-10-16 at 8 45 49 AM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/77acb88a-422c-4921-ac05-6626efb3f3c2">
<img width="919" alt="Screenshot 2023-10-16 at 8 47 27 AM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/c1f674b2-4d02-4c00-9ca3-73e0e5803234">


<img width="921" alt="Screenshot 2023-10-16 at 8 48 59 AM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/3ee1e858-a327-48df-969d-a01d2044d1ad">



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
