### PR TITLE
Fixed issue with jumbled printing of results

### DIFF
--- a/.github/workflows/build-and-release-docker-lite.yml
+++ b/.github/workflows/build-and-release-docker-lite.yml
@@ -329,6 +329,7 @@ jobs:
           git checkout ${{ inputs.awesome_branch }}
           cd ..
           make syncrunbooks
+          sed -i "s/BUILD_NUMBER = .*/BUILD_NUMBER = \"${{ inputs.build_number }}\"/g" awesome/unskript-ctl/unskript_ctl_version.py
           cp -Rf awesome/unskript-ctl/* $HOME/devops/dockers/jupyterlab/oss_docker_lite/
           cp -Rf awesome/bin/* $HOME/devops/dockers/jupyterlab/oss_docker_lite/
           cd $HOME/devops/dockers/jupyterlab/oss_docker_lite/

--- a/unskript-ctl/unskript_ctl_notification.py
+++ b/unskript-ctl/unskript_ctl_notification.py
@@ -26,6 +26,7 @@ from jsonschema import validate, ValidationError
 
 
 from unskript_utils import *
+from unskript_ctl_version import *
 from unskript_ctl_factory import NotificationFactory
 
 # This class implements Notification function for Slack
@@ -378,6 +379,7 @@ class EmailNotification(NotificationFactory):
             <center>
             <h1> {email_title} </h1>
             <h3> <strong>Tested On <br> {datetime.now().strftime("%a %b %d %I:%M:%S %p %Y %Z")} </strong></h3>
+            <h4> <strong>Build #: <br> {BUILD_NUMBER} </strong></h4>
             </center>
             '''
         return message

--- a/unskript-ctl/unskript_ctl_notification.py
+++ b/unskript-ctl/unskript_ctl_notification.py
@@ -379,7 +379,7 @@ class EmailNotification(NotificationFactory):
             <center>
             <h1> {email_title} </h1>
             <h3> <strong>Tested On <br> {datetime.now().strftime("%a %b %d %I:%M:%S %p %Y %Z")} </strong></h3>
-            <h4> <strong>Build #: <br> {BUILD_NUMBER} </strong></h4>
+            <h4> <strong>Version : {BUILD_NUMBER} </strong></h4><br>
             </center>
             '''
         return message

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -721,8 +721,6 @@ class InfoAction(ChecksFactory):
             return result.stdout
 
         script_files = [f for f in os.listdir(self.temp_jit_dir) if f.endswith('.py')]
-        # Lets sort the script files, because the os.listdir would return in not ascending order!
-        script_files.sort()
         with concurrent.futures.ThreadPoolExecutor() as executor, tqdm(total=len(script_files), desc="Running") as pbar:
             futures = {executor.submit(_execute_script, os.path.join(self.temp_jit_dir, script), idx): idx for idx, script in enumerate(script_files)}
             # Wait for all scripts to complete

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -731,8 +731,7 @@ class InfoAction(ChecksFactory):
 
         # Lets remove the directory if it exists
         try:
-            #shutil.rmtree(self.temp_jit_dir)
-            pass
+            shutil.rmtree(self.temp_jit_dir)
         except OSError as e:
             self.logging.error(str(e))
 


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Fixed printing of Results for info legos that were jumbled 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Negative test
```
root@awesome-awesome-runbooks-0:~# unskript-ctl.sh run --info
2024-02-19 21:26:57,902 - UnskriptCtlLogger - INFO - No Actions found for these names: ['k8s_get_versioning_info_wrong_one']
root@awesome-awesome-runbooks-0:~# vi /etc/unskript/unskript_ctl_config.yaml 
root@awesome-awesome-runbooks-0:~# unskript-ctl.sh run --info
2024-02-19 21:27:13,416 - UnskriptCtlLogger - INFO - No Information gathering action mentioned in the config file!
root@awesome-awesome-runbooks-0:~# 
```


#### Testing with all info legos 
```
root@awesome-awesome-runbooks-0:~# unskript-ctl.sh run --info


Information Gathering Action Results
Running: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18/18 [18:28<00:00, 61.58s/it]

k8s/k8s_get_versioning_info



Using incluster config
Versions:
kubectl: Client Version: v1.23.1
kubernetes: Client Version: v1.23.1
Server Version: v1.23.17
docker: Not found

###

k8s/k8s_get_node_status_and_resource_utilization



###

kafka/kafka_get_topic_health



Error: Parameter type validation failed: action.<locals>.kafka_get_topic_health() missing 2 required positional arguments: 'group_id' and 'topics'

###

mongodb/mongodb_get_metrics



Total Memory: 494 MB


###

mongodb/mongodb_get_write_conflicts



Potential Write Conflicts: 0

###

mongodb/mongodb_get_replica_set



+--------------------------------------------------------------------------------------------------+---------+
| Replica Name                                                                                     | Role    |
+==================================================================================================+=========+
| lightbeam-mongodb-0.lightbeam-mongodb-headless.lightbeam.svc.cluster.local:27017                 | PRIMARY |
+--------------------------------------------------------------------------------------------------+---------+
| lightbeam-mongodb-arbiter-0.lightbeam-mongodb-arbiter-headless.lightbeam.svc.cluster.local:27017 | ARBITER |
+--------------------------------------------------------------------------------------------------+---------+

###

elasticsearch/elasticsearch_get_cluster_statistics




Cluster Name:  lightbeam-elasticsearch
Timestamp:  2024-02-19 21:22:24.203000
Status:  yellow

Node Statistics
+---------+--------------+----------+
|   total |   successful |   failed |
|---------+--------------+----------|
|       1 |            1 |        0 |
+---------+--------------+----------+

Document Statistics
+-----------------+-------------------+
|   count (count) |   deleted (count) |
|-----------------+-------------------|
|             126 |                41 |
+-----------------+-------------------+

Shard Statistics
+----------------------------------+----------------------------------+--------------------------------------+
| shards (shard count)             | primaries (shard count)          | replication (shard count)            |
|----------------------------------+----------------------------------+--------------------------------------|
| {'min': 1, 'max': 1, 'avg': 1.0} | {'min': 1, 'max': 1, 'avg': 1.0} | {'min': 0.0, 'max': 0.0, 'avg': 0.0} |
+----------------------------------+----------------------------------+--------------------------------------+

Additional Metrics
+-------------------------+------------------------+--------------------------------+
|   total_index_size (MB) |   total_disk_size (MB) |   total_memory_utilization (%) |
|-------------------------+------------------------+--------------------------------|
|                    38.4 |                 247919 |                             28 |
+-------------------------+------------------------+--------------------------------+

###

keycloak/keycloak_get_audit_report



+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| Time                | Type        | User ID                              | Client ID   | IP Address     | Error                |
+=====================+=============+======================================+=============+================+======================+
| 2024-02-19 21:05:31 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-19 16:07:13 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-19 02:02:37 | LOGIN_ERROR |                                      | lightbeam   | 127.0.0.1      | invalid_redirect_uri |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-19 00:00:40 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-18 00:00:41 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-17 04:59:30 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-17 04:36:18 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-17 04:28:50 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-17 04:15:57 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-17 00:00:40 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 21:52:36 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 21:33:12 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 21:30:37 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 21:20:02 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 20:58:45 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 20:49:07 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 20:41:56 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 20:18:22 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 20:09:53 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 19:34:01 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 01:11:30 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 01:09:47 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 01:07:12 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 01:03:00 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 00:58:37 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 00:35:05 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 00:17:37 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 00:16:11 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-16 00:00:25 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-15 23:47:22 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-15 18:38:45 | LOGIN_ERROR |                                      | lightbeam   | 127.0.0.1      | invalid_redirect_uri |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-14 21:46:35 | LOGIN_ERROR |                                      | lightbeam   | 127.0.0.1      | invalid_redirect_uri |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-12 00:00:15 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-11 00:00:17 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-10 00:00:16 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-09 00:00:17 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-08 00:33:50 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-08 00:30:41 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-08 00:24:15 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-08 00:18:58 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-08 00:14:30 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-08 00:00:17 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-07 01:11:57 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-07 01:08:06 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-07 01:03:42 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-07 01:00:28 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-07 00:04:02 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 18:04:12 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 17:38:52 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 17:25:51 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 16:52:51 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.72 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 16:40:56 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.72 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 16:13:14 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.72 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 15:34:36 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 06:05:40 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 05:55:41 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 04:50:20 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 04:42:17 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 04:30:02 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-06 00:00:30 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-05 10:27:35 | LOGIN_ERROR |                                      | lightbeam   | 127.0.0.1      | invalid_redirect_uri |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-05 00:00:31 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-04 00:00:31 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-03 00:00:29 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 21:59:54 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 21:30:03 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 20:54:38 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 20:32:51 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 06:07:26 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 06:07:24 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 03:31:36 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 03:31:03 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 02:19:14 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:54:07 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:51:31 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:44:15 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:42:21 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:42:11 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:40:55 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:40:08 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:39:40 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:38:28 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:17:17 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:15:51 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-02 01:15:35 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:53:31 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:23:47 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:20:48 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:20:23 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:17:53 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:12:36 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:11:12 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:04:04 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 17:03:32 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 13:15:03 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+
| 2024-02-01 13:13:07 | LOGIN       | 747d6b08-52ae-4c9f-8fd5-a715ca05da5f | admin-cli   | 192.168.144.36 |                      |
+---------------------+-------------+--------------------------------------+-------------+----------------+----------------------+

###

redis/redis_get_keys_count



Error: Parameter type validation failed: action.<locals>.redis_get_keys_count() missing 1 required positional argument: 'pattern'

###

redis/redis_get_metrics




Redis Metrics: 
+--------------------+-------+
|       Metric       | Value |
+--------------------+-------+
|     index_size     |   3   |
| memory_utilization |  2MB  |
|    dataset_size    | 222KB |
+--------------------+-------+

###

k8s/k8s_get_all_resources_utilization_info



###

k8s/k8s_measure_worker_node_network_bandwidth



###

k8s/k8s_get_nodes_pressure



###

k8s/k8s_get_service_images



Using incluster config
+--------------------------------------------------------------+----------------------------------------------+
| Service (Namespace)                                          | Images                                       |
+==============================================================+==============================================+
| audit (unskript)                                             | public.ecr.aws/unskript/audit                |
+--------------------------------------------------------------+----------------------------------------------+
| calendar (unskript)                                          | public.ecr.aws/unskript/calendar             |
+--------------------------------------------------------------+----------------------------------------------+
| connectors (unskript)                                        | public.ecr.aws/unskript/connectors           |
+--------------------------------------------------------------+----------------------------------------------+
| enterprise-gateway (unskript)                                | elyra/enterprise-gateway                     |
+--------------------------------------------------------------+----------------------------------------------+
| events (unskript)                                            | public.ecr.aws/unskript/events               |
+--------------------------------------------------------------+----------------------------------------------+
| lambda (unskript)                                            | public.ecr.aws/unskript/lambda               |
+--------------------------------------------------------------+----------------------------------------------+
| legos (unskript)                                             | public.ecr.aws/unskript/legos                |
+--------------------------------------------------------------+----------------------------------------------+
| mongodb-arbiter-headless (unskript)                          | docker.io/bitnami/mongodb                    |
+--------------------------------------------------------------+----------------------------------------------+
| mongodb-headless (unskript)                                  | docker.io/bitnami/mongodb                    |
+--------------------------------------------------------------+----------------------------------------------+
| nginx-server (unskript)                                      | public.ecr.aws/unskript/nginx-server         |
+--------------------------------------------------------------+----------------------------------------------+
| notifications (unskript)                                     | public.ecr.aws/unskript/notifications        |
+--------------------------------------------------------------+----------------------------------------------+
| privileges (unskript)                                        | public.ecr.aws/unskript/privileges           |
+--------------------------------------------------------------+----------------------------------------------+
| redis-headless (unskript)                                    | docker.io/bitnami/redis                      |
+--------------------------------------------------------------+----------------------------------------------+
| redis-master (unskript)                                      | docker.io/bitnami/redis                      |
+--------------------------------------------------------------+----------------------------------------------+
| redis-replicas (unskript)                                    | docker.io/bitnami/redis                      |
+--------------------------------------------------------------+----------------------------------------------+
| remote-tunnel-server (unskript)                              | public.ecr.aws/unskript/remote-tunnel-server |
+--------------------------------------------------------------+----------------------------------------------+
| remote-tunnel-server-vpn (unskript)                          | public.ecr.aws/unskript/remote-tunnel-server |
+--------------------------------------------------------------+----------------------------------------------+
| skynet (unskript)                                            | public.ecr.aws/unskript/skynet               |
+--------------------------------------------------------------+----------------------------------------------+
| tenantmgr (unskript)                                         | public.ecr.aws/unskript/tenantmgr            |
+--------------------------------------------------------------+----------------------------------------------+
| unskript-72b534ed-b892-4917-b4c0-67be4b3a8ea6-res (unskript) | public.ecr.aws/unskript/jupyterlab           |
+--------------------------------------------------------------+----------------------------------------------+
| workflows (unskript)                                         | public.ecr.aws/unskript/workflows            |
+--------------------------------------------------------------+----------------------------------------------+

Using incluster config
No labels found for service kubelet in namespace lightbeam. Skipping...
+------------------------------------------------------+--------------------------------------------------+
| Service (Namespace)                                  | Images                                           |
+======================================================+==================================================+
| kafka-ui (lightbeam)                                 | docker.io/fastcomply/kafka-ui                    |
+------------------------------------------------------+--------------------------------------------------+
| kong-proxy (lightbeam)                               | fastcomply/kong-ingress-controller               |
|                                                      | docker.io/fastcomply/kong-oidc                   |
+------------------------------------------------------+--------------------------------------------------+
| kong-validation-webhook (lightbeam)                  | fastcomply/kong-ingress-controller               |
|                                                      | docker.io/fastcomply/kong-oidc                   |
+------------------------------------------------------+--------------------------------------------------+
| lb-argo-workflows-server (lightbeam)                 | docker.io/bitnami/argo-workflow-cli              |
+------------------------------------------------------+--------------------------------------------------+
| lb-kafka-connect (lightbeam)                         | docker.io/fastcomply/lightbeam-kafka-connect     |
+------------------------------------------------------+--------------------------------------------------+
| lb-keycloak (lightbeam)                              | docker.io/fastcomply/lb-keycloak                 |
+------------------------------------------------------+--------------------------------------------------+
| lb-keycloak-headless (lightbeam)                     | docker.io/fastcomply/lb-keycloak                 |
+------------------------------------------------------+--------------------------------------------------+
| lb-redis-headless (lightbeam)                        | docker.io/fastcomply/redis                       |
+------------------------------------------------------+--------------------------------------------------+
| lb-redis-master (lightbeam)                          | docker.io/fastcomply/redis                       |
+------------------------------------------------------+--------------------------------------------------+
| lb-redis-replicas (lightbeam)                        | docker.io/fastcomply/redis                       |
+------------------------------------------------------+--------------------------------------------------+
| lb-vault (lightbeam)                                 | docker.io/fastcomply/vault                       |
|                                                      | docker.io/fastcomply/vault-unseal                |
+------------------------------------------------------+--------------------------------------------------+
| lb-vault-ui (lightbeam)                              | docker.io/fastcomply/vault                       |
|                                                      | docker.io/fastcomply/vault-unseal                |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-api-gateway (lightbeam)                    | docker.io/fastcomply/api-gateway                 |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-datahub-gms (lightbeam)                    | docker.io/fastcomply/datahub-gms                 |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-datahub-gms-graphql (lightbeam)            | docker.io/fastcomply/datahub-gms-graphql-service |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-elasticsearch-master (lightbeam)           | docker.io/fastcomply/lightbeam-elasticsearch     |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-elasticsearch-master-headless (lightbeam)  | docker.io/fastcomply/lightbeam-elasticsearch     |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-elasticsearch-nodeport-service (lightbeam) | docker.io/fastcomply/lightbeam-elasticsearch     |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-files-service (lightbeam)                  | docker.io/fastcomply/rex                         |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-frontend (lightbeam)                       | docker.io/fastcomply/frontend                    |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-kafka (lightbeam)                          | docker.io/fastcomply/kafka                       |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-kafka-headless (lightbeam)                 | docker.io/fastcomply/kafka                       |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-kafka-metrics (lightbeam)                  | docker.io/fastcomply/kafka-exporter              |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-kafka-zookeeper (lightbeam)                | docker.io/fastcomply/zookeeper                   |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-kafka-zookeeper-headless (lightbeam)       | docker.io/fastcomply/zookeeper                   |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-kafka-zookeeper-metrics (lightbeam)        | docker.io/fastcomply/zookeeper                   |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-minio-svc (lightbeam)                      | docker.io/fastcomply/minio                       |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-mongodb-arbiter-headless (lightbeam)       | docker.io/fastcomply/mongodb                     |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-mongodb-headless (lightbeam)               | docker.io/fastcomply/mongodb                     |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-mongodb-nodeport-service (lightbeam)       | docker.io/fastcomply/mongodb                     |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-policy-engine (lightbeam)                  | docker.io/fastcomply/policy-engine               |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-presidio-server (lightbeam)                | docker.io/fastcomply/presidio-server             |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-prometheus (lightbeam)                     | docker.io/fastcomply/prometheus                  |
|                                                      | docker.io/fastcomply/prometheus-config-reloader  |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-prometheus-pushgateway (lightbeam)         | docker.io/fastcomply/pushgateway                 |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-qdrant (lightbeam)                         | docker.io/fastcomply/qdrant                      |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-qdrant-headless (lightbeam)                | docker.io/fastcomply/qdrant                      |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-report-engine (lightbeam)                  | docker.io/fastcomply/report-engine               |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-schema-registry (lightbeam)                | docker.io/fastcomply/cp-schema-registry          |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-text-extraction (lightbeam)                | docker.io/gotenberg/gotenberg                    |
|                                                      | docker.io/fastcomply/text-extraction             |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-text-extraction-headless (lightbeam)       | docker.io/gotenberg/gotenberg                    |
|                                                      | docker.io/fastcomply/text-extraction             |
+------------------------------------------------------+--------------------------------------------------+
| lightbeam-tika-server (lightbeam)                    | docker.io/fastcomply/tika-server                 |
+------------------------------------------------------+--------------------------------------------------+
| postgres (lightbeam)                                 | docker.io/fastcomply/bitnami-postgresql          |
|                                                      | docker.io/fastcomply/bitnami-postgres-exporter   |
+------------------------------------------------------+--------------------------------------------------+
| postgres-metrics (lightbeam)                         | docker.io/fastcomply/bitnami-postgresql          |
|                                                      | docker.io/fastcomply/bitnami-postgres-exporter   |
+------------------------------------------------------+--------------------------------------------------+
| prometheus-operated (lightbeam)                      | docker.io/fastcomply/prometheus                  |
|                                                      | docker.io/fastcomply/prometheus-config-reloader  |
+------------------------------------------------------+--------------------------------------------------+
| vault-agent-injector-svc (lightbeam)                 | docker.io/fastcomply/vault-k8s                   |
+------------------------------------------------------+--------------------------------------------------+

###

kafka/kafka_get_committed_messages_count



Error: Parameter type validation failed: action.<locals>.kafka_get_committed_messages_count() missing 1 required positional argument: 'group_id'

###

```

#### Version number displaying in the report
<img width="2317" alt="Screenshot 2024-02-19 at 4 57 21 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/a96c2d7a-1d4c-4217-b3d3-c5d28f181b89">

#### Removing sort() from the script_list (PR COMMENT)

```
                                                                                    unSkript-ctl run result

                                                                                           Tested On
                                                                            Tue Feb 20 12:56:22 AM 2024

                                                                                       Version: 1.15.20



Information Gathering Action Result


k8s/k8s_get_all_resources_utilization_info

Using incluster config

Pods:
+-----------+-----------------------------------------------------------------+---------+---------------+-------------------+
| Namespace |                              Name                               | Status  | CPU Usage (m) | Memory Usage (Mi) |
+-----------+-----------------------------------------------------------------+---------+---------------+-------------------+
| unskript  |                     audit-6d84f4dcf4-rnjpc                      | Running |      N/A      |        N/A        |
| unskript  |                    calendar-7ddd547fcc-hfzff                    | Running |      N/A      |        N/A        |
| unskript  |                   connectors-748c49c879-nsr2s                   | Running |      N/A      |        N/A        |
| unskript  |               enterprise-gateway-85b75f659c-8hclf               | Running |      N/A      |        N/A        |
| unskript  |                     events-f6dc98b4d-nksch                      | Running |      N/A      |        N/A        |
| unskript  |           jovyan-b865bf79-edde-4c1b-9f55-5e8d1e212e4a           | Running |      N/A      |        N/A        |
| unskript  |                    kernel-image-puller-dmrnd                    | Running |      N/A      |        N/A        |
| unskript  |                     lambda-f4b7b9666-jms6s                      | Running |      N/A      |        N/A        |
| unskript  |                     legos-7d95656795-fz9tp                      | Running |      N/A      |        N/A        |
| unskript  |                            mongodb-0                            | Running |      N/A      |        N/A        |
| unskript  |                        mongodb-arbiter-0                        | Running |      N/A      |        N/A        |
| unskript  |                  nginx-server-749fd77cf-qr84l                   | Running |      N/A      |        N/A        |
| unskript  |                  notifications-b46dfb877-764x6                  | Running |      N/A      |        N/A        |
| unskript  |                   privileges-5c555f847f-lppqb                   | Running |      N/A      |        N/A        |
| unskript  |                         redis-master-0                          | Running |      N/A      |        N/A        |
| unskript  |                        redis-replicas-0                         | Running |      N/A      |        N/A        |
| unskript  |                        redis-replicas-1                         | Running |      N/A      |        N/A        |
| unskript  |                        redis-replicas-2                         | Running |      N/A      |        N/A        |
| unskript  |              remote-tunnel-server-7487cb947c-wpqwj              | Running |      N/A      |        N/A        |
| unskript  |                     skynet-8c56f6cbc-qqfq4                      | Running |      N/A      |        N/A        |
| unskript  |                   tenantmgr-858f4b46bc-thdrt                    | Running |      N/A      |        N/A        |
| unskript  | unskript-72b534ed-b892-4917-b4c0-67be4b3a8ea6-res-dd9d9d88wwqbs | Running |      N/A      |        N/A        |
| unskript  |                      util-8469b7875d-l5vgt                      | Running |      N/A      |        N/A        |
| unskript  |                   workflows-6746455b6c-z2ljk                    | Running |      N/A      |        N/A        |
+-----------+-----------------------------------------------------------------+---------+---------------+-------------------+

Jobs:
+------+--------+
| Name | Status |
+------+--------+
+------+--------+

Persistentvolumeclaims:
+-----------------------------+--------+
|            Name             | Status |
+-----------------------------+--------+
|      datadir-mongodb-0      | Bound  |
|  redis-data-redis-master-0  | Bound  |
| redis-data-redis-replicas-0 | Bound  |
| redis-data-redis-replicas-1 | Bound  |
| redis-data-redis-replicas-2 | Bound  |
|       rts-openvpn-pvc       | Bound  |
+-----------------------------+--------+

Using incluster config

Pods:
+-----------+------------------------------------------------------+-----------+---------------+-------------------+
| Namespace |                         Name                         |  Status   | CPU Usage (m) | Memory Usage (Mi) |
+-----------+------------------------------------------------------+-----------+---------------+-------------------+
| lightbeam |                       curlpod                        |  Running  |      N/A      |        N/A        |
| lightbeam |            ingress-kong-69fdcf9b7c-x2j4t             |  Running  |      N/A      |        N/A        |
| lightbeam |                     jr-pkg-test                      |  Running  |      N/A      |        N/A        |
| lightbeam |              kafka-ui-558c57f65f-6cxt7               |  Running  |      N/A      |        N/A        |
| lightbeam |                kong-migrations-sfdcb                 | Succeeded |      N/A      |        N/A        |
| lightbeam |    lb-argo-workflows-controller-7f4d9d8fb9-484mk     |  Running  |      N/A      |        N/A        |
| lightbeam |      lb-argo-workflows-server-5dd6b9956b-57h9s       |  Running  |      N/A      |        N/A        |
| lightbeam |        lb-bloom-filter-builder-28472400-nm8s7        | Succeeded |      N/A      |        N/A        |
| lightbeam |        lb-bloom-filter-builder-28472760-9w88n        | Succeeded |      N/A      |        N/A        |
| lightbeam |        lb-bloom-filter-builder-28473120-rqb6q        | Succeeded |      N/A      |        N/A        |
| lightbeam |          lb-kafka-connect-5c6846cdbd-jkx2k           |  Running  |      N/A      |        N/A        |
| lightbeam |                    lb-keycloak-0                     |  Running  |      N/A      |        N/A        |
| lightbeam |       lb-prometheus-operator-6ccd9c9469-hmrgp        |  Running  |      N/A      |        N/A        |
| lightbeam |                  lb-redis-master-0                   |  Running  |      N/A      |        N/A        |
| lightbeam |                 lb-redis-replicas-0                  |  Running  |      N/A      |        N/A        |
| lightbeam |                 lb-redis-replicas-1                  |  Running  |      N/A      |        N/A        |
| lightbeam |                 lb-redis-replicas-2                  |  Running  |      N/A      |        N/A        |
| lightbeam |                      lb-vault-0                      |  Running  |      N/A      |        N/A        |
| lightbeam |        lb-workflow-executor-6d4777bb8f-qbwgf         |  Running  |      N/A      |        N/A        |
| lightbeam |            lb-workflow-gc-28473120-prs27             | Succeeded |      N/A      |        N/A        |
| lightbeam |      lightbeam-alert-handler-job-28473168-hghkx      | Succeeded |      N/A      |        N/A        |
| lightbeam |      lightbeam-alert-handler-job-28473171-dnqr9      | Succeeded |      N/A      |        N/A        |
| lightbeam |      lightbeam-alert-handler-job-28473174-cgjf9      | Succeeded |      N/A      |        N/A        |
| lightbeam |        lightbeam-api-gateway-5cdfb4b69-bqr8w         |  Running  |      N/A      |        N/A        |
| lightbeam |              lightbeam-bootstrap-fhsps               | Succeeded |      N/A      |        N/A        |
| lightbeam |   lightbeam-datahub-elasticsearch-setup-job-6kr45    | Succeeded |      N/A      |        N/A        |
| lightbeam |        lightbeam-datahub-gms-7b68f6fc7f-j8bm4        |  Running  |      N/A      |        N/A        |
| lightbeam |    lightbeam-datahub-gms-graphql-6b47fcd8ff-nh4vw    |  Running  |      N/A      |        N/A        |
| lightbeam |       lightbeam-datahub-kafka-setup-job-xhvqh        | Succeeded |      N/A      |        N/A        |
| lightbeam |      lightbeam-datahub-postgres-setup-job-r5fnt      | Succeeded |      N/A      |        N/A        |
| lightbeam | lightbeam-datasource-stats-aggregator-6d7686b8-ntrr4 |  Running  |      N/A      |        N/A        |
| lightbeam |           lightbeam-elasticsearch-master-0           |  Running  |      N/A      |        N/A        |
| lightbeam |       lightbeam-files-service-69bf959f5c-c688m       |  Running  |      N/A      |        N/A        |
| lightbeam |         lightbeam-frontend-6c7d59d869-55n8s          |  Running  |      N/A      |        N/A        |
| lightbeam |                  lightbeam-kafka-0                   |  Running  |      N/A      |        N/A        |
| lightbeam |              lightbeam-kafka-exporter-0              |  Running  |      N/A      |        N/A        |
| lightbeam |             lightbeam-kafka-zookeeper-0              |  Running  |      N/A      |        N/A        |
| lightbeam |           lightbeam-minio-6cf5844654-vlvsv           |  Running  |      N/A      |        N/A        |
| lightbeam |         lightbeam-mongo-aggr-28473174-c9bdh          | Succeeded |      N/A      |        N/A        |
| lightbeam |         lightbeam-mongo-aggr-28473175-9fl22          | Succeeded |      N/A      |        N/A        |
| lightbeam |         lightbeam-mongo-aggr-28473176-llhwt          | Succeeded |      N/A      |        N/A        |
| lightbeam |                 lightbeam-mongodb-0                  |  Running  |      N/A      |        N/A        |
| lightbeam |             lightbeam-mongodb-arbiter-0              |  Running  |      N/A      |        N/A        |
| lightbeam |      lightbeam-policy-consumer-65d546cc4d-x6nsx      |  Pending  |      N/A      |        N/A        |
| lightbeam |       lightbeam-policy-engine-76d5667bf8-mxfv4       |  Running  |      N/A      |        N/A        |
| lightbeam |          lightbeam-post-install-setup-j9tbt          | Succeeded |      N/A      |        N/A        |
| lightbeam |      lightbeam-presidio-server-7c89f7f4bd-xhqdr      |  Running  |      N/A      |        N/A        |
| lightbeam |  lightbeam-prometheus-pushgateway-6c4cf77496-l96f2   |  Running  |      N/A      |        N/A        |
| lightbeam |                  lightbeam-qdrant-0                  |  Running  |      N/A      |        N/A        |
| lightbeam |       lightbeam-report-engine-65dfdd5c7-gr4w4        |  Running  |      N/A      |        N/A        |
| lightbeam |      lightbeam-schema-registry-694887697d-vclw8      |  Running  |      N/A      |        N/A        |
| lightbeam |      lightbeam-text-extraction-7cf9f6c8b9-c9qp9      |  Running  |      N/A      |        N/A        |
| lightbeam |        lightbeam-tika-server-75485bf8fd-rvdm5        |  Running  |      N/A      |        N/A        |
| lightbeam |       local-path-provisioner-6cc89d4f76-6f96q        |  Running  |      N/A      |        N/A        |
| lightbeam |                      postgres-0                      |  Running  |      N/A      |        N/A        |
| lightbeam |              prometheus-lb-prometheus-0              |  Running  |      N/A      |        N/A        |
| lightbeam |        vault-agent-injector-6c7d69ff46-llbwm         |  Running  |      N/A      |        N/A        |
+-----------+------------------------------------------------------+-----------+---------------+-------------------+

Jobs:
+-------------------------------------------+----------+
|                   Name                    |  Status  |
+-------------------------------------------+----------+
|              kong-migrations              | Complete |
|     lb-bloom-filter-builder-28472400      | Complete |
|     lb-bloom-filter-builder-28472760      | Complete |
|     lb-bloom-filter-builder-28473120      | Complete |
|          lb-workflow-gc-28473120          | Complete |
|   lightbeam-alert-handler-job-28172295    |  Failed  |
|   lightbeam-alert-handler-job-28473168    | Complete |
|   lightbeam-alert-handler-job-28473171    | Complete |
|   lightbeam-alert-handler-job-28473174    | Complete |
|            lightbeam-bootstrap            | Complete |
| lightbeam-datahub-elasticsearch-setup-job | Complete |
|     lightbeam-datahub-kafka-setup-job     | Complete |
|   lightbeam-datahub-postgres-setup-job    | Complete |
|       lightbeam-mongo-aggr-28172293       |  Failed  |
|       lightbeam-mongo-aggr-28473174       | Complete |
|       lightbeam-mongo-aggr-28473175       | Complete |
|       lightbeam-mongo-aggr-28473176       | Complete |
|       lightbeam-post-install-setup        | Complete |
+-------------------------------------------+----------+

Persistentvolumeclaims:
+--------------------------------------------------------+--------+
|                          Name                          | Status |
+--------------------------------------------------------+--------+
|         data-lightbeam-elasticsearch-master-0          | Bound  |
|                 data-lightbeam-kafka-0                 | Bound  |
|            data-lightbeam-kafka-zookeeper-0            | Bound  |
|              datadir-lightbeam-mongodb-0               | Bound  |
|              lb-keycloakdir-lb-keycloak-0              | Bound  |
|                lightbeam-minio-pv-claim                | Bound  |
|            lightbeam-postgresql-postgres-0             | Bound  |
| prometheus-lb-prometheus-db-prometheus-lb-prometheus-0 | Bound  |
|           qdrant-storage-lightbeam-qdrant-0            | Bound  |
|              redis-data-lb-redis-master-0              | Bound  |
|             redis-data-lb-redis-replicas-0             | Bound  |
|             redis-data-lb-redis-replicas-1             | Bound  |
|             redis-data-lb-redis-replicas-2             | Bound  |
|                 vault-claim-lb-vault-0                 | Bound  |
+--------------------------------------------------------+--------+
###
k8s/k8s_measure_worker_node_network_bandwidth

NO OUTPUT 
###
redis/redis_get_keys_count

Error: Parameter type validation failed: action..redis_get_keys_count() missing 1 required positional argument: 'pattern'
###
k8s/k8s_get_versioning_info

Using incluster config
Versions:
kubectl: Client Version: v1.23.1
kubernetes: Client Version: v1.23.1
Server Version: v1.23.17
docker: Not found
###
redis/redis_get_metrics


Redis Metrics: 
+--------------------+-------+
|       Metric       | Value |
+--------------------+-------+
|     index_size     |   3   |
| memory_utilization |  2MB  |
|    dataset_size    | 262KB |
+--------------------+-------+
###
k8s/k8s_get_node_status_and_resource_utilization

Using incluster config
+-----------+--------+---------------+------------------+
| Node Name | Status | CPU Usage (%) | Memory Usage (%) |
+-----------+--------+---------------+------------------+
|  lb-inst  | Ready  |      53       |        66        |
+-----------+--------+---------------+------------------+
###
```
### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
