### PR TITLE
Update unskript_ctl_run.py

### DIFF
--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -502,6 +502,9 @@ task.configure(inputParamsJson=\'\'\'{
                                     # Also, for each check, you need to use a different
                                     # argument, so store that in a field named
                                     # matrixinputline
+                                    # UUID Mapping need to initialized before assinging it a value!
+                                    if not isinstance(self.uglobals.get('uuid_mapping'), dict):
+                                        self.uglobals['uuid_mapping'] = {}
                                     is_first = True
                                     for dup in range(duplicate_count-1):
                                         add_check_to_list = False


### PR DESCRIPTION
The matrix calulation had an issue that the uuid_mapping was not initialized before assigining it. Fixed via this PR

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
