### PR TITLE
Fix kafka check lag change action

### DIFF
--- a/Kafka/legos/kafka_check_lag_change/kafka_check_lag_change.py
+++ b/Kafka/legos/kafka_check_lag_change/kafka_check_lag_change.py
@@ -3,8 +3,8 @@
 # All rights reserved.
 ##
 from typing import Tuple, Optional
-from kafka.admin import KafkaAdminClient
-from kafka import KafkaConsumer, TopicPartition
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from kafka import KafkaAdminClient, KafkaConsumer, TopicPartition
 from pydantic import BaseModel, Field
 from tabulate import tabulate
 import time
@@ -35,8 +35,45 @@ def kafka_check_lag_change_printer(output):
         table_data = [(issue['consumer_group'], issue['topic'], issue['partition'], issue['description']) for issue in issues]
         print(tabulate(table_data, headers=headers, tablefmt='grid'))
 
+    # This would be a global or persisted store of previous lags at the last check.
+    # Format: { "topic-partition": [timestamp, lag] }
+prev_lags = {}
 
-def kafka_check_lag_change(handle, group_id: str= "", threshold: int=1) -> Tuple:
+def fetch_lag(handle, group_id, topic_partitions, current_time, threshold):
+    issues = []
+    # Utilize bootstrap_servers from handle
+    consumer = KafkaConsumer(bootstrap_servers=handle.config['bootstrap_servers'], group_id=group_id)
+    try:
+        for tp in topic_partitions:
+            end_offset = consumer.end_offsets([tp])[tp]
+            committed = consumer.committed(tp) or 0
+            lag = end_offset - committed
+
+            if lag == 0:
+                continue
+
+            key = f"{group_id}-{tp.topic}-{tp.partition}"
+            prev_entry = prev_lags.get(key)
+
+            if prev_entry:
+                prev_timestamp, prev_lag = prev_entry
+                if prev_lag != lag:
+                    prev_lags[key] = (current_time, lag)
+                elif (current_time - prev_timestamp) >= threshold * 3600:
+                    issues.append({
+                        'consumer_group': group_id,
+                        'topic': tp.topic,
+                        'partition': tp.partition,
+                        'description': f"Lag hasn't changed for {threshold} hours. Current Lag: {lag}"
+                    })
+            else:
+                prev_lags[key] = (current_time, lag)
+    finally:
+        consumer.close()
+
+    return issues
+
+def kafka_check_lag_change(handle, group_id: str = "", threshold: int = 3) -> Tuple:
     """
     kafka_check_lag_change checks if the lag for consumer groups is not changing for X hours.
 
@@ -48,56 +85,26 @@ def kafka_check_lag_change(handle, group_id: str= "", threshold: int=1) -> Tuple
 
     :return: Tuple containing a status and an optional list of issues with lag.
     """
-    # This would be a global or persisted store of previous lags at the last check.
-    # Format: { "topic-partition": [timestamp, lag] }
-    prev_lags = {}
-
     issues = []
     current_time = time.time()
+
     admin_client = KafkaAdminClient(bootstrap_servers=handle.config['bootstrap_servers'])
+    consumer_groups = [group_id] if group_id else [group[0] for group in admin_client.list_consumer_groups()]
 
-    if group_id:
-        consumer_groups = [group_id]
-    else:
-        consumer_groups = [group[0] for group in admin_client.list_consumer_groups()]
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = []
 
-    for group in consumer_groups:
-        consumer = KafkaConsumer(bootstrap_servers=handle.config['bootstrap_servers'], group_id=group)
+        for group in consumer_groups:
+            consumer = KafkaConsumer(bootstrap_servers=handle.config['bootstrap_servers'], group_id=group)
+            topics = consumer.topics()
+            topic_partitions = [TopicPartition(topic, partition) for topic in topics for partition in consumer.partitions_for_topic(topic)]
+            consumer.close()
 
-        for topic in consumer.topics():
-            partitions = consumer.partitions_for_topic(topic)
-            for partition in partitions:
-                tp = TopicPartition(topic, partition)
-                end_offset = consumer.end_offsets([tp])[tp]
-                committed = consumer.committed(tp) or 0
-                lag = end_offset - committed
+            if topic_partitions:
+                future = executor.submit(fetch_lag, handle, admin_client, group, topic_partitions, current_time, threshold)
+                futures.append(future)
 
-                if lag == 0:
-                    continue
+        for future in as_completed(futures):
+            issues.extend(future.result())
 
-                key = f"{group}-{topic}-{partition}"
-                if key in prev_lags:
-                    prev_timestamp, prev_lag = prev_lags[key]
-
-                    # Only update timestamp in prev_lags if there's a change in the lag
-                    if prev_lag != lag:
-                        prev_lags[key] = (current_time, lag)
-                    elif (current_time - prev_timestamp) >= threshold * 3600:
-                        print(f"Issue detected with {key}. Adding to issues list.")
-                        issues.append({
-                            'consumer_group': group,
-                            'topic': topic,
-                            'partition': partition,
-                            'description': f"Lag hasn't changed for {threshold} hours. Current Lag: {lag}"
-                        })
-                else:
-                    prev_lags[key] = (current_time, lag)
-
-        consumer.close()
-
-    if issues:
-        return (False, issues)
-    return (True, None)
-
-
-
+    return (False, issues) if issues else (True, None)


### PR DESCRIPTION
## Description
1. Added a try catch block to finally close the consumer when not needed. 
2. Fetching topic partitions before creating consumers
3. Using ThreadPoolExecutor to execute the task concurrently. 


### Testing
Before:
<img width="892" alt="Screenshot 2024-02-02 at 6 11 53 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/d633942a-b6cf-4ef5-831a-ad694b521e93">

After:
<img width="870" alt="Screenshot 2024-02-02 at 6 12 00 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/08174650-7260-40c8-9931-2b8a994ca13d">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
