### PR TITLE
Seperating out detect service crash as separate PR

### DIFF
--- a/Kubernetes/legos/k8s_detect_service_crashes/k8s_detect_service_crashes.py
+++ b/Kubernetes/legos/k8s_detect_service_crashes/k8s_detect_service_crashes.py
@@ -4,8 +4,6 @@
 #
 from typing import Optional, Tuple
 from pydantic import BaseModel, Field
-from kubernetes import client
-from kubernetes.client.rest import ApiException
 from tabulate import tabulate 
 import json
 
@@ -33,12 +31,13 @@ def k8s_detect_service_crashes_printer(output):
         print(tabulate(table_data, headers=headers, tablefmt="grid"))
 
 
+
 def k8s_detect_service_crashes(handle, namespace: str = '', tail_lines: int = 100) -> Tuple:
     """
     k8s_detect_service_crashes detects service crashes by checking the logs of each pod for specific error messages.
 
-    :type handle: Object
-    :param handle: Object returned from the task.validate(...) function
+    :type handle: object
+    :param handle: Object returned from the task.validate(...)
 
     :type namespace: str
     :param namespace: (Optional) String, K8S Namespace as python string
@@ -49,57 +48,72 @@ def k8s_detect_service_crashes(handle, namespace: str = '', tail_lines: int = 10
     :rtype: Status, List of objects of pods, namespaces that might have crashed along with the timestamp
     """
     ERROR_PATTERNS = [
-    "Worker exiting",
-    "Exception",
-    "Exception in worker process"
-    # Add more error patterns here as necessary
+        "Worker exiting",
+        "Exception",
+        "Exception in worker process"
+        # Add more error patterns here as necessary
     ]
     crash_logs = []
 
-    if handle.client_side_validation is not True:
-        raise ApiException(f"K8S Connector is invalid {handle}")
+    # If namespace not provided, assume it to be the default namespace
+    if not namespace:
+        namespace = "default"
 
-    v1 = client.CoreV1Api(api_client=handle) 
+    get_services_command = f"kubectl get svc -n {namespace} -o=jsonpath={{.items[*].metadata.name}}"
+    try:
+        # Execute the kubectl command to get service names
+        response = handle.run_native_cmd(get_services_command)
+        service_names = response.stdout.strip().split()
+    except Exception as e:
+        raise Exception(f"Error fetching service names: {e.stderr}") from e
 
-    namespaces_to_check = [namespace] if namespace else [ns.metadata.name for ns in v1.list_namespace().items]
+    if not isinstance(service_names, list):
+        service_names = [service_names]
 
-    for ns in namespaces_to_check:
-
-        # Get all services in the namespace
-        get_all_services_command = f"kubectl get svc -n {ns} -o=jsonpath='{{.items[*].metadata.name}}'"
-        response = handle.run_native_cmd(get_all_services_command)
-        if not response or response.stderr:
-            raise ApiException(f"Error fetching services in namespace {ns}: {response.stderr if response else 'empty response'}")
-        services_to_check = response.stdout.strip().split()
-
-        for svc in services_to_check:
-
-            # Get service's pod based on its labels
-            get_service_labels_command = f"kubectl get service {svc} -n {ns} -o=jsonpath='{{.spec.selector}}'"
+    visited_pods = []
+    for service_name in service_names:
+        # Get service's pod based on its labels
+        get_service_labels_command = f"kubectl get service {service_name} -n {namespace} -o=jsonpath={{.spec.selector}}"
+        try:
+            # Execute the kubectl command to get service labels
             response = handle.run_native_cmd(get_service_labels_command)
             if not response.stdout.strip():
-                # No labels found for a particular service. Skipping... 
+                # No labels found for a particular service. Skipping...
                 continue
             labels_dict = json.loads(response.stdout.replace("'", "\""))
             label_selector = ",".join([f"{k}={v}" for k, v in labels_dict.items()])
+        except Exception as e:
+            raise Exception(f"Error while fetching labels for service {service_name}: {e.stderr}") from e
 
-            # Fetch the pod attached to this service
-            get_pod_command = f"kubectl get pods -n {ns} -l {label_selector} -o=jsonpath='{{.items[0].metadata.name}}'"
-            response = handle.run_native_cmd(get_pod_command)
-            if not response or response.stderr:
-                raise ApiException(f"Error while executing command ({get_pod_command}): {response.stderr if response else 'empty response'}")
-            pod_name = response.stdout.strip()
+        # Fetch the pod attached to this service along and its container
+        pod_and_container_cmd = f"kubectl get pods -n {namespace} -l {label_selector}" + " -o=jsonpath=\"{range .items[*]}{.metadata.name}:{range .spec.containers[*]}{.name}{' '}{end}{end}\""
+        try:
+            # Execute the kubectl command to get pod name
+            response = handle.run_native_cmd(pod_and_container_cmd)
+            if not response.stdout.strip():
+                # No pods found for a particular service. Skipping...
+                continue
+            pod_name_with_container = response.stdout.strip()
+        except Exception as e:
+            raise Exception(f"Error while fetching pod for service {service_name}: {e.stderr}") from e
 
-            # Get the full pod object
-            try:
-                pod = v1.read_namespaced_pod(name=pod_name, namespace=ns)
-            except ApiException as e:
-                raise ApiException(f"Error fetching pod {pod_name} in namespace {ns}: {str(e)}")
+        p_and_c_list = []
+        if not isinstance(pod_name_with_container, list):
+            if len(pod_name_with_container.split(':')) > 2:
+                for pc in pod_name_with_container.split(' '):
+                    p_and_c_list.append(pc)
+            else:
+                p_and_c_list = [pod_name_with_container]
 
+        for pod_and_container in p_and_c_list:
+            pod_name, container = pod_and_container.split(':')
+            if pod_name in visited_pods:
+                continue
+
+            visited_pods.append(pod_name)
             # Fetch and analyze logs for the given pod
-            containers = [c.name for c in pod.spec.containers]
-            for container_name in containers:
-                log_cmd = f"kubectl logs {pod_name} -n {ns} -c {container_name} --tail={tail_lines}"
+            for c in container.split(' '):
+                log_cmd = f"kubectl logs {pod_name} -c {c} -n {namespace} --tail={tail_lines}"
                 try:
                     response = handle.run_native_cmd(log_cmd)
                     if response and not response.stderr:
@@ -110,11 +124,11 @@ def k8s_detect_service_crashes(handle, namespace: str = '', tail_lines: int = 10
                                     timestamp = line.split(']')[0].strip('[').split()[0] if ']' in line else "Unknown Time"
                                     crash_logs.append({
                                         "pod": pod_name,
-                                        "namespace": ns,
+                                        "namespace": namespace,
                                         "error": pattern,
                                         "timestamp": timestamp,
                                     })
                 except Exception as e:
-                    print(f"Error while fetching logs for pod {pod_name} container {container_name}: {str(e)}")
+                    print(f"Error while fetching logs for pod {pod_name}: {e}")
 
     return (False, crash_logs) if crash_logs else (True, None)


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

```
(base) root@awesome-awesome-runbooks-0:~/checks# python ./k8s_detect_service_crashes_new.py 
Using incluster config
POD kafka-ui-558c57f65f-6cxt7 CONTAINER kafka-ui
POD ingress-kong-69fdcf9b7c-x2j4t CONTAINER proxy
POD ingress-kong-69fdcf9b7c-x2j4t CONTAINER ingress-controller
POD lb-argo-workflows-server-5dd6b9956b-57h9s CONTAINER argo-server
POD lb-kafka-connect-5c6846cdbd-jkx2k CONTAINER kafka-connect
POD lb-keycloak-0 CONTAINER keycloak
POD lb-redis-master-0 CONTAINER redis
POD lb-redis-replicas-0 CONTAINER redis
POD lb-redis-replicas-1 CONTAINER redis
POD lb-redis-replicas-2 CONTAINER redis
POD lb-vault-0 CONTAINER vault
POD lb-vault-0 CONTAINER vault-unseal
POD lightbeam-api-gateway-5cdfb4b69-bqr8w CONTAINER lightbeam-api-gateway
POD lightbeam-datahub-gms-7b68f6fc7f-j8bm4 CONTAINER lightbeam-datahub-gms
POD lightbeam-datahub-gms-graphql-6b47fcd8ff-nh4vw CONTAINER lightbeam-datahub-gms-graphql
POD lightbeam-elasticsearch-master-0 CONTAINER elasticsearch
POD lightbeam-files-service-69bf959f5c-c688m CONTAINER lightbeam-files-service
POD lightbeam-frontend-6c7d59d869-55n8s CONTAINER lightbeam-frontend
POD lightbeam-kafka-0 CONTAINER lightbeam-kafka
POD lightbeam-kafka-exporter-0 CONTAINER metrics
POD lightbeam-kafka-zookeeper-0 CONTAINER zookeeper
POD lightbeam-minio-6cf5844654-vlvsv CONTAINER minio
POD lightbeam-mongodb-arbiter-0 CONTAINER lightbeam-mongodb-arbiter
POD lightbeam-mongodb-0 CONTAINER lightbeam-mongodb
POD lightbeam-policy-engine-76d5667bf8-mxfv4 CONTAINER lightbeam-policy-engine
POD lightbeam-presidio-server-7c89f7f4bd-xhqdr CONTAINER lightbeam-presidio-server
POD prometheus-lb-prometheus-0 CONTAINER prometheus
POD prometheus-lb-prometheus-0 CONTAINER config-reloader
POD lightbeam-prometheus-pushgateway-6c4cf77496-l96f2 CONTAINER pushgateway
POD lightbeam-qdrant-0 CONTAINER qdrant
POD lightbeam-report-engine-65dfdd5c7-gr4w4 CONTAINER lightbeam-report-engine
POD lightbeam-schema-registry-694887697d-vclw8 CONTAINER lightbeam-schema-registry-server
POD lightbeam-text-extraction-7cf9f6c8b9-c9qp9 CONTAINER lightbeam-text-extraction
POD lightbeam-text-extraction-7cf9f6c8b9-c9qp9 CONTAINER lightbeam-pdf-converter
POD lightbeam-tika-server-75485bf8fd-rvdm5 CONTAINER lightbeam-tika-server
POD postgres-0 CONTAINER metrics
POD postgres-0 CONTAINER postgres
POD vault-agent-injector-6c7d69ff46-llbwm CONTAINER sidecar-injector
No detected errors in the logs of the pods.
((True, None), '')
```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
