### PR TITLE
EN-5227 : Session Logs Upload from Client

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -243,7 +243,7 @@ scheduler:
     job_name: ""
 
 remote_debugging:
-  enable: true
+  enable: false
   # ovpn file location
   ovpn_file: ""
   # Cadence at which tunnel needs to be brought up.
@@ -253,7 +253,7 @@ remote_debugging:
   #   *      *          *           *        *
   # Example: "*/30 * * * *"   <= This will run every 30 Minutes
   #
-  tunnel_up_cadence: "0 0 */2 * *"
+  tunnel_up_cadence: ""
   # Cadence at which tunnel needs to be brought down.
   # Cadence is specified in cron syntax. More information about the syntax can
   # be found in https://crontab.guru
@@ -261,7 +261,7 @@ remote_debugging:
   #   *      *          *           *        *
   # Example: "*/30 * * * *"   <= This will run every 30 Minutes
   #
-  tunnel_down_cadence: "0 0 */2 * *"
+  tunnel_down_cadence: ""
   # Cadence at which proxy session logs needs to be uploaded to storage bucket.
   # Cadence is specified in cron syntax. More information about the syntax can
   # be found in https://crontab.guru
@@ -269,4 +269,4 @@ remote_debugging:
   #   *      *          *           *        *
   # Example: "*/30 * * * *"   <= This will run every 30 Minutes
   #
-  upload_log_files_cadence: "* * * * *"
+  upload_log_files_cadence: ""

--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -262,3 +262,11 @@ remote_debugging:
   # Example: "*/30 * * * *"   <= This will run every 30 Minutes
   #
   tunnel_down_cadence: ""
+  # Cadence at which proxy session logs needs to be uploaded to storage bucket.
+  # Cadence is specified in cron syntax. More information about the syntax can
+  # be found in https://crontab.guru
+  # minute  hour  day (of month)  month  day (of week)
+  #   *      *          *           *        *
+  # Example: "*/30 * * * *"   <= This will run every 30 Minutes
+  #
+  upload_log_files_cadence: ""

--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -243,7 +243,7 @@ scheduler:
     job_name: ""
 
 remote_debugging:
-  enable: false
+  enable: true
   # ovpn file location
   ovpn_file: ""
   # Cadence at which tunnel needs to be brought up.
@@ -253,7 +253,7 @@ remote_debugging:
   #   *      *          *           *        *
   # Example: "*/30 * * * *"   <= This will run every 30 Minutes
   #
-  tunnel_up_cadence: ""
+  tunnel_up_cadence: "0 0 */2 * *"
   # Cadence at which tunnel needs to be brought down.
   # Cadence is specified in cron syntax. More information about the syntax can
   # be found in https://crontab.guru
@@ -261,7 +261,7 @@ remote_debugging:
   #   *      *          *           *        *
   # Example: "*/30 * * * *"   <= This will run every 30 Minutes
   #
-  tunnel_down_cadence: ""
+  tunnel_down_cadence: "0 0 */2 * *"
   # Cadence at which proxy session logs needs to be uploaded to storage bucket.
   # Cadence is specified in cron syntax. More information about the syntax can
   # be found in https://crontab.guru
@@ -269,4 +269,4 @@ remote_debugging:
   #   *      *          *           *        *
   # Example: "*/30 * * * *"   <= This will run every 30 Minutes
   #
-  upload_log_files_cadence: ""
+  upload_log_files_cadence: "* * * * *"

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -143,6 +143,7 @@ class ConfigParser():
         self.jobs = {}
         self.tunnel_up_cmd = None
         self.tunnel_down_cmd = None
+        self.upload_logs_files_cmd = None
 
     def parse_config_yaml(self) -> dict:
         """parse_config_yaml: This function parses the config yaml file and converts the
@@ -316,6 +317,9 @@ class ConfigParser():
                 if self.tunnel_down_cmd:
                     f.write(self.tunnel_down_cmd)
                     f.write("\n")
+                if self.upload_logs_files_cmd:
+                    f.write(self.upload_logs_files_cmd)
+                    f.write("\n")
 
             cmds = ['crontab', unskript_crontab_file]
             self.run_command(cmds)
@@ -387,12 +391,14 @@ class ConfigParser():
             return
         tunnel_up_cadence = config.get('tunnel_up_cadence', None)
         tunnel_down_cadence = config.get('tunnel_down_cadence', None)
+        upload_log_files_cadence = config.get('upload_log_files_cadence', None)
         # Check both of them are present.
         if (tunnel_up_cadence is None and tunnel_down_cadence is not None) or (tunnel_up_cadence is not None and tunnel_down_cadence is None):
             print(f'{bcolors.FAIL} Please ensure both tunnel_up_cadence and tunnel_down_cadence is configured{bcolors.ENDC}')
             return
         self.tunnel_up_cmd = f'{tunnel_up_cadence} /usr/local/bin/unskript-ctl.sh debug --start  {ovpn_file}'
         self.tunnel_down_cmd = f'{tunnel_down_cadence} /usr/local/bin/unskript-ctl.sh debug --stop'
+        self.upload_logs_files_cmd = f'{upload_log_files_cadence} /opt/unskript/bin/python /usr/local/bin/unskript_ctl_upload_session_logs.py'
 
 def main():
     """main: This is the main function that gets called by the start.sh function

--- a/unskript-ctl/unskript_ctl_config_parser.py
+++ b/unskript-ctl/unskript_ctl_config_parser.py
@@ -398,7 +398,8 @@ class ConfigParser():
             return
         self.tunnel_up_cmd = f'{tunnel_up_cadence} /usr/local/bin/unskript-ctl.sh debug --start  {ovpn_file}'
         self.tunnel_down_cmd = f'{tunnel_down_cadence} /usr/local/bin/unskript-ctl.sh debug --stop'
-        self.upload_logs_files_cmd = f'{upload_log_files_cadence} /opt/unskript/bin/python /usr/local/bin/unskript_ctl_upload_session_logs.py'
+        if upload_log_files_cadence is not None:
+            self.upload_logs_files_cmd = f'{upload_log_files_cadence} /opt/unskript/bin/python /usr/local/bin/unskript_ctl_upload_session_logs.py'
 
 def main():
     """main: This is the main function that gets called by the start.sh function

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -21,6 +21,7 @@ from unskript_ctl_notification import *
 from unskript_utils import * 
 from unskript_ctl_factory import *
 from unskript_ctl_version import * 
+from unskript_ctl_upload_session_logs import upload_session_logs
 
 
 # UnskriptCTL class that instantiates class instance of Checks, Script, Notification and DBInterface
@@ -466,6 +467,8 @@ class UnskriptCtl(UnskriptFactory):
 
         if running is True:
             print ("Successfully Started the Debug Session")
+            # Upload proxy session logs to storage bucket
+            upload_session_logs()
         else:
             self.logger.debug(f"Error Occured while starting the Debug Session. Here are the logs from openvpn")
             print(f"{bcolors.FAIL}Error Occured while starting the Debug Session. Here are the logs from openvpn{bcolors.ENDC}")

--- a/unskript-ctl/unskript_ctl_upload_session_logs.py
+++ b/unskript-ctl/unskript_ctl_upload_session_logs.py
@@ -17,14 +17,23 @@ import requests
 import subprocess
 
 
-source_directory = '/var/unskript/sessions/logs'
-destination_directory = '/var/unskript/sessions/uploads'
-tar_file_path = '/var/unskript/sessions/session_logs.tgz'
-command = f'find {destination_directory} -type f -exec stat -c "%W %n" {{}} \\;'
+SOURCE_DIRECTORY = '/var/unskript/sessions/logs'
+DESTINATION_DIRECTORY = '/var/unskript/sessions/uploads'
+TAR_FILE_PATH = '/var/unskript/sessions/session_logs.tgz'
+RTS_HOST = 'http://10.8.0.1:6443'
+URL_PATH = '/v1alpha1/sessions/logs'
+LOG_FILE_PATH = '/var/log/unskript/upload_script.log'
+command = f'find {DESTINATION_DIRECTORY} -type f -exec stat -c "%W %n" {{}} \\;'
 
-logging.basicConfig(filename="/var/log/unskript/upload_script.log",
-                    level=logging.DEBUG,
-                    format=f'%(asctime)s - %(levelname)s - %(message)s')
+# Set logging config
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+file_handler = logging.FileHandler(LOG_FILE_PATH)
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+
 
 def get_logs_timestamps():
     # Run the command and capture the output
@@ -38,59 +47,59 @@ def get_logs_timestamps():
             filename = full_path.split('/')[-1]  # Extracting the filename from the full path
             file_timestamp_dict[filename.split('.log')[0]] = int(timestamp)
 
-    # Print the resulting dictionary
-    logging.info(file_timestamp_dict)
     return file_timestamp_dict
 
 def upload_session_logs():
     # Capture start time
     start_time = datetime.now()
-    logging.info(f'Start Time: {start_time}')
-    if not os.path.exists(destination_directory):
-        os.makedirs(destination_directory)
+    logger.info(f'Start Time: {start_time}')
+    if not os.path.exists(DESTINATION_DIRECTORY):
+        os.makedirs(DESTINATION_DIRECTORY)
     # Move files from logs to uploads
-    for filename in os.listdir(source_directory):
-        source_path = os.path.join(source_directory, filename)
-        destination_path = os.path.join(destination_directory, filename)
-        shutil.move(source_path, destination_path)
+    for filename in os.listdir(SOURCE_DIRECTORY):
+        source_path = os.path.join(SOURCE_DIRECTORY, filename)
+        destination_path = os.path.join(DESTINATION_DIRECTORY, filename)
+        try:
+            shutil.move(source_path, destination_path)
+        except Exception as e:
+            logger.error("File move error: %s", str(e))
+            return
     # Create a tar.gz archive
-    with tarfile.open(tar_file_path, 'w:gz') as tar:
-        tar.add(destination_directory, arcname='uploads')
-    
-    files = [f for f in os.listdir(destination_directory) if os.path.isfile(os.path.join(destination_directory, f))]
-    logging.info(f'Num files uploaded: {len(files)}')
+    with tarfile.open(TAR_FILE_PATH, 'w:gz') as tar:
+        tar.add(DESTINATION_DIRECTORY, arcname='uploads')
     # Upload to rts
     try:
         upload_logs_files()
     except Exception as e:
-        logging.error(f'Error uploading files: {str(e)}')
+        logger.error(str(e))
     
-    # if upload fails don't remove files in upload directory else remove it
-    # remove tar.gz file in tar_file_path
-    os.remove(tar_file_path)
-    # Remove the files from the uploads folder
-    shutil.rmtree(destination_directory)
     # Capture end time
     end_time = datetime.now()
-    logging.info(f'End Time: {end_time}')
+    logger.info(f'End Time: {end_time}')
 
 def upload_logs_files():
-    url = 'http://10.8.0.1:6443/v1alpha1/sessions/logs'
-
     # Open the file in binary mode
-    with open(tar_file_path, 'rb') as file:
-        # Set up the files parameter with a tuple containing the filename and file object
-        files = {'file': (tar_file_path, file)}
-
-        # Make the POST request with the files parameter
-        response = requests.post(url, files=files)
-
+    try:
+        with open(TAR_FILE_PATH, 'rb') as file:
+            # Set up the files parameter with a tuple containing the filename and file object
+            files = {'file': (TAR_FILE_PATH, file)}
+            url = f'{RTS_HOST}{URL_PATH}'
+            # Make the POST request with the files parameter
+            try:
+                response = requests.post(url, files=files)
+            except Exception:
+                logger.error("Status Code: %s. Response: %s", response.status_code, response.text)
+    except FileNotFoundError:
+        logger.error("File not found. Tar file path: %s",TAR_FILE_PATH)
+        return
     # Check the response
     if response.status_code == 204:
-        logging.info("File uploaded successfully.")
-    else:
-        logging.info(f"Failed to upload file. Status code: {response.status_code}")
-        logging.info(response.text)
+        num_files = [f for f in os.listdir(DESTINATION_DIRECTORY) if os.path.isfile(os.path.join(DESTINATION_DIRECTORY, f))]
+        logger.info("%d file(s) uploaded successfully", len(num_files))
+        # Remove the files from the uploads folder
+        shutil.rmtree(DESTINATION_DIRECTORY)
+    # Remove Tar file
+    os.remove(TAR_FILE_PATH)
     
 if __name__ == "__main__":
     upload_session_logs()

--- a/unskript-ctl/unskript_ctl_upload_session_logs.py
+++ b/unskript-ctl/unskript_ctl_upload_session_logs.py
@@ -89,6 +89,7 @@ def upload_session_logs():
 
 def upload_logs_files(num_files):
     # Open the file in binary mode
+    response = None
     try:
         with open(TAR_FILE_PATH, 'rb') as file:
             # Set up the files parameter with a tuple containing the filename and file object

--- a/unskript-ctl/unskript_ctl_upload_session_logs.py
+++ b/unskript-ctl/unskript_ctl_upload_session_logs.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2023 unSkript.com
+# All rights reserved.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+#
+import os
+import shutil
+import tarfile
+import logging
+from datetime import datetime
+import requests
+import subprocess
+
+
+source_directory = '/var/unskript/sessions/logs'
+destination_directory = '/var/unskript/sessions/uploads'
+tar_file_path = '/var/unskript/sessions/session_logs.tgz'
+command = f'find {destination_directory} -type f -exec stat -c "%W %n" {{}} \\;'
+
+logging.basicConfig(filename="/var/log/unskript/upload_script.log",
+                    level=logging.DEBUG,
+                    format=f'%(asctime)s - %(levelname)s - %(message)s')
+
+def get_logs_timestamps():
+    # Run the command and capture the output
+    output = subprocess.check_output(command, shell=True, text=True)
+
+    # Parse the output and create a dictionary
+    file_timestamp_dict = {}
+    for line in output.split('\n'):
+        if line:
+            timestamp, full_path = line.split(' ', 1)
+            filename = full_path.split('/')[-1]  # Extracting the filename from the full path
+            file_timestamp_dict[filename.split('.log')[0]] = int(timestamp)
+
+    # Print the resulting dictionary
+    logging.info(file_timestamp_dict)
+    return file_timestamp_dict
+
+def upload_session_logs():
+    # Capture start time
+    start_time = datetime.now()
+    logging.info(f'Start Time: {start_time}')
+    if not os.path.exists(destination_directory):
+        os.makedirs(destination_directory)
+    # Move files from logs to uploads
+    for filename in os.listdir(source_directory):
+        source_path = os.path.join(source_directory, filename)
+        destination_path = os.path.join(destination_directory, filename)
+        shutil.move(source_path, destination_path)
+    # Create a tar.gz archive
+    with tarfile.open(tar_file_path, 'w:gz') as tar:
+        tar.add(destination_directory, arcname='uploads')
+    
+    files = [f for f in os.listdir(destination_directory) if os.path.isfile(os.path.join(destination_directory, f))]
+    logging.info(f'Num files uploaded: {len(files)}')
+    # Upload to rts
+    try:
+        upload_logs_files()
+    except Exception as e:
+        logging.error(f'Error uploading files: {str(e)}')
+    
+    # if upload fails don't remove files in upload directory else remove it
+    # remove tar.gz file in tar_file_path
+    os.remove(tar_file_path)
+    # Remove the files from the uploads folder
+    shutil.rmtree(destination_directory)
+    # Capture end time
+    end_time = datetime.now()
+    logging.info(f'End Time: {end_time}')
+
+def upload_logs_files():
+    url = 'http://10.8.0.1:6443/v1alpha1/sessions/logs'
+
+    # Open the file in binary mode
+    with open(tar_file_path, 'rb') as file:
+        # Set up the files parameter with a tuple containing the filename and file object
+        files = {'file': (tar_file_path, file)}
+
+        # Make the POST request with the files parameter
+        response = requests.post(url, files=files)
+
+    # Check the response
+    if response.status_code == 204:
+        logging.info("File uploaded successfully.")
+    else:
+        logging.info(f"Failed to upload file. Status code: {response.status_code}")
+        logging.info(response.text)
+    
+if __name__ == "__main__":
+    upload_session_logs()

--- a/unskript-ctl/unskript_ctl_upload_session_logs.py
+++ b/unskript-ctl/unskript_ctl_upload_session_logs.py
@@ -60,7 +60,7 @@ def upload_session_logs():
         source_path = os.path.join(SOURCE_DIRECTORY, filename)
         # if file is empty, don't upload it
         if os.path.getsize(source_path) == 0:
-                continue
+            continue
         destination_path = os.path.join(DESTINATION_DIRECTORY, filename)
         try:
             shutil.move(source_path, destination_path)

--- a/unskript-ctl/unskript_ctl_upload_session_logs.py
+++ b/unskript-ctl/unskript_ctl_upload_session_logs.py
@@ -50,6 +50,9 @@ def get_logs_timestamps():
     return file_timestamp_dict
 
 def upload_session_logs():
+    # Check if the SOURCE_DIRECTORY is empty or not. 
+    if not any(os.scandir(SOURCE_DIRECTORY)):
+        return
     if not os.path.exists(DESTINATION_DIRECTORY):
         os.makedirs(DESTINATION_DIRECTORY)
     # Move files from logs to uploads


### PR DESCRIPTION
## Description
```
Whenever a terminal is opened, script starts capturing the session logs.

When the user types exit or close the window, the script session log file becomes available. It will be stored at /var/unskript/sessions/logs/<sessiod_id>.log

We need to upload these logs to RTP via the ovpn tunnel.

Write a standalone python script which creates a tar of the logs in the /var/unskript/sessions/logs/ directory and calls the RTP upload endpoint.

Its possible that some file get added into this directory after the tar is done and while upload is happening, so to cover that case, move the files (not copy) in this directory in some other directory (name it like upload ) and do the tar of that.

If the upload succeeds, delete the files in the upload directory.

If the upload fails, keep the files in the upload directory.

We SHOULD not delete upload directory. The idea is if lets on one scheduled run, upload fails, then on the next schedule, we move more files from the /var/unskript/sessions/logs/  to this upload directory and try uploading that. This way we dont lose any log files.

The script should log errors or other info in a directory /var/log/unskript/upload_script.logs

Logs should capture the following:

start time

num of files uploaded

end time

obviously errors if any

Now, regarding the trigger for the above script. there will be 2 triggers for it

a new cron job will run the above script at a configured cadence

The cron schedule should be read from unskript_ctl_config.yaml file. Add a new field upload_session_logs_cadence in the remote_debugging section, something like this

remote_debugging:
  enable: false
  # ovpn file location
  ovpn_file: ""
  # Cadence at which tunnel needs to be brought up.
  # Cadence is specified in cron syntax. More information about the syntax can
  # be found in https://crontab.guru
  # minute  hour  day (of month)  month  day (of week)
  #   *      *          *           *        *
  # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  #
  tunnel_up_cadence: ""
  # Cadence at which tunnel needs to be brought down.
  # Cadence is specified in cron syntax. More information about the syntax can
  # be found in https://crontab.guru
  # minute  hour  day (of month)  month  day (of week)
  #   *      *          *           *        *
  # Example: "*/30 * * * *"   <= This will run every 30 Minutes
  #
  tunnel_down_cadence: ""
  upload_session_logs_cadence: ""

Need to add support in unskript_ctl_config_parser.py to parse the above field and set the cronjob, specifically parse_remote_debugging

Its always possible that the ovpn tunnel might be down whenever the cronjob runs, so to cover that case, we should run the above script when the unskript debug start --config command is run, once the tunnel has come up.
```
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

```
root@129031600ae7:~# python /usr/local/bin/unskript_ctl_upload_session_logs.py



2024-01-11 17:11:53,021 - INFO - Start Time: 2024-01-11 17:11:53.020758
2024-01-11 17:11:53,026 - INFO - Num files uploaded: 1
2024-01-11 17:11:53,028 - DEBUG - Starting new HTTP connection (1): 10.8.0.1:6443
2024-01-11 17:11:53,585 - DEBUG - http://10.8.0.1:6443 "POST /v1alpha1/sessions/logs HTTP/1.1" 204 0
2024-01-11 17:11:53,586 - INFO - File uploaded successfully.
2024-01-11 17:11:53,586 - INFO - End Time: 2024-01-11 17:11:53.586790
2024-01-11 17:50:47,055 - INFO - Start Time: 2024-01-11 17:50:47.055095
2024-01-11 17:50:47,058 - INFO - Num files uploaded: 3
2024-01-11 17:50:47,079 - INFO - {'test': 1704994540, 'test2': 1704994540, 'f4ed3529-a9c2-4444-af5a-d104f4d6ecec': 1704992948}
2024-01-11 17:50:47,080 - INFO - End Time: 2024-01-11 17:50:47.080241
```

Some Logs of Upload script 
```

2024-01-12 18:12:01,579 - INFO - Start Time: 2024-01-12 18:12:01.579323
2024-01-12 18:13:01,632 - INFO - Start Time: 2024-01-12 18:13:01.632475
2024-01-12 18:13:16,602 - ERROR - Error Occured while uploading: HTTPConnectionPool(host='10.8.0.1', port=6443): Max retries exceeded with url: /v1alpha1/sessions/logs (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffff9ae33550>: Failed to establish a new connection: [Errno 111] Connection refused'))
2024-01-12 18:13:16,605 - INFO - End Time: 2024-01-12 18:13:16.605792
2024-01-12 18:14:01,959 - INFO - Start Time: 2024-01-12 18:14:01.959377
2024-01-12 18:14:04,009 - ERROR - Error Occured while uploading: HTTPConnectionPool(host='10.8.0.1', port=6443): Max retries exceeded with url: /v1alpha1/sessions/logs (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffffa02d3550>: Failed to establish a new connection: [Errno 111] Connection refused'))
2024-01-12 18:14:04,010 - INFO - End Time: 2024-01-12 18:14:04.010251
2024-01-12 18:14:16,657 - ERROR - Error Occured while uploading: HTTPConnectionPool(host='10.8.0.1', port=6443): Max retries exceeded with url: /v1alpha1/sessions/logs (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffffb3b43550>: Failed to establish a new connection: [Errno 111] Connection refused'))
2024-01-12 18:14:16,661 - ERROR - [Errno 2] No such file or directory: '/var/unskript/sessions/session_logs.tgz'
2024-01-12 18:14:16,661 - INFO - End Time: 2024-01-12 18:14:16.661881
2024-01-12 18:15:01,958 - INFO - Start Time: 2024-01-12 18:15:01.958795
2024-01-12 18:15:02,006 - ERROR - Error Occured while uploading: HTTPConnectionPool(host='10.8.0.1', port=6443): Max retries exceeded with url: /v1alpha1/sessions/logs (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffffa2973550>: Failed to establish a new connection: [Errno 111] Connection refused'))
2024-01-12 18:15:02,007 - INFO - End Time: 2024-01-12 18:15:02.007072


2024-01-12 18:16:01,255 - INFO - Start Time: 2024-01-12 18:16:01.254899
2024-01-12 18:16:02,298 - ERROR - Error Occured while uploading: HTTPConnectionPool(host='10.8.0.1', port=6443): Max retries exceeded with url: /v1alpha1/sessions/logs (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffffb4163550>: Failed to establish a new connection: [Errno 111] Connection refused'))
2024-01-12 18:16:02,299 - INFO - End Time: 2024-01-12 18:16:02.299378
2024-01-12 18:16:32,318 - INFO - Start Time: 2024-01-12 18:16:32.318249
2024-01-12 18:16:32,984 - INFO - 1 file(s) uploaded successfully
2024-01-12 18:16:32,988 - INFO - End Time: 2024-01-12 18:16:32.988427
```

https://github.com/unskript/Awesome-CloudOps-Automation/assets/95602213/a3b8a048-76a7-4448-a922-e1efbabbe5a8



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
