### PR TITLE
Per Connector Send Failed results as email attachment

### DIFF
--- a/unskript-ctl/unskript_ctl.py
+++ b/unskript-ctl/unskript_ctl.py
@@ -316,7 +316,8 @@ def run_ipynb(filename: str, status_list_of_dict: list = None, filter: str = Non
                             )
                     elif ids and CheckOutputStatus(payload.get('status')) == CheckOutputStatus.FAILED:
                         failed_objects = payload.get('objects')
-                        failed_result[get_action_name_from_id(ids[idx], nb.dict())] = failed_objects
+                        c_name = get_connector_name_from_id(ids[idx], nb.dict()) + ':' + get_action_name_from_id(ids[idx], nb.dict())
+                        failed_result[c_name] = failed_objects
                         result_table.append([
                             get_action_name_from_id(ids[idx], nb.dict()),
                             TBL_CELL_CONTENT_FAIL,
@@ -333,7 +334,8 @@ def run_ipynb(filename: str, status_list_of_dict: list = None, filter: str = Non
                     elif ids and CheckOutputStatus(payload.get('status')) == CheckOutputStatus.RUN_EXCEPTION:
                         if payload.get('error') is not None:
                             failed_objects = payload.get('error')
-                            failed_result[get_action_name_from_id(ids[idx], nb.dict())] = failed_objects
+                            c_name = get_connector_name_from_id(ids[idx], nb.dict()) + ':' + get_action_name_from_id(ids[idx], nb.dict())
+                            failed_result[c_name] = failed_objects
                         result_table.append([
                             get_action_name_from_id(ids[idx], nb.dict()),
                             TBL_CELL_CONTENT_ERROR,
@@ -1910,7 +1912,6 @@ def run_script(script:list[str]):
 
     json_output = {}
     json_output['status'] = status
-    # json_output['time_taken'] = '%.2f' % elapsed_time
     json_output['time_taken'] = f'{elapsed_time:.2f}'
     json_output['error'] = error
     json_output['output_file'] = output_file_txt

--- a/unskript-ctl/unskript_ctl_gen_report.py
+++ b/unskript-ctl/unskript_ctl_gen_report.py
@@ -324,15 +324,10 @@ def send_sendgrid_notification(summary_results: list,
                 target_name = os.path.basename(parent_folder)
                 tar_file_name = f"{target_name}" + '.tar.bz2'
                 output_metadata_file = output_metadata_file.split('/')[-1]
-                tar_cmd = ["tar", "jcvf", tar_file_name, f"--exclude={output_metadata_file}", "-C" , parent_folder, "."]
-                try:
-                    subprocess.run(tar_cmd,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                check=True)
-                except Exception as e:
-                    print(f"ERROR: {e}")
-                    return False
+                if create_tarball_archive(tar_file_name=tar_file_name,
+                                          output_metadata_file=output_metadata_file,
+                                          parent_folder=parent_folder) is False: 
+                    raise ValueError("ERROR: Archiving attachments failed!")
                 target_file_name = tar_file_name
 
         email_message = Mail(
@@ -450,15 +445,10 @@ def create_email_message_with_attachment(output_metadata_file: str = None):
         target_name = os.path.basename(parent_folder)
         tar_file_name = f"{target_name}" + '.tar.bz2'
         output_metadata_file = output_metadata_file.split('/')[-1]
-        tar_cmd = ["tar", "jcvf", tar_file_name, f"--exclude={output_metadata_file}", "-C" , parent_folder, "."]
-        try:
-            subprocess.run(tar_cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            check=True)
-        except Exception as e:
-            print(f"ERROR: {e}")
-            return
+        if create_tarball_archive(tar_file_name=tar_file_name,
+                                  output_metadata_file=output_metadata_file,
+                                  parent_folder=parent_folder) is False:
+            raise ValueError("ERROR: Archiving attachments failed!")
         target_file_name = tar_file_name
 
     with open(target_file_name, 'rb') as f:
@@ -559,6 +549,22 @@ def create_temp_files_of_failed_results(failed_result: dir):
                 list_of_failed_files.append(f'/tmp/{connector}.txt')
         
     return list_of_failed_files
+
+
+def create_tarball_archive(tar_file_name: str, 
+                           output_metadata_file: str,
+                           parent_folder: str):
+    tar_cmd = ["tar", "jcvf", tar_file_name, f"--exclude={output_metadata_file}", "-C" , parent_folder, "."]
+    try:
+        subprocess.run(tar_cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        check=True)
+    except Exception as e:
+        print(f"ERROR: {e}")
+        return False
+    
+    return True
 
 def send_smtp_notification(summary_results: list,
                             failed_result: dict,


### PR DESCRIPTION
## Description

[EN-5136]

Please include a summary of the change, motivation and context.
* Added support to generate per-connector failed object as email attachment


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### SES Notification 

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/10162fd7-550d-49e2-a758-b28c1b72bd56

#### Sendgrid Notification

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/406ab215-469d-4371-b69d-6740eacc8a83

#### SMTP Notification

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/37f4bd1c-ccf4-4b56-b085-da56705d2ef1

#### Combined Report of K8S and AWS

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/c2d8effb-5ef8-4beb-a448-95854f873097



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5136]: https://unskript.atlassian.net/browse/EN-5136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ