### PR TITLE
multiple script support

### DIFF
--- a/unskript-ctl/README.md
+++ b/unskript-ctl/README.md
@@ -1,37 +1,74 @@
 # unSkript CLI
 
-With `unskript-ctl.sh` (called unSkript cuttle) allows you to
-  * List Existing Runbook
-  * List All Existing Health Checks
-  * List All Existing Health Check per connector
-  * Run All Existing Health Checks 
-  * Run All Existing Health Checks per connector
-  * Run an existing Runbook
 
+unskript-ctl is a command line tool which allows you to run checks against your
+resources, be it infrastructure or your own services.
 
-Here are the Options that are supported by the CTL Command
+Here are the options that are supported by the uskript-ctl command
 ```
-unskript-ctl.sh 
-usage: unskript-ctl [-h] [-lr] [-rr RUN_RUNBOOK] [-rc RUN_CHECKS] [-df DISPLAY_FAILED_CHECKS] [-lc LIST_CHECKS] [-sa SHOW_AUDIT_TRAIL]
+unskript-ctl.sh
+usage: unskript-ctl [-h] [-l ...] [-r ...] [-s ...] [-d ...] [--create-credential ...]
 
 Welcome to unSkript CLI Interface VERSION: 0.1.0
 
 optional arguments:
   -h, --help            show this help message and exit
-  -lr, --list-runbooks  List Available Runbooks
-  -rr RUN_RUNBOOK, --run-runbook RUN_RUNBOOK
-                        Run the given runbook
-  -rc RUN_CHECKS, --run-checks RUN_CHECKS
-                        Run all available checks [all | connector | failed]
-  -df DISPLAY_FAILED_CHECKS, --display-failed-checks DISPLAY_FAILED_CHECKS
-                        Display Failed Checks [all | connector]
-  -lc LIST_CHECKS, --list-checks LIST_CHECKS
-                        List available checks, [all | connector]
-  -sa SHOW_AUDIT_TRAIL, --show-audit-trail SHOW_AUDIT_TRAIL
-                        Show audit trail [all | connector | execution_id]
+  -l ..., --list ...    List Options
+  -r ..., --run ...     Run Options
+  -s ..., --show ...    Show Options
+  -d ..., --debug ...   Debug Options
+  --create-credential ...
+                        Create Credential [-creds-type creds_file_path]
 ```
 
- # unskript-ctl Actions 
+## List options
+```
+usage: unskript_ctl.py [-h] [-r] [--failed-checks ...] [-c ...] [--credential]
 
-* [Db utils.py](https://github.com/unskript/Awesome-CloudOps-Automation/tree/master/unskript-ctl/legos/db_utils) 
-* [Unskript client.py](https://github.com/unskript/Awesome-CloudOps-Automation/tree/master/unskript-ctl/legos/unskript-client) 
+optional arguments:
+  -h, --help            show this help message and exit
+  -r, --runbooks        List Runbooks
+  --failed-checks ...   List Failed checks
+  -c ..., --checks ...  List Checks
+  --credential          List Credential
+```
+
+## Run options
+Using the **--run** option, you can run check(s), scripts and runbooks.
+Also, if you want to get the report of the run in an email or slack, you can
+use the **--report** option.
+
+```
+usage: unskript_ctl.py [-h] [--script SCRIPT] [--runbook [RUNBOOK ...]] [--check [CHECK ...]] [--report]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --script SCRIPT       Run script
+  --runbook [RUNBOOK ...]
+                        Run the given runbook FILENAME [-RUNBOOK_PARM1 VALUE1] etc..
+  --check [CHECK ...]   Run checks
+  --report              Report results
+```
+
+## Show options
+```
+usage: unskript_ctl.py [-h] [--audit-trail ...] [--failed-logs ...]
+
+optional arguments:
+  -h, --help         show this help message and exit
+  --audit-trail ...  Show Audit Trail
+  --failed-logs ...  Show Failed Logs
+```
+
+## Debug options
+
+Using the **--debug** option, you can connect this pod to the upstream VPN
+server, so that you can access this pod from the control unSkript portal.
+```
+usage: unskript_ctl.py [-h] [--start ...] [--stop]
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --start ...  Start debug session. Example [--start --config /tmp/config.ovpn]
+  --stop       Stop current debug session
+```

--- a/unskript-ctl/unskript_ctl.py
+++ b/unskript-ctl/unskript_ctl.py
@@ -1446,7 +1446,7 @@ def run_script(script:list[str]):
     - Stores the output of the script in a file
     - Creates a json for the run, containing some metadata about the script.
     """
-    parser = ArgumentParser(description='--run-script')
+    parser = ArgumentParser(description='--script')
     parser.add_argument('-r',
                         '--run',
                         required=True,
@@ -1477,17 +1477,17 @@ def run_script(script:list[str]):
         sys.exit(0)
 
     # Do the basic sanity check like file exists and has required permission
-    if not os.path.exists(script[0]):
-        print(f'''
-            {bcolors.FAIL}{script[0]} does not exist. Please ensure that you
-            provide the full path. {bcolors.ENDC}
-            ''')
-        return
+    #if not os.path.exists(script[0]):
+    #    print(f'''
+    #        {bcolors.FAIL}{script[0]} does not exist. Please ensure that you
+    #        provide the full path. {bcolors.ENDC}
+    #        ''')
+    #    return
 
-    accessmode = os.F_OK | os.X_OK
-    if not os.access(script[0], accessmode):
-        print(f'{bcolors.FAIL}{script[0]} is not executable. {bcolors.ENDC}')
-        return
+    #accessmode = os.F_OK | os.X_OK
+    #if not os.access(script[0], accessmode):
+    #    print(f'{bcolors.FAIL}{script[0]} is not executable. {bcolors.ENDC}')
+    #    return
 
     if not UNSKRIPT_GLOBALS.get('CURRENT_EXECUTION_RUN_DIRECTORY'):
         # Use the first command as the prefix for the file name.
@@ -1518,6 +1518,7 @@ def run_script(script:list[str]):
             result = subprocess.run(script,
                                     check=True,
                                     env=current_env,
+                                    shell=True,
                                     stdout=f,
                                     stderr=f)
     except Exception as e:

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -73,7 +73,7 @@ class Job():
         notify = '--report' if self.notify is True else ''
         #TBD: Add support for custom_scripts
         if self.checks is not None and len(self.checks) != 0:
-            cmds.append(f'{UNSKRIPT_CTL_BINARY} -rc --check {self.checks[0]} {notify}')
+            cmds.append(f'{UNSKRIPT_CTL_BINARY} -r --check --name {self.checks[0]} {notify}')
             print(f'Job: {self.job_name} contains check: {self.checks[0]}')
 
         if self.connectors is not None and len(self.connectors) != 0:
@@ -81,26 +81,28 @@ class Job():
             # unskript-ctl.sh -rc --types aws,k8s
             connector_types_string = ','.join(self.connectors)
             print(f'Job: {self.job_name} contains connector types: {connector_types_string}')
-            cmds.append(f'{UNSKRIPT_CTL_BINARY} -rc --type {connector_types_string} {notify}')
+            cmds.append(f'{UNSKRIPT_CTL_BINARY} -r --check --type {connector_types_string} {notify}')
 
         accessmode = os.F_OK | os.X_OK
         if self.custom_scripts is not None and len(self.custom_scripts) != 0:
             # Do basic checks, like the binary exists, permission is fine.
             filtered_scripts = []
-            for script in self.custom_scripts:
-                if not os.path.exists(script[0]):
-                    print(f'''{bcolors.FAIL}{script[0]} does not exist. Please ensure that you
-                         provide the full path. {bcolors.ENDC}
-                        ''')
-                    continue
-                if not os.access(script[0], accessmode):
-                    print(f'{bcolors.FAIL}{script[0]} is not executable. {bcolors.ENDC}')
-                    continue
-                filtered_scripts.append(script)
+            filtered_scripts = self.custom_scripts
+            #for script in self.custom_scripts:
+            #    command = script.split(' ')
+            #    if not os.path.exists(command[0]):
+            #        print(f'''{bcolors.FAIL}{command[0]} does not exist. Please ensure that you
+            #             provide the full path. {bcolors.ENDC}
+            #            ''')
+            #        continue
+            #    if not os.access(command, accessmode):
+            #        print(f'{bcolors.FAIL}{command} is not executable. {bcolors.ENDC}')
+            #        continue
+            #    filtered_scripts.append(script)
             if filtered_scripts:
                 combined_script = ';'.join(filtered_scripts)
                 print(f'Job: {self.job_name} contains custom script: {combined_script}')
-                cmds.append(f'{UNSKRIPT_CTL_BINARY} --run-script {notify} --script {combined_script}')
+                cmds.append(f'{UNSKRIPT_CTL_BINARY} -r --script "{combined_script}" {notify}')
         self.cmds = cmds
 
 class ConfigParser():


### PR DESCRIPTION
## Description
Support for multiple scripts

### Testing
One bad command and one good
```
(base) root@7ad279f11993:~# /usr/local/bin/unskript-ctl.sh -r --script "lf -p; df -kh"
Executing script lf -p; df -kh
OUTPUT FILE: /unskript/data/execution/unskript_script_run_output-2023-11-07T06_08_29.881419/unskript_script_run_output.txt
(base) root@7ad279f11993:~# cat /unskript/data/execution/unskript_script_run_output-2023-11-07T06_08_29.881419/unskript_script_run_output.txt
/bin/sh: 1: lf: not found
Filesystem      Size  Used Avail Use% Mounted on
overlay          59G   36G   20G  65% /
tmpfs            64M     0   64M   0% /dev
tmpfs           3.0G     0  3.0G   0% /sys/fs/cgroup
shm              64M     0   64M   0% /dev/shm
/dev/vda1        59G   36G   20G  65% /etc/hosts
tmpfs           3.0G     0  3.0G   0% /proc/acpi
tmpfs           3.0G     0  3.0G   0% /sys/firmware
```

order change of bad and good
```
(base) root@7ad279f11993:~# /usr/local/bin/unskript-ctl.sh -r --script "ls -l; dl -kh"
Executing script ls -l; dl -kh
OUTPUT FILE: /unskript/data/execution/unskript_script_run_output-2023-11-07T06_09_17.008597/unskript_script_run_output.txt
ls -l; dl -kh failed, Command '['ls -l; dl -kh']' returned non-zero exit status 127.
(base) root@7ad279f11993:~# cat /unskript/data/execution/unskript_script_run_output-2023-11-07T06_09_17.008597/unskript_script_run_output.txt
total 165896
-rw-r--r-- 1 root root       40435 Nov  6 06:55 add_creds.py
-rwxr-xr-x 1 root root         382 Nov  6 06:55 add_creds.sh
lrwxrwxrwx 1 root root          37 Nov  6 06:57 aws -> /usr/local/aws-cli/v2/current/bin/aws
lrwxrwxrwx 1 root root          47 Nov  6 06:57 aws_completer -> /usr/local/aws-cli/v2/current/bin/aws_completer
-rwxr-xr-x 1 root root        6347 Nov  6 06:55 bash_completion_unskript_ctl.bash
-rw-r--r-- 1 root root       51895 Nov  6 06:55 creds_ui.py
-rw-r--r-- 1 root root        9187 Nov  6 06:55 db_utils.py
-rw-r--r-- 1 root root         986 Nov  6 06:55 dummy.py
-rwxr-xr-x 1 root root        1034 Aug 16  2021 fix-permissions
-rwxr-xr-x 1 root root    51220480 Nov  6 06:57 helm
-rwxr-xr-x 1 1001     123 59002880 Dec 15  2022 helmfile
-rwxr-xr-x 1 root root    46587904 Dec 16  2021 kubectl
-rwxr-xr-x 1 root root        4790 Nov  6 06:58 kubectl-node_shell
drwxr-xr-x 2 root root        4096 Nov  7 05:52 __pycache__
-rwxr-xr-x 1 root root         729 Aug 16  2021 start-notebook.sh
-rwxr-xr-x 1 root root        6023 Aug 16  2021 start.sh
-rwxr-xr-x 1 root root        1309 Aug 16  2021 start-singleuser.sh
-rw-r--r-- 1 root root        6280 Nov  6 06:55 stub_creds.json
-rw-r--r-- 1 root root        4208 Nov  6 06:55 unskript-add-check.py
-rw-r--r-- 1 root root        2476 Nov  6 06:55 unskript_audit_cleanup.py
-rw-r--r-- 1  501 dialout    15029 Nov  7 05:53 unskript_ctl_config_parser.py
-rw-r--r-- 1 root root        4145 Nov  6 06:55 unskript_ctl_debug.py
-rw-r--r-- 1 root root       27103 Nov  6 06:55 unskript_ctl_gen_report.py
-rw-r--r-- 1 root root        9778 Nov  6 06:55 unskript_ctl_list.py
-rwxr-xr-x 1  501 dialout    63501 Nov  7 05:52 unskript_ctl.py
-rwxr-xr-x 1 root root         189 Nov  6 06:55 unskript-ctl.sh
-rw-r--r-- 1 root root        8233 Nov  6 06:55 unskript_ctl_show.py
-rw-r--r-- 1 root root        3765 Nov  6 06:55 unskript_utils.py
-rwxr-xr-x 1 root root    12736790 Jan 14  2023 yq
/bin/sh: 1: dl: not found
```


Verified that the cronjob and report also work

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
