### PR TITLE
Fixed regression when running info legos

### DIFF
--- a/unskript-ctl/unskript_ctl_database.py
+++ b/unskript-ctl/unskript_ctl_database.py
@@ -108,29 +108,9 @@ class ZoDBInterface(DatabaseFactory):
             data = kwargs.get('data')
         with self.db.transaction() as connection:
             root = connection.root()
-            try:
-                old_data = root[self.collection_name]
-                if 'schema_version' in root.keys():
-                    # New Format nothing be done
-                    pass 
-                else: 
-                    # Old data that has the older schema
-                    if isinstance(old_data, bytes):
-                        try:
-                            decompressed_data = zlib.decompress(old_data)
-                            old_data = json.loads(decompressed_data.decode('utf-8'))
-                        except zlib.error as e:
-                            self.logger.error(f"Error decompressing data: {e}")
-                            return False
-                        except json.JSONDecodeError as e:
-                            self.logger.error(f"Error decoding JSON data: {e}")
-                            return False
-                old_data.update(data)
-                root[self.collection_name] = old_data
-            except Exception as e: 
-                self.logger.error(f'Alert! Database schema mismatch {e}')
-                return False 
-
+            old_data = root[self.collection_name]
+            old_data.update(data)
+            root[self.collection_name] = old_data
             connection.transaction_manager.commit()
             connection.close()
 

--- a/unskript-ctl/unskript_ctl_database.py
+++ b/unskript-ctl/unskript_ctl_database.py
@@ -11,6 +11,7 @@
 import os 
 import re
 import ZODB
+import zlib
 import sqlite3
 import json
 import ZODB.FileStorage
@@ -107,11 +108,32 @@ class ZoDBInterface(DatabaseFactory):
             data = kwargs.get('data')
         with self.db.transaction() as connection:
             root = connection.root()
-            old_data = root[self.collection_name]
-            old_data.update(data)
-            root[self.collection_name] = old_data
+            try:
+                old_data = root[self.collection_name]
+                if 'schema_version' in root.keys():
+                    # New Format nothing be done
+                    pass 
+                else: 
+                    # Old data that has the older schema
+                    if isinstance(old_data, bytes):
+                        try:
+                            decompressed_data = zlib.decompress(old_data)
+                            old_data = json.loads(decompressed_data.decode('utf-8'))
+                        except zlib.error as e:
+                            self.logger.error(f"Error decompressing data: {e}")
+                            return False
+                        except json.JSONDecodeError as e:
+                            self.logger.error(f"Error decoding JSON data: {e}")
+                            return False
+                old_data.update(data)
+                root[self.collection_name] = old_data
+            except Exception as e: 
+                self.logger.error(f'Alert! Database schema mismatch {e}')
+                return False 
+
             connection.transaction_manager.commit()
             connection.close()
+
             del root
             del connection
 

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -569,7 +569,13 @@ class UnskriptCtl(UnskriptFactory):
             output_json_file = os.path.join(output_dir,UNSKRIPT_SCRIPT_RUN_OUTPUT_FILE_NAME + '.json')
             mode = 'both'
         if args.command == 'run' and args.info:
-            mode = "both"
+            if args.check_command:
+                # Case when info is called with check
+                mode = "both"
+            else:
+                # Case when run is called with info only or info with script, that case we dont want
+                # to send any slack notification because we dont have any slack notification to send
+                mode = "email"
 
         self._notification.notify(summary_results=summary_result,
                                   failed_objects=failed_objects,

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -687,7 +687,7 @@ class InfoAction(ChecksFactory):
             self.logger.error("ERROR: Action list is empty, Cannot run anything")
             raise ValueError("Action List is empty!")
 
-        self.action_uuid, self.check_names, self.connector_types, _= \
+        self.action_uuid, self.check_names, self.connector_types, self.check_entry_functions = \
                 self._common.get_code_cell_name_and_uuid(list_of_actions=action_list)
 
         action_list = self.create_checks_for_matrix_argument(action_list)
@@ -700,7 +700,7 @@ class InfoAction(ChecksFactory):
 
         # Internal routine to run through all python JIT script and return the output
         def _execute_script(script, idx):
-            check_name = self.check_names[idx]
+            check_name = self.check_entry_functions[idx]
             connector_name = self.connector_types[idx]
             result_key = f"{connector_name}/{check_name}"
             if not self.uglobals['info_action_results'].get(result_key):


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Before priority check support running of `info legos` was using `name` as `action_entry_function`
* When priority checks support was added the running of info legos got impacted because it was still looking for `name`. Changed the logic to form the checks based on action_entry_function list rather than `name` 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Test with info only


https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/b4ef892f-a8c9-4458-88d5-be83bafa8985

#### Test with check.+ info 


https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/37ddd440-c865-4654-a9fa-160d3a891a96


#### Test with check + script + info 


https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/c062bcf5-10c2-437a-a2f1-6c794b15dc4b



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
