### PR TITLE
remote debugging schedule option

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -241,3 +241,24 @@ scheduler:
     cadence: "*/60 * * * *"
     # Name of the job to add to the schedule
     job_name: ""
+
+remote_debugging:
+  enable: false
+  # ovpn file location
+  ovpn_file: ""
+  # Cadence at which tunnel needs to be brought up.
+  # Cadence is specified in cron syntax. More information about the syntax can
+  # be found in https://crontab.guru
+  # minute  hour  day (of month)  month  day (of week)
+  #   *      *          *           *        *
+  # Example: "*/30 * * * *"   <= This will run every 30 Minutes
+  #
+  tunnel_up_cadence: ""
+  # Cadence at which tunnel needs to be brought down.
+  # Cadence is specified in cron syntax. More information about the syntax can
+  # be found in https://crontab.guru
+  # minute  hour  day (of month)  month  day (of week)
+  #   *      *          *           *        *
+  # Example: "*/30 * * * *"   <= This will run every 30 Minutes
+  #
+  tunnel_down_cadence: ""


### PR DESCRIPTION
## Description
Added support for scheduling remote debugging.

### Testing
```
remote_debugging:
  enable: true
  # ovpn file location
  ovpn_file: "/tmp/client-abc.ovpn"
  # Cadence at which tunnel needs to be brought up.
  # Cadence is specified in cron syntax. More information about the syntax can
  # be found in https://crontab.guru
  # minute  hour  day (of month)  month  day (of week)
  #   *      *          *           *        *
  # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  #
  tunnel_up_cadence: "42 23 * * *"
  # Cadence at which tunnel needs to be brought down.
  # Cadence is specified in cron syntax. More information about the syntax can
  # be found in https://crontab.guru
  # minute  hour  day (of month)  month  day (of week)
  #   *      *          *           *        *
  # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  tunnel_down_cadence: "43 23 * * *"
  #
```

Related crontab entry
```
0 0 * * * /opt/conda/bin/python /usr/local/bin/unskript_audit_cleanup.py
42 23 * * * /usr/local/bin/unskript-ctl.sh --debug --start --config /tmp/client-abc.ovpn
43 23 * * * /usr/local/bin/unskript-ctl.sh --debug --stop
```





### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
