### PR TITLE
Change Keycloak schema and inputs in add_creds

### DIFF
--- a/unskript-ctl/add_creds.py
+++ b/unskript-ctl/add_creds.py
@@ -906,57 +906,95 @@ credential_schemas = '''
       "url"
     ]
   },
-   {
-      "title": "KeycloakSchema",
-      "type": "object",
-      "properties": {
-        "server_url": {
-          "title": "Keycloak Server URL",
-          "description": "Base URL of the Keycloak instance",
-          "type": "string"
-        },
-        "realm": {
-          "title": "Keycloak Realm",
-          "description": "Name of the realm for authentication",
-          "type": "string"
-        },
-        "client_id": {
-          "title": "Client ID",
-          "description": "Client ID for authentication",
-          "type": "string"
-        },
-        "username": {
-          "title": "Username",
-          "description": "Username for client-based authentication",
-          "type": "string"
-        },
-        "password": {
-          "title": "Password",
-          "description": "Password for client-based authentication",
-          "type": "string",
-          "writeOnly": true,
-          "format": "password"
-        },
-        "client_secret": {
-          "title": "Client Secret",
-          "description": "Client Secret for client-based authentication",
-          "type": "string",
-          "writeOnly": true,
-          "format": "password"
-        },
-        "verify": {
-          "title": "SSL Verification",
-          "description": "Boolean to decide if SSL certificate verification should be performed",
-          "default": true,
-          "type": "boolean"
-        }
+  {
+    "properties": {
+      "server_url": {
+        "description": "Base URL of the Keycloak instance",
+        "title": "Keycloak Server URL",
+        "type": "string"
       },
-      "required": [
-        "server_url",
-        "realm",
-        "client_id"
-      ]
-    }
+      "realm": {
+        "description": "Name of the realm for authentication",
+        "title": "Keycloak Realm",
+        "type": "string"
+      },
+      "client_id": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Client ID for authentication",
+        "title": "Client ID"
+      },
+      "username": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Username for client-based authentication",
+        "title": "Username"
+      },
+      "password": {
+        "anyOf": [
+          {
+            "format": "password",
+            "type": "string",
+            "writeOnly": true
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Password for client-based authentication",
+        "title": "Password"
+      },
+      "client_secret": {
+        "anyOf": [
+          {
+            "format": "password",
+            "type": "string",
+            "writeOnly": true
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Client Secret for client-based authentication",
+        "title": "Client Secret"
+      },
+      "verify": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": true,
+        "description": "Boolean to decide if SSL certificate verification should be performed",
+        "title": "SSL Verification"
+      }
+    },
+    "required": [
+      "server_url",
+      "realm"
+    ],
+    "title": "KeycloakSchema",
+    "type": "object"
+  }
   ]
 '''
 
@@ -1270,7 +1308,7 @@ class CredentialsAdd():
                           Base URL of the keycloak instance.
                          ''')
       parser.add_argument('-r', '--realm', required=True, help='Name of the realm for authentication')
-      parser.add_argument('-c', '--client-id', required=True, help='Client ID for authentication')
+      parser.add_argument('-c', '--client-id', help='Client ID for authentication')
       parser.add_argument('-u', '--username', help='Username for client-based authentication')
       parser.add_argument('-p', '--password', help='Password for client-based authentication')
       parser.add_argument('-cs', '--client-secret', help='Client secret for client-based authentication')


### PR DESCRIPTION
## Description
Made server_url and realm as the only mandatory parameters,.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing


<img width="875" alt="Screenshot 2023-10-21 at 2 20 47 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/028cce43-b93a-4350-8fcf-5e17deff1900">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
