### PR TITLE
EN-5252: Ensure terminal session is completed before upload

### DIFF
--- a/unskript-ctl/unskript_ctl_upload_session_logs.py
+++ b/unskript-ctl/unskript_ctl_upload_session_logs.py
@@ -17,7 +17,7 @@ import requests
 import subprocess
 
 
-SOURCE_DIRECTORY = '/var/unskript/sessions/logs'
+SOURCE_DIRECTORY = '/var/unskript/sessions/completed-logs'
 DESTINATION_DIRECTORY = '/var/unskript/sessions/uploads'
 TAR_FILE_PATH = '/var/unskript/sessions/session_logs.tgz'
 RTS_HOST = 'http://10.8.0.1:6443'
@@ -57,12 +57,9 @@ def upload_session_logs():
     if not any(os.scandir(SOURCE_DIRECTORY)) and not any(os.scandir(DESTINATION_DIRECTORY)):
         return
     
-    # Move files from logs to uploads
+    # Move files from completed-logs to uploads
     for filename in os.listdir(SOURCE_DIRECTORY):
         source_path = os.path.join(SOURCE_DIRECTORY, filename)
-        # if file is empty, don't upload it
-        if os.path.getsize(source_path) == 0:
-            continue
         destination_path = os.path.join(DESTINATION_DIRECTORY, filename)
         try:
             shutil.move(source_path, destination_path)


### PR DESCRIPTION
Fix: [EN-5252](https://unskript.atlassian.net/browse/EN-5252)

## Description

Move logs from completed-logs to uploads when doing upload
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5252]: https://unskript.atlassian.net/browse/EN-5252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ