### PR TITLE
Amit en 5152 multiple namespace

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -33,6 +33,8 @@ checks:
   arguments:
     global:
        region: us-west-2
+       matrix:
+         namespace: [n1, n2]
 
 # Credential section
 #
@@ -147,6 +149,7 @@ notification:
   Email:
     verbose: true #Not yet supported
     enable: false
+    email_subject_line: ""
     # provider for the email. Possible values:
     #    - SMTP - SMTP server
     #    - SES -  AWS SES
@@ -168,6 +171,7 @@ notification:
       api_key: ""
       to-email: ""
       from-email: ""
+
 #
 # Job section
 #
@@ -176,6 +180,7 @@ jobs:
   - name: "" # Unique name
     # The results of the job to be notified or not.
     notify: true
+    #notify_sink: foo
     enable: false
     # Specific checks to run
     # Not supported: multiple checks, only single check support for now.
@@ -220,7 +225,6 @@ jobs:
     #   - opsgenie
     connector_types: []
     # Custom scripts to be run.
-    # Not supported
     custom_scripts: []
 
 #

--- a/unskript-ctl/unskript_ctl.py
+++ b/unskript-ctl/unskript_ctl.py
@@ -284,7 +284,7 @@ def run_ipynb(filename: str, status_list_of_dict: list = None, filter: str = Non
         for output in outputs:
             r = output.get('text')
             r = output_after_merging_checks(r.split('\n'), ids)
-            print(f'new_output {r}, len_r {len(r)}, ids {ids}, len_ids  {len(ids)}')
+            #print(f'new_output {r}, len_r {len(r)}, ids {ids}, len_ids  {len(ids)}')
             for result in r:
                 if result.get('skip') and result.get('skip') is True:
                     idx += 1
@@ -364,7 +364,7 @@ def output_after_merging_checks(outputs: list, ids: list) -> list:
     # Remove empty strings
     filtered_output = []
     for output in outputs:
-        if output == '':
+        if not output:
             continue
         payload = json.loads(output)
         filtered_output.append(payload)
@@ -390,7 +390,7 @@ def output_after_merging_checks(outputs: list, ids: list) -> list:
             combined_output = calculate_combined_check_status(outputs[parent_index:index])
             # Combined output should be the output of the parent check, so
             # overwrite it.
-            print(f'parent_index {parent_index}, index {index}, combined_output {combined_output}')
+            #print(f'parent_index {parent_index}, index {index}, combined_output {combined_output}')
             new_outputs[parent_index] = combined_output
     return new_outputs
 
@@ -603,7 +603,7 @@ def create_checks_for_matrix_argument(checks: list):
                                         UNSKRIPT_GLOBALS["uuid_mapping"][new_uuid] = check["uuid"]
                                         newcheck['uuid'] = new_uuid
                                         newcheck['id'] = str(uuid.uuid4())[:8]
-                                        print(f'Adding duplicate check {new_uuid}, parent_uuid {check.get("uuid")}')
+                                        #print(f'Adding duplicate check {new_uuid}, parent_uuid {check.get("uuid")}')
                                     newcheck['matrixinputline'] = input_json_line.rstrip(',')
                                     checks_list.append(newcheck)
                                     is_first = False

--- a/unskript-ctl/unskript_ctl.py
+++ b/unskript-ctl/unskript_ctl.py
@@ -83,7 +83,7 @@ def load_or_create_global_configuration():
                 if config_yaml.get('checks').get('arguments').get('global'):
                     # Handle matrix
                     matrix = config_yaml.get('checks').get('arguments').get('global').get('matrix')
-                    if matrix != None:
+                    if matrix is not None:
                         UNSKRIPT_GLOBALS['matrix'] = matrix
                         UNSKRIPT_GLOBALS['uuid_mapping'] = {}
                     UNSKRIPT_GLOBALS['global'] = config_yaml.get('checks').get('arguments').get('global')
@@ -150,7 +150,7 @@ nbParamsObj = nbparams.NBParams(paramsJson)
     #   duplicated cells to show a uniform view.
     if UNSKRIPT_GLOBALS.get('matrix'):
         for k, v in UNSKRIPT_GLOBALS.get('matrix').items():
-            if v != None:
+            if v is not None:
                 for index, value in enumerate(v):
                     first_cell_content += f'{k}{index} = \"{value}\"' + '\n'
 
@@ -584,7 +584,7 @@ def create_checks_for_matrix_argument(checks: list):
                         duplicate_count = 1
                         if UNSKRIPT_GLOBALS.get('matrix'):
                             matrix_value = UNSKRIPT_GLOBALS.get('matrix').get(key)
-                            if matrix_value != None:
+                            if matrix_value is not None:
                                 duplicate_count += len(matrix_value)
                                 # Duplicate this check len(matrix_argument) times.
                                 # Also, for each check, you need to use a different

--- a/unskript-ctl/unskript_ctl.py
+++ b/unskript-ctl/unskript_ctl.py
@@ -319,8 +319,10 @@ def run_ipynb(filename: str, status_list_of_dict: list = None, filter: str = Non
         for output in outputs:
             r = output.get('text')
             r = output_after_merging_checks(r.split('\n'), ids)
+            print(f'new_output {r}, len_r {len(r)}, ids {ids}, len_ids  {len(ids)}')
             for result in r:
                 if result.get('skip') and result.get('skip') is True:
+                    idx += 1
                     continue
                 payload = result
                 try:
@@ -409,19 +411,22 @@ def output_after_merging_checks(outputs: list, ids: list) -> list:
     outputs = filtered_output
     if UNSKRIPT_GLOBALS.get('uuid_mapping') is None:
         return outputs
-    for index in range(len(outputs)):
+
+    index = 0
+    while index < len(outputs):
         if UNSKRIPT_GLOBALS['uuid_mapping'].get(ids[index]) is None:
-            new_outputs.append(payload)
+            new_outputs.append(outputs[index])
+            index = index+1
         else:
             parent_index = index - 1
             while index < len(outputs):
                 if UNSKRIPT_GLOBALS['uuid_mapping'].get(ids[index]):
-                    payload['skip'] = True
-                    new_outputs.append(payload)
+                    outputs[index]['skip'] = True
+                    new_outputs.append(outputs[index])
                     index = index + 1
                 else:
                     break
-            combined_output = calculate_combined_check_status(new_outputs[parent_index:index])
+            combined_output = calculate_combined_check_status(outputs[parent_index:index])
             # Combined output should be the output of the parent check, so
             # overwrite it.
             print(f'parent_index {parent_index}, index {index}, combined_output {combined_output}')

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -23,7 +23,7 @@ from unskript_utils import bcolors, UNSKRIPT_EXECUTION_DIR
 #)
 UNSKRIPT_CTL_CONFIG_FILE="/etc/unskript/unskript_ctl_config.yaml"
 UNSKRIPT_CTL_BINARY="/usr/local/bin/unskript-ctl.sh"
-UNSKRIPT_EXECUTION_DIR="/unskript/data/execution/"
+
 
 # Job config related
 JOB_CONFIG_CHECKS_KEY_NAME = "checks"
@@ -39,7 +39,18 @@ CREDENTIAL_CONFIG_SKIP_VALUE_FOR_ARGUMENTS = ["no-verify-certs", "no-verify-ssl"
 GLOBAL_CONFIG_AUDIT_PERIOD_KEY_NAME = "audit_period"
 GLOBAL_DEFAULT_AUDIT_PERIOD = 90
 
+# Checks section related
+CHECKS_ARGUMENTS_KEY_NAME = "arguments"
+CHECKS_GLOBAL_KEY_NAME = "global"
+CHECKS_MATRIX_KEY_NAME = "matrix"
 
+# Config top level keys
+CONFIG_GLOBAL = "global"
+CONFIG_CHECKS = "checks"
+CONFIG_CREDENTIAL = "credential"
+CONFIG_NOTIFICATION = "notification"
+CONFIG_JOBS = "jobs"
+CONFIG_SCHEDULER = "scheduler"
 
 class Job():
     def __init__(
@@ -127,7 +138,7 @@ class ConfigParser():
         print('###################################')
         print(f'{bcolors.HEADER}Processing global section{bcolors.ENDC}')
         print('###################################')
-        config = self.parsed_config.get('global')
+        config = self.parsed_config.get(CONFIG_GLOBAL)
         if config is None:
             print(f"{bcolors.WARNING}Global: Nothing to configure credential with, found empty creds data{bcolors.ENDC}")
             return
@@ -137,6 +148,31 @@ class ConfigParser():
         print(f'Global: audit period {audit_period} days')
         self.audit_period = audit_period
 
+    def parse_checks(self):
+        """parse_checks: This function parses the checks section of the config.
+        """
+        print('###################################')
+        print(f'{bcolors.HEADER}Processing checks section{bcolors.ENDC}')
+        print('###################################')
+        config = self.parsed_config.get(CONFIG_CHECKS)
+        if config is None:
+            print(f"{bcolors.WARNING}Checks: No checks config{bcolors.ENDC}")
+            return
+        arguments = config.get(CHECKS_ARGUMENTS_KEY_NAME)
+        if arguments is None:
+            print(f"{bcolors.WARNING}Checks: No arguments config{bcolors.ENDC}")
+            return
+        global_args = arguments.get(CHECKS_GLOBAL_KEY_NAME)
+        if global_args is None:
+            print(f"{bcolors.WARNING}Checks: No global config{bcolors.ENDC}")
+            return
+        # Ensure we atmost have ONLY one matrix argument
+        matrix_args = global_args.get(CHECKS_MATRIX_KEY_NAME)
+        if matrix_args is None:
+            return
+        if len(matrix_args) > 1:
+            print(f'{bcolors.FAIL} Only one matrix argument supported {bcolors.ENDC}')
+            return
 
     def configure_credential(self):
         """configure_credential: This function is used to parse through the creds_dict and
@@ -145,7 +181,7 @@ class ConfigParser():
         print('###################################')
         print(f'{bcolors.HEADER}Processing credential section{bcolors.ENDC}')
         print('###################################')
-        creds_dict = self.parsed_config.get('credential')
+        creds_dict = self.parsed_config.get(CONFIG_CREDENTIAL)
         if creds_dict is None:
             print(f"{bcolors.WARNING}Credential: Nothing to configure credential with, found empty creds data{bcolors.ENDC}")
             return
@@ -185,7 +221,7 @@ class ConfigParser():
         print('###################################')
         print(f'{bcolors.HEADER}Processing scheduler section{bcolors.ENDC}')
         print('###################################')
-        config = self.parsed_config.get('scheduler')
+        config = self.parsed_config.get(CONFIG_SCHEDULER)
         if config is None:
             print(f"{bcolors.WARNING}Scheduler: No scheduler configuration found{bcolors.ENDC}")
             return
@@ -247,7 +283,7 @@ class ConfigParser():
         print('###################################')
         print(f'{bcolors.HEADER}Processing jobs section{bcolors.ENDC}')
         print('###################################')
-        config = self.parsed_config.get('jobs')
+        config = self.parsed_config.get(CONFIG_JOBS)
         if config is None:
             print(f'{bcolors.WARNING}Jobs: No jobs config found{bcolors.ENDC}')
             return
@@ -298,6 +334,7 @@ def main():
     config_parser.parse_config_yaml()
 
     config_parser.parse_global()
+    config_parser.parse_checks()
     config_parser.configure_credential()
     config_parser.parse_jobs()
     config_parser.configure_schedule()


### PR DESCRIPTION
## Description

- Support for matrix arguments.
- Support for email subject line


### Testing
- Multiple namespace (lightbeam, unskript) run
```
╒════════════════════════════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                                            │ Result   │   Failed Count │ Error   │
╞════════════════════════════════════════════════════════╪══════════╪════════════════╪═════════╡
│ Get Kubernetes PODS with high restart                  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8S Service with no associated endpoints           │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check the status of K8s CronJob pods                   │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Error PODs from All Jobs                │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Detect K8s service crashes                             │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8s get pending pods                               │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get all K8s Pods in ImagePullBackOff State             │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8s services exceeding memory utilization          │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check K8s service PVC utilization                      │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8S Cluster Health                                 │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check K8s worker CPU Utilization                       │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get all K8s Pods in CrashLoopBackOff State             │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Nodes that have insufficient resources  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8s offline nodes                                  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check K8s services endpoint and SSL certificate health │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get expiring K8s certificates                          │  FAIL    │              2 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get frequently restarting K8s pods                     │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get All Evicted PODS From Namespace                    │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Failed Deployments                      │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Deployment Status                                  │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get all K8s Pods in Terminating State                  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes PODs in not Running State               │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8S OOMKilled Pods                                 │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Unbound PVCs                            │  PASS    │              0 │ N/A     │
╘════════════════════════════════════════════════════════╧══════════╧════════════════╧═════════╛


FAILED RESULTS

k8s:Get K8S Service with no associated endpoints
Failed Objects:
[[{'name': 'lightbeam-kafka-zookeeper-metrics', 'namespace': 'lightbeam'}]]

k8s:Check the status of K8s CronJob pods
Failed Objects:
[{'NotAssociated': [],
  'Pending': [],
  'UnexpectedState': [{'namespace': 'lightbeam',
                       'pod_name': 'lightbeam-mongo-aggr-28321529-sg57j',
                       'state': 'Pending'}]}]

k8s:Get Kubernetes Error PODs from All Jobs
Failed Objects:
[[{'namespace': 'lightbeam',
   'pod_name': 'lightbeam-mongo-aggr-28321529-sg57j'}]]

k8s:Get K8s get pending pods
Failed Objects:
[[['lightbeam-policy-consumer-65d546cc4d-x6nsx', 'lightbeam']]]

k8s:Get all K8s Pods in ImagePullBackOff State
Failed Objects:
[[{'lightbeam': ['lightbeam-policy-consumer-65d546cc4d-x6nsx']}]]

k8s:Get K8S Cluster Health
Failed Objects:
[{'abnormal_nodes': [],
  'not_ready_nodes': [],
  'not_ready_pods': [{'condition_message': 'containers with unready status: '
                                           '[lightbeam-policy-consumer]',
                      'condition_reason': 'ContainersNotReady',
                      'condition_status': 'False',
                      'condition_type': 'Ready',
                      'name': 'lightbeam-policy-consumer-65d546cc4d-x6nsx',
                      'namespace': 'lightbeam'},
                     {'condition_message': 'containers with unready status: '
                                           '[mongodb]',
                      'condition_reason': 'ContainersNotReady',
                      'condition_status': 'False',
                      'condition_type': 'Ready',
                      'name': 'mongodb-0',
                      'namespace': 'unskript'}]}]

k8s:Check K8s services endpoint and SSL certificate health
Failed Objects:
[{'Error': 'No endpoints specified.'}]

k8s:Get expiring K8s certificates
Failed Objects:
[[{'namespace': 'lightbeam', 'secret_name': 'lb-https-secret'},
  {'namespace': 'lightbeam', 'secret_name': 'lbdemoeg'},
  {'namespace': 'lightbeam', 'secret_name': 'vault-tls-server'}],
 [{'namespace': 'unskript', 'secret_name': 'lbdemoeg'},
  {'namespace': 'unskript', 'secret_name': 'lbunskript'},
  {'namespace': 'unskript', 'secret_name': 'lbunskript1'},
  {'namespace': 'unskript', 'secret_name': 'letsencrypt-cert-unskript'},
  {'namespace': 'unskript', 'secret_name': 'unskript-proxy'}]]

k8s:Get Deployment Status
Failed Objects:
[[{'deployment_name': 'lightbeam-policy-consumer', 'namespace': 'lightbeam'}]]

k8s:Get Kubernetes PODs in not Running State
Failed Objects:
[[{'name': 'kong-migrations-sfdcb', 'namespace': 'lightbeam'}]]
```
You can see some of the checks failed in unskript too.

- Single namespace run
```
════════════════════════════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                                            │ Result   │   Failed Count │ Error   │
╞════════════════════════════════════════════════════════╪══════════╪════════════════╪═════════╡
│ Get Kubernetes PODS with high restart                  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8S Service with no associated endpoints           │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check the status of K8s CronJob pods                   │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Error PODs from All Jobs                │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Detect K8s service crashes                             │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8s get pending pods                               │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get all K8s Pods in ImagePullBackOff State             │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8s services exceeding memory utilization          │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check K8s service PVC utilization                      │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8S Cluster Health                                 │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check K8s worker CPU Utilization                       │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get all K8s Pods in CrashLoopBackOff State             │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Nodes that have insufficient resources  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8s offline nodes                                  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Check K8s services endpoint and SSL certificate health │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get expiring K8s certificates                          │  FAIL    │              3 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get frequently restarting K8s pods                     │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get All Evicted PODS From Namespace                    │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Failed Deployments                      │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Deployment Status                                  │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get all K8s Pods in Terminating State                  │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes PODs in not Running State               │  FAIL    │              1 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get K8S OOMKilled Pods                                 │  PASS    │              0 │ N/A     │
├────────────────────────────────────────────────────────┼──────────┼────────────────┼─────────┤
│ Get Kubernetes Unbound PVCs                            │  PASS    │              0 │ N/A     │
╘════════════════════════════════════════════════════════╧══════════╧════════════════╧═════════╛


FAILED RESULTS

k8s:Get K8S Service with no associated endpoints
Failed Objects:
[{'name': 'lightbeam-kafka-zookeeper-metrics', 'namespace': 'lightbeam'}]

k8s:Get K8s get pending pods
Failed Objects:
[['lightbeam-policy-consumer-65d546cc4d-x6nsx', 'lightbeam']]

k8s:Get all K8s Pods in ImagePullBackOff State
Failed Objects:
[{'lightbeam': ['lightbeam-policy-consumer-65d546cc4d-x6nsx']}]

k8s:Get K8S Cluster Health
Failed Objects:
[{'abnormal_nodes': [],
  'not_ready_nodes': [],
  'not_ready_pods': [{'condition_message': 'containers with unready status: '
                                           '[lightbeam-policy-consumer]',
                      'condition_reason': 'ContainersNotReady',
                      'condition_status': 'False',
                      'condition_type': 'Ready',
                      'name': 'lightbeam-policy-consumer-65d546cc4d-x6nsx',
                      'namespace': 'lightbeam'},
                     {'condition_message': 'containers with unready status: '
                                           '[mongodb]',
                      'condition_reason': 'ContainersNotReady',
                      'condition_status': 'False',
                      'condition_type': 'Ready',
                      'name': 'mongodb-0',
                      'namespace': 'unskript'}]}]

k8s:Check K8s services endpoint and SSL certificate health
Failed Objects:
[{'Error': 'No endpoints specified.'}]

k8s:Get expiring K8s certificates
Failed Objects:
[{'namespace': 'lightbeam', 'secret_name': 'lb-https-secret'},
 {'namespace': 'lightbeam', 'secret_name': 'lbdemoeg'},
 {'namespace': 'lightbeam', 'secret_name': 'vault-tls-server'}]

k8s:Get Deployment Status
Failed Objects:
[{'deployment_name': 'lightbeam-policy-consumer', 'namespace': 'lightbeam'}]

k8s:Get Kubernetes PODs in not Running State
Failed Objects:
[{'name': 'kong-migrations-sfdcb', 'namespace': 'lightbeam'}]
```
### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
