### PR TITLE
EN-5150: Support all connectors in unskript_ctl_config.yaml

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -33,106 +33,6 @@ checks:
   arguments:
     global:
        region: us-west-2
-
-# Credential section
-#
-# uncomment the relevant sections below to enable respective credential
-#
-credential:
-  # AWS connector details
-  aws:
-   - name: awscreds
-     enable: false
-     access-key: ""
-     secret-access-key: ""
-
-  # Kubernetes connector details
-  k8s:
-   - name: k8screds
-     enable: false
-     kubeconfig: ""
-
-  # GCP connector details
-  gcp:
-   - name: gcpcreds
-     enable: false
-     credential-json: ""
-
-  # Elasticsearch connector details
-  elasticsearch:
-   - name: escreds
-     enable: false
-     host: ""
-     api-key: ""
-     no-verify-ssl: ""
-
-  # Redis connector details
-  redis:
-   - name: rediscreds
-     enable: false
-     host: ""
-     port: ""
-     username: ""
-     password: ""
-     database: ""
-     use-ssl: ""
-
-  # Postgres connector details
-  postgres:
-   - name: postgrescreds
-     enable: false
-     host: ""
-     port: ""
-     username: ""
-     password: ""
-     database: ""
-
-  # Mongodb connector details
-  mongodb:
-   - name: mongodbcreds
-     enable: false
-     host: ""
-     port: ""
-     username: ""
-     password: ""
-
-  # Kafka connector details
-  kafka:
-   - name: kafkacreds
-     enable: false
-     broker: ""
-     username: ""
-     password: ""
-     zookeeper: ""
-
-  # Rest connector details
-  rest:
-   - name: restcreds
-     enable: false
-     base-url: ""
-     username: ""
-     password: ""
-     headers: ""
-
-  # Vault connector details
-  vault:
-   - name: vaultcreds
-     enable: false
-     url: ""
-     token: ""
-
-  # Keycloak connector details
-  keycloak:
-   - name: keycloakcreds
-     enable: false
-     server-url: ""
-     realm: ""
-     client-id: ""
-     username: ""
-     password: ""
-     client-secret: ""
-     no-verify-certs: ""
-
 #
 # Notification section
 #
@@ -237,3 +137,7 @@ scheduler:
     cadence: "*/60 * * * *"
     # Name of the job to add to the schedule
     job_name: ""
+# Credential section
+#
+# uncomment the relevant sections below to enable respective credential
+#


### PR DESCRIPTION
Fixes [EN-5150]

## Brief description of fix.

Generate credentials details in unskript-ctl_config.py as per credentials schema. 

## Add Unit test results.

To test, spun up container instance using

docker run -it -d -p 8888:8888 --user root unskript/awesome-runbooks:latest

Removed all existing credentials details from /etc/unskript/unskript_ctl_config.yaml

Added logic manually in /usr/local/bin/unskript_ctl_config_parser.py

Ran start.sh script

This generated the credentials in unskript_ctl_config.yaml

Before:

```
# unSkript-ctl config file
#
# Copyright (c) 2023 unSkript.com
# All rights reserved.
#
# This program is distributed in the hope that it will be useful, but WITHOUT
# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
# FOR A PARTICULAR PURPOSE
#
#
version: 1.0.0

#
# Global section
#
# Global config
#
global:
   # if enable_runbooks is enabled, jupyterlab is launched so that one can open
   # runbooks in jupyterlab.
  enable_runbooks: true
   # audit_period in days. Number of days worth of audit data to be kept.
   # Any date older than this number of days, will be deleted.
  audit_period: 90

#
# Checks section
#
# Check specific configuration. For eg, arguments.
#
checks:
  # Arguments common to all checks, like region, namespace, etc.
  arguments:
    global:
      region: us-west-2



#
# Notification section
#
# uncomment the relevant sections below to enable either slack or email notification
notification:
  # Slack Notification setting
  Slack:
    enable: false
    web-hook-url: ''
    channel-name: ''
    verbose: false #Not yet supported
  Email:
    verbose: true #Not yet supported
    enable: false
    # provider for the email. Possible values:
    #    - SMTP - SMTP server
    #    - SES -  AWS SES
    #    - Sendgrid - Sendgrid
    provider: ''
    SMTP:
      smtp-host: ''
      smtp-user: ''
      smtp-password: ''
      to-email: ''
      from-email: ''
    SES:
      access_key: ''
      secret_access: ''
      region: ''
      to-email: ''
      from-email: ''
    Sendgrid:
      api_key: ''
      to-email: ''
      from-email: ''
#
# Job section
#
# Job detail contains information about what all unskript-ctl can run.
jobs:
- name: ''   # Unique name
    # The results of the job to be notified or not.
  notify: true
  enable: false
    # Specific checks to run
    # Not supported: multiple checks, only single check support for now.
  checks: []
    # Specific suites to run
    # Not supported
  suites: []
    # connector types whose checks need to be run
    # Possible values:
    #   - aws
    #   - k8s
    #   - gcp
    #   - postgresql
    #   - slack
    #   - mongodb
    #   - jenkins
    #   - mysql
    #   - jira
    #   - rest
    #   - elasticsearch
    #   - kafka
    #   - grafana
    #   - ssh
    #   - prometheus
    #   - datadog
    #   - stripe
    #   - redis
    #   - zabbix
    #   - opensearch
    #   - pingdom
    #   - github
    #   - terraform
    #   - airflow
    #   - hadoop
    #   - mssql
    #   - snowflake
    #   - splunk
    #   - salesforce
    #   - azure
    #   - nomad
    #   - netbox
    #   - opsgenie
  connector_types: []
    # Custom scripts to be run.
    # Not supported
  custom_scripts: []

#
# Scheduler section
#
# You can configure multiple schedules.
scheduler:
- enable: false
    # Cadence is specified in cron syntax. More information about the syntax can
    # be found in https://crontab.guru
    # minute  hour  day (of month)  month  day (of week)
    #   *      *          *           *        *
    # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  cadence: '*/60 * * * *'
    # Name of the job to add to the schedule
  job_name: ''

# Credential section
#
# uncomment the relevant sections below to enable respective credential
#
```

After
```
# unSkript-ctl config file
#
# Copyright (c) 2023 unSkript.com
# All rights reserved.
#
# This program is distributed in the hope that it will be useful, but WITHOUT
# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
# FOR A PARTICULAR PURPOSE
#
#
version: 1.0.0

#
# Global section
#
# Global config
#
global:
   # if enable_runbooks is enabled, jupyterlab is launched so that one can open
   # runbooks in jupyterlab.
  enable_runbooks: true
   # audit_period in days. Number of days worth of audit data to be kept.
   # Any date older than this number of days, will be deleted.
  audit_period: 90

#
# Checks section
#
# Check specific configuration. For eg, arguments.
#
checks:
  # Arguments common to all checks, like region, namespace, etc.
  arguments:
    global:
      region: us-west-2



#
# Notification section
#
# uncomment the relevant sections below to enable either slack or email notification
notification:
  # Slack Notification setting
  Slack:
    enable: false
    web-hook-url: ''
    channel-name: ''
    verbose: false #Not yet supported
  Email:
    verbose: true #Not yet supported
    enable: false
    # provider for the email. Possible values:
    #    - SMTP - SMTP server
    #    - SES -  AWS SES
    #    - Sendgrid - Sendgrid
    provider: ''
    SMTP:
      smtp-host: ''
      smtp-user: ''
      smtp-password: ''
      to-email: ''
      from-email: ''
    SES:
      access_key: ''
      secret_access: ''
      region: ''
      to-email: ''
      from-email: ''
    Sendgrid:
      api_key: ''
      to-email: ''
      from-email: ''
#
# Job section
#
# Job detail contains information about what all unskript-ctl can run.
jobs:
- name: ''   # Unique name
    # The results of the job to be notified or not.
  notify: true
  enable: false
    # Specific checks to run
    # Not supported: multiple checks, only single check support for now.
  checks: []
    # Specific suites to run
    # Not supported
  suites: []
    # connector types whose checks need to be run
    # Possible values:
    #   - aws
    #   - k8s
    #   - gcp
    #   - postgresql
    #   - slack
    #   - mongodb
    #   - jenkins
    #   - mysql
    #   - jira
    #   - rest
    #   - elasticsearch
    #   - kafka
    #   - grafana
    #   - ssh
    #   - prometheus
    #   - datadog
    #   - stripe
    #   - redis
    #   - zabbix
    #   - opensearch
    #   - pingdom
    #   - github
    #   - terraform
    #   - airflow
    #   - hadoop
    #   - mssql
    #   - snowflake
    #   - splunk
    #   - salesforce
    #   - azure
    #   - nomad
    #   - netbox
    #   - opsgenie
  connector_types: []
    # Custom scripts to be run.
    # Not supported
  custom_scripts: []

#
# Scheduler section
#
# You can configure multiple schedules.
scheduler:
- enable: false
    # Cadence is specified in cron syntax. More information about the syntax can
    # be found in https://crontab.guru
    # minute  hour  day (of month)  month  day (of week)
    #   *      *          *           *        *
    # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  cadence: '*/60 * * * *'
    # Name of the job to add to the schedule
  job_name: ''

credential:
  aws:
  - name: awscreds
    enable: false
    auth_type: ''
    access_key: ''
    secret_access_key: ''
  gcp:
  - name: gcpcreds
    enable: false
    credentials: ''
  elasticsearch:
  - name: elasticsearchcreds
    enable: false
    host: ''
    username: ''
    password: ''
    api_key: ''
  grafana:
  - name: grafanacreds
    enable: false
    api_key: ''
    username: ''
    password: ''
    host: ''
  redis:
  - name: rediscreds
    enable: false
    db: ''
    host: ''
    username: ''
    password: ''
    port: ''
    use_ssl: false
  jenkins:
  - name: jenkinscreds
    enable: false
    url: ''
    user_name: ''
    password: ''
  github:
  - name: githubcreds
    enable: false
    token: ''
    hostname: ''
  netbox:
  - name: netboxcreds
    enable: false
    host: ''
    token: ''
    threading: false
  nomad:
  - name: nomadcreds
    enable: false
    host: ''
    timeout: ''
    token: ''
    verify_certs: false
    secure: false
    namespace: ''
  chatgpt:
  - name: chatgptcreds
    enable: false
    organization: ''
    api_token: ''
  opsgenie:
  - name: opsgeniecreds
    enable: false
    api_token: ''
  jira:
  - name: jiracreds
    enable: false
    url: ''
    email: ''
    api_token: ''
  k8s:
  - name: k8screds
    enable: false
    kubeconfig: ''
  kafka:
  - name: kafkacreds
    enable: false
    broker: ''
    sasl_username: ''
    sasl_password: ''
  mongodb:
  - name: mongodbcreds
    enable: false
    auth_type: ''
    atlas_public_key: ''
    atlas_private_key: ''
    user_name: ''
    password: ''
    host: ''
    port: ''
  mysql:
  - name: mysqlcreds
    enable: false
    DBName: ''
    User: ''
    Password: ''
    Host: ''
    Port: ''
  postgresql:
  - name: postgresqlcreds
    enable: false
    DBName: ''
    User: ''
    Password: ''
    Host: ''
    Port: ''
  rest:
  - name: restcreds
    enable: false
    base_url: ''
    username: ''
    password: ''
    headers: {}
  slack:
  - name: slackcreds
    enable: false
    bot_user_oauth_token: ''
  ssh:
  - name: sshcreds
    enable: false
    auth_type: ''
    password: ''
    proxy_password: ''
    private_key: ''
    proxy_private_key: ''
    vault_url: ''
    vault_secret_path: ''
    vault_role: ''
    user_with_realm: ''
    kdc_server: ''
    admin_server: ''
    port: ''
    username: ''
    proxy_host: ''
    proxy_user: ''
    proxy_port: ''
  salesforce:
  - name: salesforcecreds
    enable: false
    Username: ''
    Password: ''
    Security_Token: ''
  vault:
  - name: vaultcreds
    enable: false
    url: ''
    token: ''
    verify_ssl: false
  keycloak:
  - name: keycloakcreds
    enable: false
    server_url: ''
    realm: ''
    client_id: ''
    username: ''
    password: ''
    client_secret: ''
    verify: ''
```

[EN-5150]: https://unskript.atlassian.net/browse/EN-5150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ