### PR TITLE
Fixed config parser and debug option

### DIFF
--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -73,7 +73,7 @@ class Job():
         cmds = []
         notify = '--report' if self.notify is True else ''
         # Today, we dont support
-        # --check --name <> --check --type k8s --script
+        # check --name <> check --type k8s --script
         # So, if both check names and types are configured, we will split it
         # into 2 commands.
         # We will combine script with --types and make the --name as separate
@@ -87,25 +87,25 @@ class Job():
             combine_check_names_and_script = False
             combine_check_types_and_script = True
 
-        # full_command will contain the full command if both --check and --script
+        # full_command will contain the full command if both check and --script
         # are specified.
         full_command = None
         if self.checks is not None and len(self.checks) != 0:
             if combine_check_names_and_script:
-                full_command = f'{UNSKRIPT_CTL_BINARY} -r --check --name {self.checks[0]}'
+                full_command = f'{UNSKRIPT_CTL_BINARY} run check --name {self.checks[0]}'
             else:
-                cmds.append(f'{UNSKRIPT_CTL_BINARY} -r --check --name {self.checks[0]} {notify}')
+                cmds.append(f'{UNSKRIPT_CTL_BINARY} run check --name {self.checks[0]} {notify}')
             print(f'Job: {self.job_name} contains check: {self.checks[0]}')
 
         if self.connectors is not None and len(self.connectors) != 0:
             # Need to construct the unskript-ctl command like
-            # unskript-ctl.sh -rc --types aws,k8s
+            # unskript-ctl.sh run check --types aws,k8s
             connector_types_string = ','.join(self.connectors)
             print(f'Job: {self.job_name} contains connector types: {connector_types_string}')
             if combine_check_types_and_script:
-                full_command = f'{UNSKRIPT_CTL_BINARY} -r --check --type {connector_types_string}'
+                full_command = f'{UNSKRIPT_CTL_BINARY} run check --type {connector_types_string}'
             else:
-                cmds.append(f'{UNSKRIPT_CTL_BINARY} -r --check --type {connector_types_string} {notify}')
+                cmds.append(f'{UNSKRIPT_CTL_BINARY} run check --type {connector_types_string} {notify}')
 
         accessmode = os.F_OK | os.X_OK
         if self.custom_scripts is not None and len(self.custom_scripts) != 0:
@@ -129,7 +129,7 @@ class Job():
                 if combine_check_types_and_script or combine_check_names_and_script:
                     full_command += f' --script "{combined_script}" {notify}'
                 else:
-                    cmds.append(f'{UNSKRIPT_CTL_BINARY} -r --script "{combined_script}" {notify}')
+                    cmds.append(f'{UNSKRIPT_CTL_BINARY} run --script "{combined_script}" {notify}')
 
         if full_command is not None:
             cmds.append(full_command)
@@ -391,8 +391,8 @@ class ConfigParser():
         if (tunnel_up_cadence is None and tunnel_down_cadence is not None) or (tunnel_up_cadence is not None and tunnel_down_cadence is None):
             print(f'{bcolors.FAIL} Please ensure both tunnel_up_cadence and tunnel_down_cadence is configured{bcolors.ENDC}')
             return
-        self.tunnel_up_cmd = f'{tunnel_up_cadence} /usr/local/bin/unskript-ctl.sh --debug --start --config {ovpn_file}'
-        self.tunnel_down_cmd = f'{tunnel_down_cadence} /usr/local/bin/unskript-ctl.sh --debug --stop'
+        self.tunnel_up_cmd = f'{tunnel_up_cadence} /usr/local/bin/unskript-ctl.sh debug --start  {ovpn_file}'
+        self.tunnel_down_cmd = f'{tunnel_down_cadence} /usr/local/bin/unskript-ctl.sh debug --stop'
 
 def main():
     """main: This is the main function that gets called by the start.sh function

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -397,8 +397,8 @@ class UnskriptCtl(UnskriptFactory):
         parser = kwargs.get('parser', None)
 
         if args and args.command == 'debug':
-            if args.start:
-                self.start_debug(args.start)
+            if args.debug_command == 'start':
+                self.start_debug(args.config)
                 pass 
             elif args.stop:
                 self.stop_debug()
@@ -417,14 +417,8 @@ class UnskriptCtl(UnskriptFactory):
             print("ERROR: Insufficient information provided")
             return
 
-        remote_config = args[0]
-        remote_config = remote_config.replace('-','')
-
-        if remote_config != "config":
-            print(f"ERROR:The Allowed Parameter is --config, Given Flag is not recognized, --{remote_config}")
-            return
         try:
-            remote_config_file = args[1]
+            remote_config_file = args.config
         except:
             print(f"ERROR: Not able to find the configuration to start debug session")
             return
@@ -585,13 +579,16 @@ def main():
     
     # Debug / Service Option
     debug_parser = subparsers.add_parser('debug', help='Debug Option')
-    debug_parser.add_argument('--start',
-                                      help='Start debug session. Example [--start --config /tmp/config.ovpn]',
-                                      type=str,
-                                      nargs=REMAINDER)
+    debug_subparser = debug_parser.add_subparsers(dest='debug_command')
+    
+    debug_start_parser = debug_subparser.add_parser('start', help='Start Debug Option')
+
+    debug_start_parser.add_argument('--config',
+                                help='Config File, OVPN File, eg: /tmp/test.ovpn',
+                                type=str)
     debug_parser.add_argument('--stop',
-                                      help='Stop debug session',
-                                      action='store_true') 
+                                help='Stop debug session',
+                                action='store_true') 
 
     # Create Credential
     parser.add_argument('--create-credential',
@@ -642,7 +639,7 @@ def main():
     elif args.command == 'show':
         uc.show_main(args=args, parser=parser)
     elif args.command == 'debug':
-        uc.service_main(args=args, parser=parser)
+        uc.debug_main(args=args, parser=parser)
     elif args.create_credential not in ('', None):
         if len(args.create_credential) == 0:
             uc.display_creds_ui()


### PR DESCRIPTION
## Description
The unskript-ctl changes had to be percolated to config_parser.py too, which was missed in the main PR.

This PR brings in the change for that.


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

```
root@e859cf63c01a:/# ./start.sh 
 * Starting periodic command scheduler cron                                                                                                         [ OK ] 
###################################
Processing global section
###################################
Global: audit period 90 days
###################################
Processing checks section
###################################
###################################
Processing credential section
###################################
Credential: Programming type aws, name awscreds
Credential: Successfully programmed aws, name awscreds
Credential: Programming type k8s, name k8screds
Credential: Successfully programmed k8s, name k8screds
Credential: Programming type elasticsearch, name elasticsearchcreds
Credential: Successfully programmed elasticsearch, name elasticsearchcreds
Credential: Programming type redis, name rediscreds
Credential: Failed to program redis, name rediscreds
Credential: Programming type postgres, name postgrescreds
Credential: Failed to program mongodb, name mongodbcreds
Credential: Programming type kafka, name kafkacreds
Credential: Successfully programmed kafka, name kafkacreds
Credential: Skipping type rest, name restcreds
Credential: Programming type vault, name vaultcreds
Credential: Successfully programmed vault, name vaultcreds
Credential: Programming type keycloak, name keycloakcreds
Credential: Successfully programmed keycloak, name keycloakcreds
###################################
Processing jobs section
###################################
Job: lightbeam contains custom script: /usr/local/bin/lb_pvc.sh
###################################
Processing remote debugging section
###################################
Remote_debugging: No remote_debugging config found
###################################
Processing scheduler section
###################################
Schedule: cadence 0 0 * * *, job name: lightbeam
Schedule: Programming crontab 0 0 * * * /usr/local/bin/unskript-ctl.sh run --script "/usr/local/bin/lb_pvc.sh" --report
Adding audit log deletion cron job entry, 0 0 * * * /opt/conda/bin/python /usr/local/bin/unskript_audit_cleanup.py
2024/01/09 01:05:24 GoTTY is starting with command: /usr/local/bin/gotty_script.sh
2024/01/09 01:05:24 Permitting clients to write input to the PTY.
Error: failed to listen at `0.0.0.0:8888`: listen tcp 0.0.0.0:8888: bind: address already in use
failed to listen at `0.0.0.0:8888`: listen tcp 0.0.0.0:8888: bind: address already in use
```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
