### PR TITLE
Inline display of failed objects

### DIFF
--- a/unskript-ctl/unskript_utils.py
+++ b/unskript-ctl/unskript_utils.py
@@ -22,6 +22,12 @@ UNSKRIPT_SCRIPT_RUN_OUTPUT_FILE_NAME = "unskript_script_run_output"
 UNSKRIPT_SCRIPT_RUN_OUTPUT_DIR_ENV = "UNSKRIPT_SCRIPT_OUTPUT_DIR"
 JIT_PYTHON_SCRIPT = "/tmp/jit_script.py"
 
+# Character count for including failed objects as INLINE text in email
+# Each line is an average 80 character approximately 
+# 20000 / 80 = 250 lines approximately. If Failed object length is
+# more than 20000 characters, we will send as EMAIL attachment.  
+MAX_CHARACTER_COUNT_FOR_FAILED_OBJECTS = 20000
+
 TBL_HDR_CHKS_NAME="\033[36m Checks Name \033[0m"
 TBL_HDR_INFO_NAME="\033[36m Action Name \033[0m"
 TBL_HDR_DSPL_CHKS_NAME="\033[35m Check Name \n (Last Failed) \033[0m"


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
Fixes [EN-5277]

* Includes Failed object inline 
* If the Failed object character count is more than 20000 (roughly 250 lines) then we send as attachment.



### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Checks Only

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/b44be918-7346-4ae9-b083-d6e2b1e668a3

#### Checks + Info Gathering 

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/cce96601-a0e2-40db-9d5d-08fe1bf1a096


#### Checks + Script + Info Gathering 

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/990839af-c87e-4f6b-a16d-8525f2413ef5

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5277]: https://unskript.atlassian.net/browse/EN-5277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ