### PR TITLE
Fix: Decode key for Redis large keys check

### DIFF
--- a/Redis/legos/redis_list_large_keys/redis_list_large_keys.py
+++ b/Redis/legos/redis_list_large_keys/redis_list_large_keys.py
@@ -43,13 +43,12 @@ def redis_list_large_keys(handle, size_in_bytes: int = 500) -> Tuple :
     """
     try:
         result = []
-        large_keys = {}
         keys = handle.keys('*')
         for key in keys:
             value = handle.memory_usage(key)
             if value > int(size_in_bytes):
-                large_keys[key]= value
-                result.append(large_keys)
+                large_key = {key.decode('utf-8'): value}
+                result.append(large_key)
     except Exception as e:
         raise e
     if result:


### PR DESCRIPTION
## Description
Decode key from bytes to a string before using it as a key in dict as it is not serializable.

### Testing
<img width="769" alt="Screenshot 2023-11-09 at 11 53 12 AM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/cd2dc985-1b21-41d8-8b6a-8254ebc8e196">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
