### PR TITLE
Optimize Kafka Get Topic With Lag 

### DIFF
--- a/Kafka/legos/kafka_get_topics_with_lag/kafka_get_topics_with_lag.py
+++ b/Kafka/legos/kafka_get_topics_with_lag/kafka_get_topics_with_lag.py
@@ -66,7 +66,10 @@ def kafka_get_topics_with_lag(handle, group_id: str = "", threshold: int = 10, s
     sample_data_dict = {}
     for group in consumer_groups:
         consumer = KafkaConsumer(bootstrap_servers=handle.config['bootstrap_servers'], group_id=group)
+        if consumer is None:
+            continue
         cached_kafka_info[group] = {'consumer': consumer}
+        
         try:
             for topic in consumer.topics():
                 partitions = consumer.partitions_for_topic(topic)

--- a/Kafka/legos/kafka_get_topics_with_lag/kafka_get_topics_with_lag.py
+++ b/Kafka/legos/kafka_get_topics_with_lag/kafka_get_topics_with_lag.py
@@ -70,7 +70,7 @@ def kafka_get_topics_with_lag(handle, group_id: str = "", threshold: int = 10, s
         try:
             for topic in consumer.topics():
                 partitions = consumer.partitions_for_topic(topic)
-                cached_kafka_info.update({'topics': {topic:partitions}})
+                cached_kafka_info[group].update({'topics': {topic:partitions}})
                 for partition in partitions:
                     tp = TopicPartition(topic, partition)
                     end_offset = consumer.end_offsets([tp])[tp]

--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -24,7 +24,7 @@ global:
    audit_period: 90
    # per check timeout, this timeout decides how much time should be given
    # per check for it to complete
-   execution_timeout: 140
+   execution_timeout: 200
 
 #
 # Checks section

--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -24,7 +24,7 @@ global:
    audit_period: 90
    # per check timeout, this timeout decides how much time should be given
    # per check for it to complete
-   execution_timeout: 60
+   execution_timeout: 140
 
 #
 # Checks section


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Diff provided by @amit-chandak-unskript  



### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

```
root@awesome-awesome-runbooks-0:~/test# time python ./kafka_test.py 
LENGTH OF CONSUMER_GROUPS: 5
Max Topics 63
Max Parition 32
Sum of Topics 315
Sum of Partition 765

real	0m38.206s
user	0m1.441s
sys	0m0.231s
root@awesome-awesome-runbooks-0:~/test# 
```

#### Simulated group to 100
```
root@awesome-awesome-runbooks-0:~/test# time python ./kafka_test.py 
LENGTH OF CONSUMER_GROUPS: 100
Max Topics 63
Max Parition 32
Sum of Topics 6300
Sum of Partition 15300

real	2m19.458s
user	0m16.369s
sys	0m2.976s
```



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
