### PR TITLE
EN-5100 EN-5150 : Autogeneration of add_creds.py and unskript_ctl_config.yaml using scheme

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -18,10 +18,10 @@ version: 1.0.0
 global:
    # if enable_runbooks is enabled, jupyterlab is launched so that one can open
    # runbooks in jupyterlab.
-   enable_runbooks: true
+  enable_runbooks: true
    # audit_period in days. Number of days worth of audit data to be kept.
    # Any date older than this number of days, will be deleted.
-   audit_period: 90
+  audit_period: 90
 
 #
 # Checks section
@@ -32,109 +32,9 @@ checks:
   # Arguments common to all checks, like region, namespace, etc.
   arguments:
     global:
-       region: us-west-2
+      region: us-west-2
        #matrix:
        #  namespace: [n1, n2]
-
-# Credential section
-#
-# uncomment the relevant sections below to enable respective credential
-#
-credential:
-  # AWS connector details
-  aws:
-   - name: awscreds
-     enable: false
-     access-key: ""
-     secret-access-key: ""
-
-  # Kubernetes connector details
-  k8s:
-   - name: k8screds
-     enable: false
-     kubeconfig: ""
-
-  # GCP connector details
-  gcp:
-   - name: gcpcreds
-     enable: false
-     credential-json: ""
-
-  # Elasticsearch connector details
-  elasticsearch:
-   - name: escreds
-     enable: false
-     host: ""
-     api-key: ""
-     no-verify-ssl: ""
-
-  # Redis connector details
-  redis:
-   - name: rediscreds
-     enable: false
-     host: ""
-     port: ""
-     username: ""
-     password: ""
-     database: ""
-     use-ssl: ""
-
-  # Postgres connector details
-  postgres:
-   - name: postgrescreds
-     enable: false
-     host: ""
-     port: ""
-     username: ""
-     password: ""
-     database: ""
-
-  # Mongodb connector details
-  mongodb:
-   - name: mongodbcreds
-     enable: false
-     host: ""
-     port: ""
-     username: ""
-     password: ""
-
-  # Kafka connector details
-  kafka:
-   - name: kafkacreds
-     enable: false
-     broker: ""
-     username: ""
-     password: ""
-     zookeeper: ""
-
-  # Rest connector details
-  rest:
-   - name: restcreds
-     enable: false
-     base-url: ""
-     username: ""
-     password: ""
-     headers: ""
-
-  # Vault connector details
-  vault:
-   - name: vaultcreds
-     enable: false
-     url: ""
-     token: ""
-
-  # Keycloak connector details
-  keycloak:
-   - name: keycloakcreds
-     enable: false
-     server-url: ""
-     realm: ""
-     client-id: ""
-     username: ""
-     password: ""
-     client-secret: ""
-     no-verify-certs: ""
-
 #
 # Notification section
 #
@@ -143,8 +43,8 @@ notification:
   # Slack Notification setting
   Slack:
     enable: false
-    web-hook-url: ""
-    channel-name: ""
+    web-hook-url: ''
+    channel-name: ''
     verbose: false #Not yet supported
   Email:
     verbose: true #Not yet supported
@@ -154,90 +54,280 @@ notification:
     #    - SMTP - SMTP server
     #    - SES -  AWS SES
     #    - Sendgrid - Sendgrid
-    provider: ""
+    provider: ''
     SMTP:
-      smtp-host: ""
-      smtp-user: ""
-      smtp-password: ""
-      to-email: ""
-      from-email: ""
+      smtp-host: ''
+      smtp-user: ''
+      smtp-password: ''
+      to-email: ''
+      from-email: ''
     SES:
-      access_key: ""
-      secret_access: ""
-      region: ""
-      to-email: ""
-      from-email: ""
+      access_key: ''
+      secret_access: ''
+      region: ''
+      to-email: ''
+      from-email: ''
     Sendgrid:
-      api_key: ""
-      to-email: ""
-      from-email: ""
-
+      api_key: ''
+      to-email: ''
+      from-email: ''
 #
 # Job section
 #
 # Job detail contains information about what all unskript-ctl can run.
 jobs:
-  - name: "" # Unique name
+- name: ''   # Unique name
     # The results of the job to be notified or not.
-    notify: true
-    #notify_sink: foo
-    enable: false
-    # Specific checks to run
-    # Not supported: multiple checks, only single check support for now.
-    checks: []
-    # Specific suites to run
-    # Not supported
-    suites: []
-    # connector types whose checks need to be run
-    # Possible values:
-    #   - aws
-    #   - k8s
-    #   - gcp
-    #   - postgresql
-    #   - slack
-    #   - mongodb
-    #   - jenkins
-    #   - mysql
-    #   - jira
-    #   - rest
-    #   - elasticsearch
-    #   - kafka
-    #   - grafana
-    #   - ssh
-    #   - prometheus
-    #   - datadog
-    #   - stripe
-    #   - redis
-    #   - zabbix
-    #   - opensearch
-    #   - pingdom
-    #   - github
-    #   - terraform
-    #   - airflow
-    #   - hadoop
-    #   - mssql
-    #   - snowflake
-    #   - splunk
-    #   - salesforce
-    #   - azure
-    #   - nomad
-    #   - netbox
-    #   - opsgenie
-    connector_types: []
-    # Custom scripts to be run.
-    custom_scripts: []
+  notify: true
+  #notify_sink: foo
+  enable: false
+  # Specific checks to run
+  # Not supported: multiple checks, only single check support for now.
+  checks: []
+  # Specific suites to run
+  # Not supported
+  suites: []
+  # connector types whose checks need to be run
+  # Possible values:
+  #   - aws
+  #   - k8s
+  #   - gcp
+  #   - postgresql
+  #   - slack
+  #   - mongodb
+  #   - jenkins
+  #   - mysql
+  #   - jira
+  #   - rest
+  #   - elasticsearch
+  #   - kafka
+  #   - grafana
+  #   - ssh
+  #   - prometheus
+  #   - datadog
+  #   - stripe
+  #   - redis
+  #   - zabbix
+  #   - opensearch
+  #   - pingdom
+  #   - github
+  #   - terraform
+  #   - airflow
+  #   - hadoop
+  #   - mssql
+  #   - snowflake
+  #   - splunk
+  #   - salesforce
+  #   - azure
+  #   - nomad
+  #   - netbox
+  #   - opsgenie
+  connector_types: []
+  # Custom scripts to be run.
+  custom_scripts: []
 
 #
 # Scheduler section
 #
 # You can configure multiple schedules.
 scheduler:
-  - enable: false
+- enable: false
     # Cadence is specified in cron syntax. More information about the syntax can
     # be found in https://crontab.guru
     # minute  hour  day (of month)  month  day (of week)
     #   *      *          *           *        *
     # Example: "*/30 * * * *"   <= This will run every 30 Minutes
-    cadence: "*/60 * * * *"
+  cadence: '*/60 * * * *'
     # Name of the job to add to the schedule
-    job_name: ""
+  job_name: ''
+
+# Credential section
+#
+# uncomment the relevant sections below to enable respective credential
+#
+credential:
+  aws:
+  - name: awscreds
+    enable: false
+    discriminator: auth_type
+    AccessKeySchema:
+      enable: false
+      auth_type: Access Key
+      access_key: ''
+      secret_access_key: ''
+  gcp:
+  - name: gcpcreds
+    enable: false
+    credentials: ''
+  elasticsearch:
+  - name: elasticsearchcreds
+    enable: false
+    host: ''
+    username: ''
+    password: ''
+    api_key: ''
+  grafana:
+  - name: grafanacreds
+    enable: false
+    api_key: ''
+    username: ''
+    password: ''
+    host: ''
+  redis:
+  - name: rediscreds
+    enable: false
+    db: 0
+    host: ''
+    username: ''
+    password: ''
+    port: 6379
+    use_ssl: false
+  jenkins:
+  - name: jenkinscreds
+    enable: false
+    url: ''
+    user_name: ''
+    password: ''
+  github:
+  - name: githubcreds
+    enable: false
+    token: ''
+    hostname: ''
+  netbox:
+  - name: netboxcreds
+    enable: false
+    host: ''
+    token: ''
+    threading: false
+  nomad:
+  - name: nomadcreds
+    enable: false
+    host: ''
+    timeout: 5
+    token: ''
+    verify_certs: false
+    secure: false
+    namespace: ''
+  chatgpt:
+  - name: chatgptcreds
+    enable: false
+    organization: ''
+    api_token: ''
+  opsgenie:
+  - name: opsgeniecreds
+    enable: false
+    api_token: ''
+  jira:
+  - name: jiracreds
+    enable: false
+    url: ''
+    email: ''
+    api_token: ''
+  k8s:
+  - name: k8screds
+    enable: false
+    kubeconfig: ''
+  kafka:
+  - name: kafkacreds
+    enable: false
+    broker: ''
+    sasl_username: ''
+    sasl_password: ''
+  mongodb:
+  - name: mongodbcreds
+    enable: false
+    host: ''
+    port: 27017
+    discriminator: auth_type
+    AtlasSchema:
+      enable: false
+      auth_type: Atlas Administrative API using HTTP Digest Authentication
+      atlas_public_key: ''
+      atlas_private_key: ''
+    AuthSchema:
+      enable: false
+      auth_type: Basic Auth
+      user_name: ''
+      password: ''
+  mysql:
+  - name: mysqlcreds
+    enable: false
+    DBName: ''
+    User: ''
+    Password: ''
+    Host: ''
+    Port: 5432
+  postgresql:
+  - name: postgresqlcreds
+    enable: false
+    DBName: ''
+    User: ''
+    Password: ''
+    Host: ''
+    Port: 5432
+  rest:
+  - name: restcreds
+    enable: false
+    base_url: ''
+    username: ''
+    password: ''
+    headers: {}
+  slack:
+  - name: slackcreds
+    enable: false
+    bot_user_oauth_token: ''
+  ssh:
+  - name: sshcreds
+    enable: false
+    port: 22
+    username: ''
+    proxy_host: ''
+    proxy_user: ''
+    proxy_port: 22
+    discriminator: auth_type
+    AuthSchema:
+      enable: false
+      auth_type: Basic Auth
+      password: ''
+      proxy_password: ''
+    PrivateKeySchema:
+      enable: false
+      auth_type: API Token
+      private_key: ''
+      proxy_private_key: ''
+    VaultSchema:
+      enable: false
+      auth_type: Vault
+      vault_url: ''
+      vault_secret_path: ''
+      vault_role: ''
+    KerberosSchema:
+      enable: false
+      auth_type: Kerberos
+      user_with_realm: ''
+      kdc_server: ''
+      admin_server: ''
+      password: ''
+      proxy_password: ''
+  salesforce:
+  - name: salesforcecreds
+    enable: false
+    Username: ''
+    Password: ''
+    Security_Token: ''
+  vault:
+  - name: vaultcreds
+    enable: false
+    url: ''
+    token: ''
+    verify_ssl: false
+  keycloak:
+  - name: keycloakcreds
+    enable: false
+    server_url: ''
+    realm: ''
+    client_id: ''
+    username: ''
+    password: ''
+    client_secret: ''
+    verify: true

--- a/unskript-ctl/generate_credentials.py
+++ b/unskript-ctl/generate_credentials.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2023 unSkript.com
+# All rights reserved.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+#
+import add_creds
+import json
+import ruamel.yaml
+import sys
+
+UNSKRIPT_CTL_CONFIG_FILE="config/unskript_ctl_config.yaml"
+
+# Add credentials details to the config file based on the credential schemas
+def generate_credentials(config_file):
+    try:
+        schema_json = json.loads(add_creds.credential_schemas)
+    except Exception as e:
+        print(f"Exception occured {e}")
+        return
+    yaml = ruamel.yaml.YAML()
+    with open(config_file) as fp:
+        unskript_ctl_config_yaml_data = yaml.load(fp)
+        credentials_details = {}
+        for schema in schema_json:
+            credential_name = schema.get('title').replace('Schema', '').lower()
+            properties = schema.get('properties', {})
+            params_info = {"name": credential_name+"creds", "enable": False}
+            discriminator = ""
+            for prop, prop_info in properties.items():
+                if prop_info.get('discriminator') is not None:
+                    discriminator = prop_info.get('discriminator')
+                    params_info['discriminator'] = discriminator
+                    continue
+                prop_value = None
+                if prop_info.get('default') is not None:
+                    prop_value = prop_info.get('default')
+                else:
+                    prop_value = get_default_value_for_param(prop_info.get('type'))
+                params_info[prop] = prop_value
+            if schema.get('definitions') is not None:
+                    definitions = schema.get('definitions')
+                    for schema_name, schema_definition in definitions.items():
+                        schema_properties = schema_definition.get('properties', {})
+                        schema_params_info = {"enable": False}
+                        for schema_prop, schema_prop_info in schema_properties.items():
+                            if schema_prop == discriminator and len(schema_prop_info.get('enum')) == 1:
+                                schema_params_info[discriminator] = schema_prop_info.get('enum')[0]
+                                continue
+                            schema_prop_value = None
+                            if schema_prop_info.get('default') is not None:
+                                schema_prop_value = schema_prop_info.get('default')
+                            else:
+                                schema_prop_value = get_default_value_for_param(schema_prop_info.get('type'))
+                            schema_params_info[schema_prop] = schema_prop_value
+                        params_info[schema_name] = schema_params_info
+            credentials_details[credential_name] = [params_info]
+        unskript_ctl_config_yaml_data['credential'] = credentials_details
+        # Redirect stdout to a file. Dumping yaml to stdout ensures formatting and comments are retained
+        with open(config_file, 'w') as output_file:
+            sys.stdout = output_file
+            yaml.dump(unskript_ctl_config_yaml_data, sys.stdout)
+    # Reset stdout to the original sys.stdout
+    sys.stdout = sys.__stdout__
+
+def get_default_value_for_param(parameter_type) -> any:
+    default_value = ""
+    if parameter_type == "number":
+        default_value = 0
+    if parameter_type == "boolean":
+        default_value = False
+    if parameter_type == "array":
+        default_value = []
+    if parameter_type == "object":
+        default_value = {}
+    return default_value
+
+if __name__ == "__main__":
+    generate_credentials(UNSKRIPT_CTL_CONFIG_FILE)

--- a/unskript-ctl/stub_creds.json
+++ b/unskript-ctl/stub_creds.json
@@ -23,12 +23,12 @@
     "id": "7ab97aa6-3016-4818-afde-1a9eb3cb32cb"
   },
   {
-    "display_name": "escreds",
+    "display_name": "elasticsearchscreds",
     "metadata": {
       "id": "025e0bcd-1ddf-426c-bf24-864dfe3adf9a",
       "connectorData": "{}",
       "type": "CONNECTOR_TYPE_ELASTICSEARCH",
-      "name": "escreds"
+      "name": "elasticsearchscreds"
     },
     "schema_name": "credential-save",
     "type": "CONNECTOR_TYPE_ELASTICSEARCH",
@@ -159,9 +159,9 @@
     "id": "907fcd0c-df0e-44b6-bc98-e97fe898cfcf"
   },
   {
-    "display_name": "postgrescreds",
+    "display_name": "postgresqlcreds",
     "metadata": {
-      "name": "postgrescreds",
+      "name": "postgresqlcreds",
       "connectorData": "{}",
       "type": "CONNECTOR_TYPE_POSTGRESQL"
     },


### PR DESCRIPTION
Fixes [EN-5100] [EN-5150](https://unskript.atlassian.net/browse/EN-5150)

## Brief description of fix.

1. add_creds need to support all connectors. Generate argparse arugments for connectors as they are added based on connector schema. 
2. autocreated from the connector schema for unskript_ctl_config.yaml

## Add Unit test results.

```
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c aws
usage: add_creds.py [-h] --auth_type {Access Key} {AccessKeySchema} ...
add_creds.py: error: the following arguments are required: --auth_type
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c aws --auth_type Access\ Key AccessKeySchema -h
usage: add_creds.py AccessKeySchema [-h] --access_key ACCESS_KEY --secret_access_key SECRET_ACCESS_KEY

optional arguments:
  -h, --help            show this help message and exit
  --access_key ACCESS_KEY
                        Access Key to use for authentication.
  --secret_access_key SECRET_ACCESS_KEY
                        Secret Access Key to use for authentication.
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c aws --auth_type Access\ Key AccessKeySchema --access_key dshfdsfhkdsfhjdsf --secret_access_key dsfdsfjldsfdshfdsfdsf
(base) root@90dc84569a29:/usr/local/bin# cd ~/.local/share/jupyter/metadata/credential-save/
(base) root@90dc84569a29:~/.local/share/jupyter/metadata/credential-save# cat awscreds.json
{
  "display_name": "awscreds",
  "metadata": {
    "proxy_id": "",
    "tenant_id": "",
    "tenant_url": "",
    "id": "ebca9178-aadc-478d-bc87-7c895874d3ab",
    "connectorData": "{\"authentication\": {\"auth_type\": \"Access Key\", \"access_key\": \"dshfdsfhkdsfhjdsf\", \"secret_access_key\": \"dsfdsfjldsfdshfdsfdsf\"}}",
    "type": "CONNECTOR_TYPE_AWS",
    "name": "awscreds"
  },
  "schema_name": "credential-save",
  "type": "CONNECTOR_TYPE_AWS",
  "id": "38467de3-895d-49a5-8abb-1a65144d6fc6"
```


```
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c jira
usage: add_creds.py [-h] --url URL --email EMAIL --api_token API_TOKEN
add_creds.py: error: the following arguments are required: --url, --email, --api_token
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c jira --url http://testing.com --email testing@gmail.com --api_token test-token
(base) root@90dc84569a29:/usr/local/bin# cd ~/.local/share/jupyter/metadata/credential-save/
(base) root@90dc84569a29:~/.local/share/jupyter/metadata/credential-save# cat jiracreds.json
{
  "display_name": "jiracreds",
  "metadata": {
    "proxy_id": "",
    "tenant_id": "",
    "tenant_url": "",
    "id": "486460a4-72b9-4759-8f8f-5a3ccb0096f9",
    "connectorData": "{\"url\": \"http://testing.com\", \"email\": \"testing@gmail.com\", \"api_token\": \"test-token\"}",
    "type": "CONNECTOR_TYPE_JIRA",
    "name": "jiracreds"
  },
  "schema_name": "credential-save",
  "type": "CONNECTOR_TYPE_JIRA",
  "id": "05ad517c-2a7f-4027-8459-1bacb415138d"
```

```
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c rest
usage: add_creds.py [-h] --base_url BASE_URL [--username USERNAME] [--password PASSWORD] [--headers HEADERS]
add_creds.py: error: the following arguments are required: --base_url
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c rest --base_url testurl --headers '{"key":"value"}'
(base) root@90dc84569a29:/usr/local/bin# cd ~/.local/share/jupyter/metadata/credential-save/
(base) root@90dc84569a29:~/.local/share/jupyter/metadata/credential-save# cat restcreds.json
{
  "display_name": "restcreds",
  "metadata": {
    "environment_id": "",
    "tenant_id": "",
    "tenant_url": "",
    "name": "restcreds",
    "connectorData": "{\"base_url\": \"testurl\", \"username\": \"\", \"password\": \"\", \"headers\": {\"key\": \"value\"}}",
    "type": "CONNECTOR_TYPE_REST"
  },
  "schema_name": "credential-save",
  "type": "CONNECTOR_TYPE_REST",
  "id": "75dafeae-b46d-45dc-9614-a58ba94187be"
```

```
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c mongodb
usage: add_creds.py [-h] --host HOST [--port PORT] --auth_type {Atlas Administrative API using HTTP Digest Authentication,Basic Auth} {AtlasSchema,AuthSchema} ...
add_creds.py: error: the following arguments are required: --host, --auth_type
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c mongodb --host test --auth_type Basic\ Auth AuthSchema -h
usage: add_creds.py AuthSchema [-h] [--user_name USER_NAME] [--password PASSWORD]

optional arguments:
  -h, --help            show this help message and exit
  --user_name USER_NAME
                        Username to authenticate with MongoDB.
  --password PASSWORD   Password to authenticate with MongoDB.
(base) root@90dc84569a29:/usr/local/bin# python add_creds.py -c mongodb --host test --auth_type Basic\ Auth AuthSchema --user_name testing --password secret_password
(base) root@90dc84569a29:/usr/local/bin# cd ~/.local/share/jupyter/metadata/credential-save/
(base) root@90dc84569a29:~/.local/share/jupyter/metadata/credential-save# cat mongodbcreds.json
{
  "display_name": "mongodbcreds",
  "metadata": {
    "environment_id": "",
    "tenant_id": "",
    "tenant_url": "",
    "name": "mongodbcreds",
    "connectorData": "{\"host\": \"test\", \"port\": 27017, \"authentication\": {\"auth_type\": \"Basic Auth\", \"user_name\": \"testing\", \"password\": \"secret_password\"}}",
    "type": "CONNECTOR_TYPE_MONGODB"
  },
  "schema_name": "credential-save",
  "type": "CONNECTOR_TYPE_MONGODB",
  "id": "8af91554-f190-48f6-8407-43cf4d3a2eaa"
```


Programming credentials based on contents in YAML file

```
(base) root@14947c2b8763:~# ./start.sh
 * Starting periodic command scheduler cron                                                                                                           [ OK ]
###################################
Processing global section
###################################
Global: audit period 90 days
###################################
Processing credential section
###################################
Credential: Programming type aws, name awscreds
Credential: Successfully programmed aws, name awscreds
Credential: Programming type gcp, name gcpcreds
Credential: Successfully programmed gcp, name gcpcreds
Credential: Skipping type elasticsearch, name elasticsearchcreds
Credential: Programming type grafana, name grafanacreds
Credential: Successfully programmed grafana, name grafanacreds
Credential: Programming type redis, name rediscreds
Credential: Successfully programmed redis, name rediscreds
Credential: Programming type jenkins, name jenkinscreds
Credential: Successfully programmed jenkins, name jenkinscreds
Credential: Programming type github, name githubcreds
Credential: Successfully programmed github, name githubcreds
Credential: Programming type netbox, name netboxcreds
Credential: Successfully programmed netbox, name netboxcreds
Credential: Programming type nomad, name nomadcreds
Credential: Successfully programmed nomad, name nomadcreds
Credential: Programming type chatgpt, name chatgptcreds
Credential: Successfully programmed chatgpt, name chatgptcreds
Credential: Skipping type opsgenie, name opsgeniecreds
Credential: Programming type jira, name jiracreds
Credential: Successfully programmed jira, name jiracreds
Credential: Programming type k8s, name k8screds
Credential: Successfully programmed k8s, name k8screds
Credential: Programming type kafka, name kafkacreds
Credential: Successfully programmed kafka, name kafkacreds
Credential: Programming type mongodb, name mongodbcreds
Credential: Successfully programmed mongodb, name mongodbcreds
Credential: Programming type mysql, name mysqlcreds
Credential: Successfully programmed mysql, name mysqlcreds
Credential: Skipping type postgresql, name postgresqlcreds
Credential: Programming type rest, name restcreds
Credential: Successfully programmed rest, name restcreds
Credential: Skipping type slack, name slackcreds
Credential: Programming type ssh, name sshcreds
Credential: Successfully programmed ssh, name sshcreds
Credential: Skipping type salesforce, name salesforcecreds
Credential: Skipping type vault, name vaultcreds
Credential: Skipping type keycloak, name keycloakcreds
###################################
Processing jobs section
###################################
Jobs: Skipping
###################################
Processing scheduler section
###################################
Skipping
Adding audit log deletion cron job entry, 0 0 * * * /opt/conda/bin/python /usr/local/bin/unskript_audit_cleanup.py
dirsync finished in 0.00 seconds.
12 directories parsed, 0 files copied
16 files were updated by timestamp.


                        _
                       / \__      _____  ___  ___  _ __ ___   ___
                      / _ \ \ /\ / / _ \/ __|/ _ \| '_ ` _ \ / _ \
                     / ___ \ V  V /  __/\__ \ (_) | | | | | |  __/
                    /_/   \_\_/\_/ \___||___/\___/|_| |_| |_|\___|

                        ____ _                 _  ___
                       / ___| | ___  _   _  __| |/ _ \ _ __  ___
                      | |   | |/ _ \| | | |/ _` | | | | '_ \/ __|
                      | |___| | (_) | |_| | (_| | |_| | |_) \__ \
                       \____|_|\___/ \__,_|\__,_|\___/| .__/|___/
                                                      |_|
                   _         _                        _   _
                  / \  _   _| |_ ___  _ __ ___   __ _| |_(_) ___  _ __
                 / _ \| | | | __/ _ \| '_ ` _ \ / _` | __| |/ _ \| '_ \
                / ___ \ |_| | || (_) | | | | | | (_| | |_| | (_) | | | |
               /_/   \_\__,_|\__\___/|_| |_| |_|\__,_|\__|_|\___/|_| |_|


            Thank you for using unSkript Docker. We hope you love this
            release as much as we do.

            Please support our project by starring our repo
            at https://github.com/unskript/Awesome-CloudOps-Automation


            Start by visiting http://127.0.0.1:8888/awesome

[W 2023-11-03 21:21:48.716 ServerApp] The module 'jupyter_resource_usage' could not be found. Are you sure the extension is installed?
[W 2023-11-03 21:21:48.719 ServerApp] The module 'jupyterlab_git' could not be found. Are you sure the extension is installed?
[I 2023-11-03 21:21:48.730 ServerApp] elyra | extension was successfully linked.
[I 2023-11-03 21:21:48.749 ServerApp] jupyter_server_mathjax | extension was successfully linked.
[I 2023-11-03 21:21:48.772 ServerApp] jupyterlab | extension was successfully linked.
[W 2023-11-03 21:21:48.780 NotebookApp] 'ip' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2023-11-03 21:21:48.780 NotebookApp] 'port' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2023-11-03 21:21:48.781 NotebookApp] 'port' has moved from NotebookApp to ServerApp. This config will be passed to ServerApp. Be sure to update your config before our next release.
[W 2023-11-03 21:21:49.123 ServerApp] The module 'jupyter_resource_usage' could not be found. Are you sure the extension is installed?
[W 2023-11-03 21:21:49.123 ServerApp] The module 'jupyterlab_git' could not be found. Are you sure the extension is installed?
[I 2023-11-03 21:21:49.123 ServerApp] nbclassic | extension was successfully linked.
[W 2023-11-03 21:21:49.151 ServerApp] All authentication is disabled.  Anyone who can connect to this server will be able to run code.
[I 2023-11-03 21:21:49.165 ServerApp] nbclassic | extension was successfully loaded.
[I 2023-11-03 21:21:49.166 ElyraApp] Config {'LabApp': {'default_url': DeferredConfigString('/awesome')}, 'ServerApp': {'token': '', 'allow_root': True, 'ip': '0.0.0.0', 'port': 8888, 'open_browser': False, 'jpserver_extensions': <LazyConfigValue value={'jupyterlab': True, 'elyra': True, 'jupyter_resource_usage': True, 'jupyter_server_mathjax': True, 'jupyterlab_git': True, 'nbclassic': True}>}, 'FileContentsManager': {'delete_to_trash': False}}
[I 2023-11-03 21:21:49.177 ServerApp] elyra | extension was successfully loaded.
[I 2023-11-03 21:21:49.180 ServerApp] jupyter_server_mathjax | extension was successfully loaded.
[I 2023-11-03 21:21:49.182 LabApp] JupyterLab extension loaded from /opt/conda/lib/python3.9/site-packages/jupyterlab
[I 2023-11-03 21:21:49.182 LabApp] JupyterLab application directory is /opt/conda/share/jupyter/lab
[I 2023-11-03 21:21:49.188 ServerApp] jupyterlab | extension was successfully loaded.
[I 2023-11-03 21:21:49.189 ServerApp] The port 8888 is already in use, trying another port.
[I 2023-11-03 21:21:49.189 ServerApp] Serving notebooks from local directory: /home/jovyan/runbooks
[I 2023-11-03 21:21:49.189 ServerApp] Jupyter Server 1.13.5 is running at:
[I 2023-11-03 21:21:49.189 ServerApp] http://14947c2b8763:8889/awesome
[I 2023-11-03 21:21:49.190 ServerApp]  or http://127.0.0.1:8889/awesome
[I 2023-11-03 21:21:49.190 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
```

The Yaml file can be updated with the credentials based on the credential schema by running the generate_credentials.py script in unskript-ctl folder

Before:

```
# unSkript-ctl config file
#
# Copyright (c) 2023 unSkript.com
# All rights reserved.
#
# This program is distributed in the hope that it will be useful, but WITHOUT
# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
# FOR A PARTICULAR PURPOSE
#
#
version: 1.0.0

#
# Global section
#
# Global config
#
global:
   # if enable_runbooks is enabled, jupyterlab is launched so that one can open
   # runbooks in jupyterlab.
  enable_runbooks: true
   # audit_period in days. Number of days worth of audit data to be kept.
   # Any date older than this number of days, will be deleted.
  audit_period: 90

#
# Checks section
#
# Check specific configuration. For eg, arguments.
#
checks:
  # Arguments common to all checks, like region, namespace, etc.
  arguments:
    global:
      region: us-west-2



#
# Notification section
#
# uncomment the relevant sections below to enable either slack or email notification
notification:
  # Slack Notification setting
  Slack:
    enable: false
    web-hook-url: ''
    channel-name: ''
    verbose: false #Not yet supported
  Email:
    verbose: true #Not yet supported
    enable: false
    # provider for the email. Possible values:
    #    - SMTP - SMTP server
    #    - SES -  AWS SES
    #    - Sendgrid - Sendgrid
    provider: ''
    SMTP:
      smtp-host: ''
      smtp-user: ''
      smtp-password: ''
      to-email: ''
      from-email: ''
    SES:
      access_key: ''
      secret_access: ''
      region: ''
      to-email: ''
      from-email: ''
    Sendgrid:
      api_key: ''
      to-email: ''
      from-email: ''
#
# Job section
#
# Job detail contains information about what all unskript-ctl can run.
jobs:
- name: ''   # Unique name
    # The results of the job to be notified or not.
  notify: true
  enable: false
    # Specific checks to run
    # Not supported: multiple checks, only single check support for now.
  checks: []
    # Specific suites to run
    # Not supported
  suites: []
    # connector types whose checks need to be run
    # Possible values:
    #   - aws
    #   - k8s
    #   - gcp
    #   - postgresql
    #   - slack
    #   - mongodb
    #   - jenkins
    #   - mysql
    #   - jira
    #   - rest
    #   - elasticsearch
    #   - kafka
    #   - grafana
    #   - ssh
    #   - prometheus
    #   - datadog
    #   - stripe
    #   - redis
    #   - zabbix
    #   - opensearch
    #   - pingdom
    #   - github
    #   - terraform
    #   - airflow
    #   - hadoop
    #   - mssql
    #   - snowflake
    #   - splunk
    #   - salesforce
    #   - azure
    #   - nomad
    #   - netbox
    #   - opsgenie
  connector_types: []
    # Custom scripts to be run.
    # Not supported
  custom_scripts: []

#
# Scheduler section
#
# You can configure multiple schedules.
scheduler:
- enable: false
    # Cadence is specified in cron syntax. More information about the syntax can
    # be found in https://crontab.guru
    # minute  hour  day (of month)  month  day (of week)
    #   *      *          *           *        *
    # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  cadence: '*/60 * * * *'
    # Name of the job to add to the schedule
  job_name: ''

# Credential section
#
# uncomment the relevant sections below to enable respective credential
#
```

After

```
(base) root@14947c2b8763:/usr/local/bin# python generate_credentials.py
(base) root@14947c2b8763:/usr/local/bin# cat /etc/unskript/unskript_ctl_config.yaml
# unSkript-ctl config file
#
# Copyright (c) 2023 unSkript.com
# All rights reserved.
#
# This program is distributed in the hope that it will be useful, but WITHOUT
# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
# FOR A PARTICULAR PURPOSE
#
#
version: 1.0.0

#
# Global section
#
# Global config
#
global:
   # if enable_runbooks is enabled, jupyterlab is launched so that one can open
   # runbooks in jupyterlab.
  enable_runbooks: true
   # audit_period in days. Number of days worth of audit data to be kept.
   # Any date older than this number of days, will be deleted.
  audit_period: 90

#
# Checks section
#
# Check specific configuration. For eg, arguments.
#
checks:
  # Arguments common to all checks, like region, namespace, etc.
  arguments:
    global:
      region: us-west-2
#
# Notification section
#
# uncomment the relevant sections below to enable either slack or email notification
notification:
  # Slack Notification setting
  Slack:
    enable: false
    web-hook-url: ''
    channel-name: ''
    verbose: false #Not yet supported
  Email:
    verbose: true #Not yet supported
    enable: false
    # provider for the email. Possible values:
    #    - SMTP - SMTP server
    #    - SES -  AWS SES
    #    - Sendgrid - Sendgrid
    provider: ''
    SMTP:
      smtp-host: ''
      smtp-user: ''
      smtp-password: ''
      to-email: ''
      from-email: ''
    SES:
      access_key: ''
      secret_access: ''
      region: ''
      to-email: ''
      from-email: ''
    Sendgrid:
      api_key: ''
      to-email: ''
      from-email: ''
#
# Job section
#
# Job detail contains information about what all unskript-ctl can run.
jobs:
- name: ''   # Unique name
    # The results of the job to be notified or not.
  notify: true
  enable: false
    # Specific checks to run
    # Not supported: multiple checks, only single check support for now.
  checks: []
    # Specific suites to run
    # Not supported
  suites: []
    # connector types whose checks need to be run
    # Possible values:
    #   - aws
    #   - k8s
    #   - gcp
    #   - postgresql
    #   - slack
    #   - mongodb
    #   - jenkins
    #   - mysql
    #   - jira
    #   - rest
    #   - elasticsearch
    #   - kafka
    #   - grafana
    #   - ssh
    #   - prometheus
    #   - datadog
    #   - stripe
    #   - redis
    #   - zabbix
    #   - opensearch
    #   - pingdom
    #   - github
    #   - terraform
    #   - airflow
    #   - hadoop
    #   - mssql
    #   - snowflake
    #   - splunk
    #   - salesforce
    #   - azure
    #   - nomad
    #   - netbox
    #   - opsgenie
  connector_types: []
    # Custom scripts to be run.
    # Not supported
  custom_scripts: []

#
# Scheduler section
#
# You can configure multiple schedules.
scheduler:
- enable: false
    # Cadence is specified in cron syntax. More information about the syntax can
    # be found in https://crontab.guru
    # minute  hour  day (of month)  month  day (of week)
    #   *      *          *           *        *
    # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  cadence: '*/60 * * * *'
    # Name of the job to add to the schedule
  job_name: ''
# Credential section
#
# uncomment the relevant sections below to enable respective credential
#

credential:
  aws:
  - name: awscreds
    enable: false
    discriminator: auth_type
    AccessKeySchema:
      enable: false
      auth_type: Access Key
      access_key: ''
      secret_access_key: ''
  gcp:
  - name: gcpcreds
    enable: false
    credentials: ''
  elasticsearch:
  - name: elasticsearchcreds
    enable: false
    host: ''
    username: ''
    password: ''
    api_key: ''
  grafana:
  - name: grafanacreds
    enable: false
    api_key: ''
    username: ''
    password: ''
    host: ''
  redis:
  - name: rediscreds
    enable: false
    db: 0
    host: ''
    username: ''
    password: ''
    port: 6379
    use_ssl: false
  jenkins:
  - name: jenkinscreds
    enable: false
    url: ''
    user_name: ''
    password: ''
  github:
  - name: githubcreds
    enable: false
    token: ''
    hostname: ''
  netbox:
  - name: netboxcreds
    enable: false
    host: ''
    token: ''
    threading: false
  nomad:
  - name: nomadcreds
    enable: false
    host: ''
    timeout: 5
    token: ''
    verify_certs: false
    secure: false
    namespace: ''
  chatgpt:
  - name: chatgptcreds
    enable: false
    organization: ''
    api_token: ''
  opsgenie:
  - name: opsgeniecreds
    enable: false
    api_token: ''
  jira:
  - name: jiracreds
    enable: false
    url: ''
    email: ''
    api_token: ''
  k8s:
  - name: k8screds
    enable: false
    kubeconfig: ''
  kafka:
  - name: kafkacreds
    enable: false
    broker: ''
    sasl_username: ''
    sasl_password: ''
  mongodb:
  - name: mongodbcreds
    enable: false
    host: ''
    port: 27017
    discriminator: auth_type
    AtlasSchema:
      enable: false
      auth_type: Atlas Administrative API using HTTP Digest Authentication
      atlas_public_key: ''
      atlas_private_key: ''
    AuthSchema:
      enable: false
      auth_type: Basic Auth
      user_name: ''
      password: ''
  mysql:
  - name: mysqlcreds
    enable: false
    DBName: ''
    User: ''
    Password: ''
    Host: ''
    Port: 5432
  postgresql:
  - name: postgresqlcreds
    enable: false
    DBName: ''
    User: ''
    Password: ''
    Host: ''
    Port: 5432
  rest:
  - name: restcreds
    enable: false
    base_url: ''
    username: ''
    password: ''
    headers: {}
  slack:
  - name: slackcreds
    enable: false
    bot_user_oauth_token: ''
  ssh:
  - name: sshcreds
    enable: false
    port: 22
    username: ''
    proxy_host: ''
    proxy_user: ''
    proxy_port: 22
    discriminator: auth_type
    AuthSchema:
      enable: false
      auth_type: Basic Auth
      password: ''
      proxy_password: ''
    PrivateKeySchema:
      enable: false
      auth_type: API Token
      private_key: ''
      proxy_private_key: ''
    VaultSchema:
      enable: false
      auth_type: Vault
      vault_url: ''
      vault_secret_path: ''
      vault_role: ''
    KerberosSchema:
      enable: false
      auth_type: Kerberos
      user_with_realm: ''
      kdc_server: ''
      admin_server: ''
      password: ''
      proxy_password: ''
  salesforce:
  - name: salesforcecreds
    enable: false
    Username: ''
    Password: ''
    Security_Token: ''
  vault:
  - name: vaultcreds
    enable: false
    url: ''
    token: ''
  keycloak:
  - name: keycloakcreds
    enable: false
    server_url: ''
    realm: ''
    client_id: ''
    username: ''
    password: ''
    client_secret: ''
    verify: true
```

[EN-5100]: https://unskript.atlassian.net/browse/EN-5100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EN-5150]: https://unskript.atlassian.net/browse/EN-5150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ