### PR TITLE
Amit-k8s-support

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -19,6 +19,9 @@ global:
    # if enable_runbooks is enabled, jupyterlab is launched so that one can open
    # runbooks in jupyterlab.
    enable_runbooks: true
+   # audit_period in days. Number of days worth of audit data to be kept.
+   # Any date older than this number of days, will be deleted.
+   audit_period: 90
 
 #
 # Checks section

--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -161,15 +161,13 @@ notification:
     SES:
       access_key: ""
       secret_access: ""
-      region: us-west-2
+      region: ""
       to-email: ""
       from-email: ""
     Sendgrid:
       api_key: ""
       to-email: ""
-      from-email: support@unskript.com
-
-
+      from-email: ""
 #
 # Job section
 #

--- a/unskript-ctl/unskript_ctl.py
+++ b/unskript-ctl/unskript_ctl.py
@@ -253,6 +253,7 @@ def run_ipynb(filename: str, status_list_of_dict: list = None, filter: str = Non
     except CellExecutionError as e:
         raise e
     finally:
+        os.remove(filename)
         output_file = filename
         output_file = output_file.replace('.ipynb', '_output.ipynb')
         nbformat.write(nb, output_file)
@@ -1821,6 +1822,20 @@ def save_check_names(filename: str):
             f.write(name + '\n')
 
 
+def run_script(script:list[str]):
+    try:
+        result = subprocess.run(script,
+                                capture_output=True,
+                                check=True)
+    except Exception as e:
+        print(f'{"".join(script)} failed, {e}')
+        raise e
+
+
+    print(str(result.stdout))
+    return str(result.stdout)
+
+
 if __name__ == "__main__":
     try:
         if os.environ.get('EXECUTION_DIR') is None:
@@ -1894,6 +1909,9 @@ if __name__ == "__main__":
     parser.add_argument('--save-check-names',
                         type=str,
                         help=SUPPRESS)
+   # parser.add_argument('--run-script',
+   #                     help='Run script',
+   #                     nargs=REMAINDER)
 
     args = parser.parse_args()
 
@@ -1933,5 +1951,7 @@ if __name__ == "__main__":
         stop_debug()
     elif args.save_check_names not in ('', None):
         save_check_names(args.save_check_names)
+    #elif args.run_script not in ('', None):
+    #    run_script(args.run_script)
     else:
         parser.print_help()

--- a/unskript-ctl/unskript_ctl.py
+++ b/unskript-ctl/unskript_ctl.py
@@ -1822,18 +1822,18 @@ def save_check_names(filename: str):
             f.write(name + '\n')
 
 
-def run_script(script:list[str]):
-    try:
-        result = subprocess.run(script,
-                                capture_output=True,
-                                check=True)
-    except Exception as e:
-        print(f'{"".join(script)} failed, {e}')
-        raise e
-
-
-    print(str(result.stdout))
-    return str(result.stdout)
+#def run_script(script:list[str]):
+#    try:
+#        result = subprocess.run(script,
+#                                capture_output=True,
+#                                check=True)
+#    except Exception as e:
+#        print(f'{"".join(script)} failed, {e}')
+#        raise e
+#
+#
+#    print(str(result.stdout))
+#    return str(result.stdout)
 
 
 if __name__ == "__main__":

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -163,7 +163,7 @@ class ConfigParser():
                     if creds_cmd:
                         print_cmd = ' '.join(creds_cmd)
                         self.run_command(creds_cmd)
-                        print(f"Credential: Successfully programmed {cred_type}, name {name}, cmd {print_cmd}")
+                        print(f"{bcolors.OKGREEN}Credential: Successfully programmed {cred_type}, name {name}, cmd {print_cmd}{bcolors.ENDC}")
                 except Exception as e:
                     print(f'{bcolors.FAIL}Credential: Failed to program {cred_type}, name {name}{bcolors.ENDC}')
                     continue
@@ -196,6 +196,9 @@ class ConfigParser():
                     print(f'{bcolors.FAIL}Schedule: Unknown job name {job_name}. Please check the jobs section and ensure the job is defined{bcolors.ENDC}')
                     continue
                 print(f'Schedule: cadence {cadence}, job name: {job_name}')
+                if len(job.cmds) == 0:
+                    print(f'{bcolors.WARNING}Scheduler: Empty job {job.job_name}, not adding to schedule{bcolors.ENDC}')
+                    continue
                 script = '; '.join(job.cmds)
                 # TBD: Validate cadence and script is valid
                 crons.append(f'{cadence} {script}')
@@ -221,7 +224,7 @@ class ConfigParser():
                 # Add the audit period cron job as well, to be run daily.
                 audit_cadence = "0 0 * * *"
                 delete_old_files_command = f'/usr/bin/find {UNSKRIPT_EXECUTION_DIR} -name "*.ipynb" -type f -mtime +{self.audit_period} -exec rm -f {{}} \;'
-                print(f'Adding audit log deletion cron job entry, {audit_cadence} {delete_old_files_command}')
+                print(f'{bcolors.OKGREEN}Adding audit log deletion cron job entry, {audit_cadence} {delete_old_files_command}{bcolors.ENDC}')
                 f.write(f'{audit_cadence} {delete_old_files_command}')
                 f.write("\n")
 

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -24,6 +24,7 @@ from pathlib import Path
 #)
 UNSKRIPT_CTL_CONFIG_FILE="/etc/unskript/unskript_ctl_config.yaml"
 UNSKRIPT_CTL_BINARY="/usr/local/bin/unskript-ctl.sh"
+UNSKRIPT_EXECUTION_DIR="/unskript/data/execution/workspace/"
 
 # Job config related
 JOB_CONFIG_CHECKS_KEY_NAME = "checks"
@@ -34,6 +35,10 @@ JOB_CONFIG_NOTIFY_KEY_NAME = "notify"
 
 # Credential section related
 CREDENTIAL_CONFIG_SKIP_VALUE_FOR_ARGUMENTS = ["no-verify-certs", "no-verify-ssl", "use-ssl"]
+
+# Global section related
+GLOBAL_CONFIG_AUDIT_PERIOD_KEY_NAME = "audit_period"
+GLOBAL_DEFAULT_AUDIT_PERIOD = 90
 
 class bcolors:
     HEADER = '\033[95m'
@@ -49,11 +54,13 @@ class bcolors:
 class Job():
     def __init__(
             self,
+            job_name: str,
             checks: list[str],
             suites: list[str]=None,
             connectors: list[str] = None,
             custom_scripts: list[str] = None,
             notify: bool = False):
+        self.job_name = job_name
         self.checks = checks
         self.suites = suites
         self.connectors = connectors
@@ -66,10 +73,12 @@ class Job():
         #TBD: Add support for suites and custom_scripts
         if self.checks is not None and len(self.checks) != 0:
             cmds.append(f'{UNSKRIPT_CTL_BINARY} -rc --check {self.checks[0]} {notify}')
+            print(f'Job: {self.job_name} contains check: {self.checks[0]}')
         if self.connectors is not None and len(self.connectors) != 0:
             # Need to construct the unskript-ctl command like
             # unskript-ctl.sh -rc --types aws,k8s
             connector_types_string = ','.join(self.connectors)
+            print(f'Job: {self.job_name} contains connector types: {connector_types_string}')
             cmds.append(f'{UNSKRIPT_CTL_BINARY} -rc --type {connector_types_string} {notify}')
         self.cmds = cmds
 
@@ -99,6 +108,23 @@ class ConfigParser():
 
         self.parsed_config = retval
 
+    def parse_global(self):
+        """parse_global: This function parses the global section of the config.
+        """
+        print('###################################')
+        print(f'{bcolors.HEADER}Processing global section{bcolors.ENDC}')
+        print('###################################')
+        config = self.parsed_config.get('global')
+        if config is None:
+            print(f"{bcolors.WARNING}Global: Nothing to configure credential with, found empty creds data{bcolors.ENDC}")
+            return
+
+        # Process the audit_period config
+        audit_period = config.get(GLOBAL_CONFIG_AUDIT_PERIOD_KEY_NAME, GLOBAL_DEFAULT_AUDIT_PERIOD)
+        print(f'Global: audit period {audit_period} days')
+        self.audit_period = audit_period
+
+
     def configure_credential(self):
         """configure_credential: This function is used to parse through the creds_dict and
         call the add_creds.sh method to populate the respective credential json
@@ -108,7 +134,7 @@ class ConfigParser():
         print('###################################')
         creds_dict = self.parsed_config.get('credential')
         if creds_dict is None:
-            print(f"ERROR: Nothing to configure credential with, found empty creds data")
+            print(f"{bcolors.WARNING}Credential: Nothing to configure credential with, found empty creds data{bcolors.ENDC}")
             return
 
         for cred_type in creds_dict.keys():
@@ -148,7 +174,7 @@ class ConfigParser():
         print('###################################')
         config = self.parsed_config.get('scheduler')
         if config is None:
-            print(f"No scheduler configuration found")
+            print(f"{bcolors.WARNING}Scheduler: No scheduler configuration found{bcolors.ENDC}")
             return
 
         unskript_crontab_file = "/etc/unskript/unskript_crontab.tab"
@@ -156,7 +182,8 @@ class ConfigParser():
         try:
             for schedule in config:
                 if schedule.get('enable') is False:
-                        continue
+                    print(f'Skipping')
+                    continue
                 cadence = schedule.get('cadence')
                 job_name = schedule.get('job_name')
                 # look up the job name and get the commands
@@ -164,6 +191,7 @@ class ConfigParser():
                 if job is None:
                     print(f'{bcolors.FAIL}Schedule: Unknown job name {job_name}. Please check the jobs section and ensure the job is defined{bcolors.ENDC}')
                     continue
+                print(f'Schedule: cadence {cadence}, job name: {job_name}')
                 script = '; '.join(job.cmds)
                 # TBD: Validate cadence and script is valid
                 crons.append(f'{cadence} {script}')
@@ -172,25 +200,32 @@ class ConfigParser():
             #raise e
             return
 
-        if crons:
-            cmds = []
-            crons_per_line = "\n".join(crons)
-            print(f'Schedule: Programming crontab {crons_per_line}')
-            try:
-                with open(unskript_crontab_file, "w") as f:
-                    # Since crontabs dont inherit the environmnent variables, we have to
-                    # do it explicitly.
-                    for name, value in os.environ.items():
-                        if value != "":
-                            f.write(f'{name}={value}')
-                            f.write("\n")
+        try:
+            with open(unskript_crontab_file, "w") as f:
+                # Since crontabs dont inherit the environmnent variables, we have to
+                # do it explicitly.
+                for name, value in os.environ.items():
+                    if value != "":
+                        f.write(f'{name}={value}')
+                        f.write("\n")
+                if crons:
+                    cmds = []
+                    crons_per_line = "\n".join(crons)
+                    print(f'Schedule: Programming crontab {crons_per_line}')
                     f.write('\n'.join(crons))
                     f.write("\n")
-                cmds = ['crontab', unskript_crontab_file]
-                self.run_command(cmds)
-            except Exception as e:
-                print(f'{bcolors.FAIL}Schedule: Cron programming failed, {e}{bcolors.ENDC}')
-                #raise e
+                # Add the audit period cron job as well, to be run daily.
+                audit_cadence = "0 0 * * *"
+                delete_old_files_command = f'/usr/bin/find {UNSKRIPT_EXECUTION_DIR} -name "*.ipynb" -type f -mtime +{self.audit_period} -exec rm -f {{}} \;'
+                print(f'Adding audit log deletion cron job entry, {audit_cadence} {delete_old_files_command}')
+                f.write(f'{audit_cadence} {delete_old_files_command}')
+                f.write("\n")
+
+            cmds = ['crontab', unskript_crontab_file]
+            self.run_command(cmds)
+        except Exception as e:
+            print(f'{bcolors.FAIL}Schedule: Cron programming failed, {e}{bcolors.ENDC}')
+            #raise e
 
     def parse_jobs(self):
         print('###################################')
@@ -198,19 +233,20 @@ class ConfigParser():
         print('###################################')
         config = self.parsed_config.get('jobs')
         if config is None:
-            print(f'No jobs config found')
+            print(f'{bcolors.WARNING}Jobs: No jobs config found{bcolors.ENDC}')
             return
 
         for job in config:
-            if job.get('enable') is False:
-                continue
             job_name = job.get('name')
             if job_name is None:
-                print(f"{bcolors.OKBLUE}Skipping invalid job, name not found{bcolors.ENDC}")
+                print(f"{bcolors.OKBLUE}Jobs: Skipping invalid job, name not found{bcolors.ENDC}")
+                continue
+            if job.get('enable') is False:
+                print(f'Jobs: Skipping {job_name}')
                 continue
             # Check if the same job name exists
             if job_name in self.jobs:
-                print(f'{bcolors.WARNING}Skipping job name {job_name}, duplicate entry{bcolors.ENDC}')
+                print(f'{bcolors.WARNING}Jobs: Skipping job name {job_name}, duplicate entry{bcolors.ENDC}')
                 continue
             checks = job.get(JOB_CONFIG_CHECKS_KEY_NAME)
             suites = job.get(JOB_CONFIG_SUITES_KEY_NAME)
@@ -221,7 +257,7 @@ class ConfigParser():
             if checks is not None and len(checks) > 1:
                 print(f'{job_name}: NOT SUPPORTED: more than 1 check')
                 continue
-            new_job = Job(checks, suites, connectors, custom_scripts, notify)
+            new_job = Job(job_name, checks, suites, connectors, custom_scripts, notify)
             new_job.parse()
             self.jobs[job_name] = new_job
 
@@ -246,6 +282,7 @@ def main():
     config_parser = ConfigParser(UNSKRIPT_CTL_CONFIG_FILE)
     config_parser.parse_config_yaml()
 
+    config_parser.parse_global()
     config_parser.configure_credential()
     config_parser.parse_jobs()
     config_parser.configure_schedule()

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -97,7 +97,7 @@ class ConfigParser():
 
         if os.path.exists(self.config_file) is False:
             print(f"{bcolors.FAIL} {self.config_file} Not found!{bcolors.ENDC}")
-            exit(0)
+            sys.exit(0)
 
         # We use EnvYAML to parse the hook file and give us the
         # dictionary representation of the YAML file

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -12,6 +12,7 @@ import logging
 import subprocess
 import os
 from envyaml import EnvYAML
+import sys
 
 
 from pathlib import Path
@@ -102,13 +103,12 @@ class ConfigParser():
         # dictionary representation of the YAML file
         try:
             retval = EnvYAML(self.config_file, strict=False)
-
             if not retval:
                 print(f"{bcolors.WARNING} Parsing config file {self.config_file} failed{bcolors.ENDC}")
-                exit(0)
+                sys.exit(0)
         except Exception as e:
             print(f"{bcolors.FAIL} Parsing config file {self.config_file} failed{bcolors.ENDC}")
-            exit(0)
+            sys.exit(0)
 
         self.parsed_config = retval
 

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -95,16 +95,20 @@ class ConfigParser():
         retval = {}
 
         if os.path.exists(self.config_file) is False:
-            print(f"ERROR: {self.config_file} Not found!")
-            raise Exception(f'{self.config_file} not found')
+            print(f"{bcolors.FAIL} {self.config_file} Not found!{bcolors.ENDC}")
+            exit(0)
 
         # We use EnvYAML to parse the hook file and give us the
         # dictionary representation of the YAML file
-        retval = EnvYAML(self.config_file, strict=False)
+        try:
+            retval = EnvYAML(self.config_file, strict=False)
 
-        if not retval:
-            print(f"WARNING: config file {self.config_file} content seems to be empty!")
-            return retval
+            if not retval:
+                print(f"{bcolors.WARNING} Parsing config file {self.config_file} failed{bcolors.ENDC}")
+                exit(0)
+        except Exception as e:
+            print(f"{bcolors.FAIL} Parsing config file {self.config_file} failed{bcolors.ENDC}")
+            exit(0)
 
         self.parsed_config = retval
 


### PR DESCRIPTION
Audit files delete support

## Description

-  Dont error out if the config file processing fails
- Be more verbose
- Add audit period support.
- For k8s in cron, it needs to have the env variables, as kubectl uses them, so instead copying over all non-empty env variables to the cron job defintion.


### Testing
- Invalid yaml file

```
(base) root@ddebc3651a02:~# python /usr/local/bin/unskript_ctl_config_parser.py
 Parsing config file /etc/unskript/unskript_ctl_config.yaml failed
```

- Yaml file doesnt exist
```
(base) root@ddebc3651a02:~# python /usr/local/bin/unskript_ctl_config_parser.py
 /etc/unskript/unskript_ctl_config.yaml Not found!
```

Good case
```
(base) root@ddebc3651a02:~# python /usr/local/bin/unskript_ctl_config_parser.py
###################################
Processing global section
###################################
Global: audit period 89 days
###################################
Processing credential section
###################################
Credential: Skipping type aws, name awscreds
Credential: Skipping type k8s, name k8screds
Credential: Skipping type gcp, name gcpcreds
Credential: Programming type elasticsearch, name escreds
cmd: /usr/local/bin/add_creds.sh -c elasticsearch --host  --api-key  --no-verify-ssl failed, Command '['/usr/local/bin/add_creds.sh', '-c', 'elasticsearch', '--host', '', '--api-key', '', '--no-verify-ssl']' returned non-zero exit status 2.
Credential: Failed to program elasticsearch, name escreds
Credential: Skipping type redis, name rediscreds
Credential: Skipping type postgres, name postgrescreds
Credential: Skipping type mongodb, name mongodbcreds
Credential: Skipping type kafka, name kafkacreds
Credential: Skipping type rest, name restcreds
Credential: Skipping type vault, name vaultcreds
Credential: Skipping type keycloak, name keycloakcreds
###################################
Processing jobs section
###################################
Job: trial contains connector types: k8s
###################################
Processing scheduler section
###################################
Schedule: cadence * * * * *, job name: trial
Schedule: Programming crontab * * * * * /usr/local/bin/unskript-ctl.sh -rc --type k8s --report
Adding audit log deletion cron job entry, 0 0 * * * /usr/bin/find /unskript/data/execution/workspace/ -name "*.ipynb" -type f -mtime +89 -exec rm -f {} \;
```
 Crontab entry
 ```
(base) root@ddebc3651a02:~# crontab -l
SHELL=/bin/bash
MINIFORGE_VERSION=4.10.3-3
CONDA_EXE=/opt/conda/bin/conda
HOSTNAME=ddebc3651a02
LANGUAGE=en_US.UTF-8
NB_UID=1000
PWD=/home/jovyan
CONDA_PREFIX=/opt/conda
HOME=/home/jovyan
LANG=en_US.UTF-8
LS_COLORS=rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:
NB_GID=100
CHOWN_HOME=yes
CONDA_PROMPT_MODIFIER=(base)
LESSCLOSE=/usr/bin/lesspipe %s %s
TERM=xterm
LESSOPEN=| /usr/bin/lesspipe %s
CONDA_SHLVL=1
SHLVL=1
CONDA_DIR=/opt/conda
CONDA_PYTHON_EXE=/opt/conda/bin/python
CONDA_DEFAULT_ENV=base
CONDA_VERSION=4.10.3
NB_USER=jovyan
LC_ALL=en_US.UTF-8
PATH=/opt/conda/bin:/opt/conda/condabin:/usr/local/kafka/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/mssql-tools/bin
PYTHONWARNINGS=ignore
CHOWN_EXTRA_OPTS=-R
DEBIAN_FRONTEND=noninteractive
_=/opt/conda/bin/python
* * * * * /usr/local/bin/unskript-ctl.sh -rc --type k8s --report
0 0 * * * /usr/bin/find /unskript/data/execution/workspace/ -name "*.ipynb" -type f -mtime +89 -exec rm -f {} \;
```
