### PR TITLE
bugfix/EN-5229 : Update unskript_ctl_main.py

### DIFF
--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -418,7 +418,7 @@ class UnskriptCtl(UnskriptFactory):
             return
 
         try:
-            remote_config_file = args.config
+            remote_config_file = args
         except:
             print(f"ERROR: Not able to find the configuration to start debug session")
             return


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
It was failing while 
```
root@92a22155aa18:~# unskript-ctl.sh debug start  --config /tmp/client-abc.ovpn
ERROR: Not able to find the configuration to start debug session
root@92a22155aa18:~# 
```
After fix
```
root@92a22155aa18:~# unskript-ctl.sh debug start  --config /tmp/client-abc.ovpn
Successfully Started the Debug Session
```

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
