### PR TITLE
Per Check Timeout support

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -22,6 +22,9 @@ global:
    # audit_period in days. Number of days worth of audit data to be kept.
    # Any date older than this number of days, will be deleted.
    audit_period: 90
+   # per check timeout, this timeout decides how much time should be given
+   # per check for it to complete
+   execution_timeout: 60
 
 #
 # Checks section

--- a/unskript-ctl/templates/template_script.j2
+++ b/unskript-ctl/templates/template_script.j2
@@ -1,3 +1,31 @@
+import time
+import os
+from tqdm import tqdm
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def rate_limited(num_tokens, interval):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            nonlocal num_tokens
+            current_time = time.time()
+            if num_tokens <= 0:
+                time.sleep(interval - (current_time % interval))
+                num_tokens = 1
+            else:
+                num_tokens -= 1
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+@rate_limited(num_tokens=1, interval=60)  # Adjust interval based on your needs
+def execute_check_function(check_function):
+    return _run_function(check_function)
+
+@rate_limited(num_tokens=1, interval=60)  # Adjust interval based on your needs
+def execute_last_cell():
+    return last_cell()
+
 def _run_function(fn):
     import io
     import os
@@ -23,17 +51,25 @@ def _run_function(fn):
     return output
 
 def do_run_():
-    import sys
-    from tqdm import tqdm
-    output = None
-    for i in tqdm(range({{ num_checks + 2}}), desc="Running", leave=True, ncols=100):
-        if i == {{ num_checks + 1}}:
-             fn = "last_cell"
-        else:
-            fn = "check_" + str(i)
-        if hasattr(globals().get(fn), "__call__"):
-            output = _run_function(fn)
-    return output
+    check_functions = [f"check_{i}" for i in range({{ num_checks }})]
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = {executor.submit(execute_check_function, check_function): check_function for check_function in check_functions}
+
+        for future in tqdm(as_completed(futures), desc="Running", total=len(futures), leave=True, ncols=100):
+            check_function = futures[future]
+            try:
+                output = future.result()
+                if output:
+                    print(output)
+            except Exception as e:
+                print(f"Error executing {check_function}: {str(e)}")
+
+    # Execute last_cell with rate limiting
+    try:
+        execute_last_cell()
+    except Exception as e:
+        print(f"Error executing last_cell: {str(e)}")
 
 if __name__ == "__main__":
     do_run_()

--- a/unskript-ctl/templates/template_script.j2
+++ b/unskript-ctl/templates/template_script.j2
@@ -1,41 +1,24 @@
-import time
+import signal 
+import sys
 import os
-from tqdm import tqdm
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import io
+from polling2 import poll
 
+class TimeoutException(Exception):
+    pass
 
-def rate_limited(num_tokens, interval):
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            nonlocal num_tokens
-            current_time = time.time()
-            if num_tokens <= 0:
-                time.sleep(interval - (current_time % interval))
-                num_tokens = 1
-            else:
-                num_tokens -= 1
-            return func(*args, **kwargs)
-        return wrapper
-    return decorator
-
-@rate_limited(num_tokens=1, interval=60)  # Adjust interval based on your needs
-def execute_check_function(check_function):
-    return _run_function(check_function)
-
-@rate_limited(num_tokens=1, interval=60)  # Adjust interval based on your needs
-def execute_last_cell():
-    return last_cell()
+def timeout_handler(signum, frame):
+    raise TimeoutException("Checks timed out")
 
 def _run_function(fn):
-    import io
-    import os
-    import sys
     global w
     l_cell = False
     if fn == "last_cell":
         l_cell = True
-    fn = fn + "()"
+    signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm({{ execution_timeout }})
     output = None
+    success = False 
     output_buffer = io.StringIO()
     sys.stdout = output_buffer
     if l_cell is True:
@@ -43,33 +26,39 @@ def _run_function(fn):
         output = output_buffer.getvalue()
     else:
         try:
-            eval(fn)
+            fn = globals().get(fn)
+            fn() 
+            success = True
         except Exception as e:
             # If one of the action fails dump the exception on console and proceed further
             print(str(e))
+        finally:
+            signal.alarm(0) # Rest alarm
     sys.stdout = sys.__stdout__
-    return output
+    return output, success
 
 def do_run_():
-    check_functions = [f"check_{i}" for i in range({{ num_checks }})]
-
-    with ThreadPoolExecutor(max_workers=3) as executor:
-        futures = {executor.submit(execute_check_function, check_function): check_function for check_function in check_functions}
-
-        for future in tqdm(as_completed(futures), desc="Running", total=len(futures), leave=True, ncols=100):
-            check_function = futures[future]
+    import sys
+    from tqdm import tqdm
+    output = None
+    for i in tqdm(range({{ num_checks + 1 }}), desc="Running", leave=True, ncols=100):
+        fn = "check_" + str(i)
+        if hasattr(globals().get(fn), "__call__"):
             try:
-                output = future.result()
-                if output:
-                    print(output)
+                result = poll(lambda: _run_function(fn), 
+                                step=1, 
+                                timeout={{ execution_timeout }},
+                                poll_forever=False)
+                if result and not result[1]:
+                    print('\n. Check Did not complete')
+            except polling2.TimeoutException:
+                print("Timeout Reached")
+                continue
             except Exception as e:
-                print(f"Error executing {check_function}: {str(e)}")
-
-    # Execute last_cell with rate limiting
-    try:
-        execute_last_cell()
-    except Exception as e:
-        print(f"Error executing last_cell: {str(e)}")
+                print(f" Exception Reached {str(e)}")
+                return 
+    output, _ = _run_function('last_cell')
+    return output
 
 if __name__ == "__main__":
     do_run_()

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -364,8 +364,14 @@ class Checks(ChecksFactory):
         with open(os.path.join(os.path.dirname(__file__), 'templates/template_script.j2'), 'r') as f:
             content_template = f.read()
 
+        execution_timeout = 60
+        g = self._config.get_global()
+        if g and g.get('execution_timeout'):
+            execution_timeout = g.get('execution_timeout')
+
         template = Template(content_template)
-        return  template.render(num_checks=len_of_checks)
+        return  template.render(num_checks=len_of_checks, execution_timeout=execution_timeout)
+
 
     def insert_task_lines(self, checks_list: list):
         if checks_list and len(checks_list):


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Implemented  `per check timeout` 
* When a check is started to execute, a Poll timer is set, at the timer expiring, if the check is still not completed, it is interrupted and declared `ERROR` with the reason `Check time out` 


<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Timeout Occuring when check is still underway

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/688018f5-f710-4a0c-be6a-dd17e27511a8

#### Timeout adequate to run the check successfully


https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/0a8ada0a-d527-47c7-b8ae-9d4c7890e560





### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
