### PR TITLE
Fix: update method in unskript_ctl_db

### DIFF
--- a/Kubernetes/legos/k8s_get_memory_utilization_of_services/k8s_get_memory_utilization_of_services.py
+++ b/Kubernetes/legos/k8s_get_memory_utilization_of_services/k8s_get_memory_utilization_of_services.py
@@ -46,8 +46,8 @@ def k8s_get_memory_utilization_of_services_printer(output):
 
 
 
-def convert_memory_to_bytes(memory_value: str) -> int:
-    if not memory_value:
+def convert_memory_to_bytes(memory_value: Optional[str]) -> int:
+    if memory_value is None:
         return 0
     units = {
         'K': 1000,

--- a/unskript-ctl/unskript_ctl_database.py
+++ b/unskript-ctl/unskript_ctl_database.py
@@ -107,9 +107,11 @@ class ZoDBInterface(DatabaseFactory):
             self.collection_name = kwargs.get('collection_name')
         if 'data' in kwargs:
             data = kwargs.get('data')
+        
         with self.db.transaction() as connection:
             root = connection.root()
             stored_data = root.get(self.collection_name, {})
+            migrated_to_new_format = False
             if isinstance(stored_data, bytes):
                 self.logger.info("Found database to be using old schema, will migrate to new format")
                 try:
@@ -117,14 +119,13 @@ class ZoDBInterface(DatabaseFactory):
                     old_data = json.loads(decompressed_data.decode('utf-8'))
                     # Make sure the DB has the schema version to indicate the migration
                     root['schema_version'] = SCHEMA_VERSION
+                    migrated_to_new_format = True
                 except zlib.error as e:
                     self.logger.error(f"Error decompressing data: {e}")
                     return False
                 except json.JSONDecodeError as e:
                     self.logger.error(f"Error decoding JSON data: {e}")
                     return False
-                finally:
-                    self.logger.info("DB schema migrated successfully")
             elif isinstance(stored_data, dict):
                 if 'schema_version' not in root.keys():
                     # In case we dont find it, lets add the schema version
@@ -137,8 +138,11 @@ class ZoDBInterface(DatabaseFactory):
                 old_data.update(data)
                 root[self.collection_name] = old_data
                 connection.transaction_manager.commit()
+                if migrated_to_new_format:
+                    self.logger.info("DB migrated successfully")
             except Exception as e:
                 self.logger.debug("Exception Occurred when updating ")
+                return False
             
             connection.close()
 

--- a/unskript-ctl/unskript_ctl_database.py
+++ b/unskript-ctl/unskript_ctl_database.py
@@ -111,6 +111,7 @@ class ZoDBInterface(DatabaseFactory):
             root = connection.root()
             stored_data = root.get(self.collection_name, {})
             if isinstance(stored_data, bytes):
+                self.logger.info("Found database to be using old schema, will migrate to new format")
                 try:
                     decompressed_data = zlib.decompress(stored_data)
                     old_data = json.loads(decompressed_data.decode('utf-8'))
@@ -120,6 +121,8 @@ class ZoDBInterface(DatabaseFactory):
                 except json.JSONDecodeError as e:
                     self.logger.error(f"Error decoding JSON data: {e}")
                     return False
+                finally:
+                    self.logger.info("DB schema migrated successfully")
             elif isinstance(stored_data, dict):
                 old_data = stored_data
             else:

--- a/unskript-ctl/unskript_ctl_database.py
+++ b/unskript-ctl/unskript_ctl_database.py
@@ -115,6 +115,8 @@ class ZoDBInterface(DatabaseFactory):
                 try:
                     decompressed_data = zlib.decompress(stored_data)
                     old_data = json.loads(decompressed_data.decode('utf-8'))
+                    # Make sure the DB has the schema version to indicate the migration
+                    root['schema_version'] = SCHEMA_VERSION
                 except zlib.error as e:
                     self.logger.error(f"Error decompressing data: {e}")
                     return False
@@ -124,13 +126,20 @@ class ZoDBInterface(DatabaseFactory):
                 finally:
                     self.logger.info("DB schema migrated successfully")
             elif isinstance(stored_data, dict):
+                if 'schema_version' not in root.keys():
+                    # In case we dont find it, lets add the schema version
+                    root['schema_version'] = SCHEMA_VERSION
                 old_data = stored_data
             else:
                 self.logger.error("Unsupported data type in database")
                 return False
-            old_data.update(data)
-            root[self.collection_name] = old_data
-            connection.transaction_manager.commit()
+            try:
+                old_data.update(data)
+                root[self.collection_name] = old_data
+                connection.transaction_manager.commit()
+            except Exception as e:
+                self.logger.debug("Exception Occurred when updating ")
+            
             connection.close()
 
             del root


### PR DESCRIPTION
## Description
1.  Need to handle None type in the convert_memory_to_bytes function
```
k8s:Get K8s services exceeding memory utilization convert_memory_to_bytes function
    Failed Objects:
     '@beartyped check_4.convert_memory_to_bytes() parameter memory_value="None" violates
      type hint <class ''str''>, as "None" not instance of str.'
```
2. Updated the update method to accept byte type object instead of assuming it is dict and added type check.

```
  Traceback (most recent call last):
  File "/usr/local/bin/./unskript_ctl_main.py", line 740, in <module>
    main()
  File "/usr/local/bin/./unskript_ctl_main.py", line 719, in main
    uc.run_main(args=args, parser=parser)
  File "/usr/local/bin/./unskript_ctl_main.py", line 137, in run_main
    self.update_audit_trail(collection_name='audit_trail', status_dict_list=status_of_run)
  File "/usr/local/bin/./unskript_ctl_main.py", line 213, in update_audit_trail
    self._db.pss.update(collection_name=collection_name, data=trail_data)
  File "/usr/local/bin/unskript_ctl_database.py", line 111, in update
    old_data.update(data)
    ^^^^^^^^^^^^^^^
AttributeError: 'bytes' object has no attribute 'update'
```

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing

<img width="929" alt="Screenshot 2024-02-14 at 5 10 39 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/6eea6140-196a-4eb9-9631-d943e53abed6">


#### Before Fix

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/5c5abf76-9c90-474b-8f4a-ddd4efe85112


#### After Fix & Surviving POD Restart (upgrade scenario)


https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/63cc5a53-4585-4a65-b456-4fb3cbdb10d8







### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
