### PR TITLE
Disable Timeout Restriction after all checks are run

### DIFF
--- a/unskript-ctl/templates/template_script.j2
+++ b/unskript-ctl/templates/template_script.j2
@@ -58,6 +58,12 @@ def do_run_():
                 print(f" Exception Reached {str(e)}")
                 return 
     output, _ = _run_function('last_cell')
+
+    # We need to reset alarm because if any SIGALRM was triggred in the _run_function
+    # then any other operation like running info checks, or running script will also
+    # be subject to the same timeout restriction. Need to reset before running them.
+    signal.alarm(0)
+
     return output
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Reset SIGALRM after running all the checks, this is essential if any other operation follows running checks, like `--info` or `--script`


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Before the fix

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/573604bd-5dd5-4314-be4e-6dac69d2e740

#### After the fix


https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/92d9d47d-4d7d-4bb2-9345-a661e9c11949






### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
