### PR TITLE
Minor changes for k8s service endpoints and kafka lag check lego

### DIFF
--- a/Kafka/legos/kafka_check_lag_change/kafka_check_lag_change.py
+++ b/Kafka/legos/kafka_check_lag_change/kafka_check_lag_change.py
@@ -101,7 +101,7 @@ def kafka_check_lag_change(handle, group_id: str = "", threshold: int = 3) -> Tu
             consumer.close()
 
             if topic_partitions:
-                future = executor.submit(fetch_lag, handle, admin_client, group, topic_partitions, current_time, threshold)
+                future = executor.submit(fetch_lag, handle, group, topic_partitions, current_time, threshold)
                 futures.append(future)
 
         for future in as_completed(futures):

--- a/Kubernetes/legos/k8s_check_service_status/k8s_check_service_status.py
+++ b/Kubernetes/legos/k8s_check_service_status/k8s_check_service_status.py
@@ -15,7 +15,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 class InputSchema(BaseModel):
-    endpoints: Optional[list] = Field(
+    endpoints: list = Field(
         ..., description='The URLs of the endpoint whose SSL certificate is to be checked. Eg: ["https://www.google.com", "https://expired.badssl.com/"]', title='List of URLs'
     )
     threshold: Optional[int] = Field(
@@ -71,7 +71,7 @@ def check_ssl_expiry(endpoint, threshold):
         raise e
 
 
-def k8s_check_service_status(handle, endpoints:list=[], threshold: int = 30) -> Tuple:
+def k8s_check_service_status(handle, endpoints:list, threshold: int = 30) -> Tuple:
     """
     k8s_check_service_status Checks the health status of the provided endpoints.
 
@@ -81,10 +81,6 @@ def k8s_check_service_status(handle, endpoints:list=[], threshold: int = 30) -> 
     :return: Tuple with a boolean indicating if all services are healthy, and a list of dictionaries 
              with individual service status.
     """
-    # Check if no endpoints are provided
-    if not endpoints:
-        return False, [{"Error": "No endpoints specified."}]
-
     failed_endpoints = []
 
     for endpoint in endpoints:


### PR DESCRIPTION
## Description
1. Make endpoints as a required parameter
2. Update fetch_leg function call

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Error:
<img width="1119" alt="Screenshot 2024-02-13 at 3 46 37 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/bf7f4ce2-c8e1-4aab-bd3d-f658780fc82f">

Fail:
<img width="831" alt="Screenshot 2024-02-13 at 11 19 00 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/e30b50c6-7351-4f75-ad82-09cbe9467d74">

Pass:
<img width="871" alt="Screenshot 2024-02-13 at 11 18 29 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/15a78730-bffe-49f7-92bd-6af22f9ca88b">



<img width="885" alt="Screenshot 2024-02-13 at 3 43 53 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/0c302146-91c4-4b64-b064-33df23f23c9c">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
