### PR TITLE
Adding * for index to get metadata name

### DIFF
--- a/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
+++ b/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
@@ -105,67 +105,95 @@ def k8s_check_service_pvc_utilization(handle, service_name: str = "", namespace:
         if not response or response.stderr:
             raise ApiException(f"Error while executing command ({get_pod_command}): {response.stderr if response else 'empty response'}")
 
-        pod_name = response.stdout.strip()
-        if not pod_name:
+        # This variable should be named pod_names as we would get more than one pod_name in the space saparated string
+        pod_names = response.stdout.strip()
+        if not pod_names:
             print(f"No pods found for service {svc} in namespace {namespace} with labels {label_selector}")
             continue
         
         # Fetch PVCs attached to the pod
-        get_pvc_names_command = f"kubectl get pod {pod_name} -n {namespace} -o=jsonpath='{{.spec.volumes[*].persistentVolumeClaim.claimName}}'"
+        # The Above kubectl command would return a string that is space separated name(s) of the pod. 
+        # Given such a string, lets find out if we have one or more than one pod name in the string.
+        # If there are more than one pod name in the output, we need to iterate over all items[] array.
+        # Else we can directly access the persistentVolumeClaim name 
+        # Lets also associate the pod_name along with the claim name (PVC Name) in the format of
+        # pod_name:pv_claim_name
+        
+        if len(pod_names.split()) > 1:
+            json_path_cmd = "{range .items[*]}{.metadata.name}:{range .spec.volumes[*].persistentVolumeClaim}{.claimName} {end}{\"\\n\"}{end}"
+        else:
+            json_path_cmd = "{.metadata.name}:{range .spec.volumes[*].persistentVolumeClaim}{.claimName}{end}"
+
+        get_pvc_names_command = f"kubectl get pod {pod_names} -n {namespace} -o=jsonpath='{json_path_cmd}'"
+
+
         response = handle.run_native_cmd(get_pvc_names_command)
         if not response or response.stderr:
             raise ApiException(f"Error while executing command ({get_pvc_names_command}): {response.stderr if response else 'empty response'}")
-        pvc_names = response.stdout.strip().split()
-                
-        # If there are no PVCs for this service, continue to the next one
-        if not pvc_names:
+        # Example: ['lightbeam-elasticsearch-master-0:data-lightbeam-elasticsearch-master-0']
+        pod_and_pvc_names = response.stdout.strip().split()
+
+
+        # The pod_and_pvc_names 
+        if not pod_and_pvc_names:
             services_without_pvcs.append(svc)
             continue
 
-        # Fetch the Pod JSON
-        get_pod_json_command = f"kubectl get pod {pod_name} -n {namespace} -o json"
-        pod_json_output = handle.run_native_cmd(get_pod_json_command)
-        if not pod_json_output or pod_json_output.stderr:
-            raise ApiException(f"Error fetching pod json for {pod_name}: {pod_json_output.stderr if pod_json_output else 'empty response'}")
-        pod_data = json.loads(pod_json_output.stdout)
-
-        pvc_mounts = [
-            {"container_name": container['name'],
-            "mount_path": mount['mountPath'],
-            "pvc_name": volume['persistentVolumeClaim']['claimName']}
-            for container in pod_data['spec']['containers']
-            for mount in container.get('volumeMounts', [])
-            for volume in pod_data['spec']['volumes']
-            if 'persistentVolumeClaim' in volume and volume['name'] == mount['name']
-        ]
-
+        pvc_mounts = []
         alert_pvcs = []
         all_pvcs = []
+        for element in pod_and_pvc_names:
+            pod_name, claim_name = element.split(':')
 
-        for mount in pvc_mounts:
-            container_name = mount['container_name']
-            mount_path = mount['mount_path']
-            pvc_name = mount['pvc_name']
-            all_pvcs.append({"pvc_name": pvc_name, "mount_path": mount_path, "used": None, "capacity": None})
+            # Fetch the Pod JSON 
+            # We need to get the container name (if any) from the Pod's JSON. This is needed
+            # if we want to exec into the POD that is within a container. The JSON data that
+            # we obtain is used to fill the pvc_mounts list, which is a list of dictionaries.
+            # We use this pvc_mounts to find out the used_space percentage. We compare that with
+            # the threshold to flag if the utilization is above threshold. 
+            # df -kh is the command used to get the disk utilization. This is accurate as we get
+            # the disk utilization from the POD directly, rather than checking the resource limit
+            # and resource request from the deployment / stateful YAML file. 
+            get_pod_json_command = f"kubectl get pod {pod_name} -n {namespace} -o json"
+            pod_json_output = handle.run_native_cmd(get_pod_json_command)
+            if not pod_json_output or pod_json_output.stderr:
+                raise ApiException(f"Error fetching pod json for {pod_name}: {pod_json_output.stderr if pod_json_output else 'empty response'}")
+            pod_data = json.loads(pod_json_output.stdout)
+    
+            pvc_mounts.extend([
+                {"container_name": container['name'],
+                "mount_path": mount['mountPath'],
+                "pvc_name": claim_name if claim_name else volume['persistentVolumeClaim']['claimName']}
+                for container in pod_data['spec']['containers']
+                for mount in container.get('volumeMounts', [])
+                for volume in pod_data['spec']['volumes']
+                if 'persistentVolumeClaim' in volume and volume['name'] == mount['name']
+            ])
 
-        all_mounts = [mount.get('mount_path') for mount in pvc_mounts]
-        all_mounts = " ".join(all_mounts).strip()
-        du_command = f"kubectl exec -n {namespace} {pod_name} -c {container_name} -- df -kh {all_mounts} | grep -v Filesystem"
-        du_output = handle.run_native_cmd(du_command)
 
+            all_mounts = [mount.get('mount_path') for mount in pvc_mounts]
+            all_mounts = " ".join(all_mounts).strip()
+            for mount in pvc_mounts:
+                container_name = mount['container_name']
+                mount_path = mount['mount_path']
+                pvc_name = mount['pvc_name']
+                all_pvcs.append({"pvc_name": pvc_name, "mount_path": mount_path, "used": None, "capacity": None})
+    
+                du_command = f"kubectl exec -n {namespace} {pod_name} -c {container_name} -- df -kh {all_mounts} | grep -v Filesystem"
+                du_output = handle.run_native_cmd(du_command)
+                        
+                if du_output and not du_output.stderr:
+                    used_space = du_output.stdout.strip()
+                    for idx, space in enumerate([used_space]):
+                        space = space.split()
+                        used_percentage = int(space[-2].replace('%', ''))
+                        total_capacity_str = space[1].replace('%', '')
+                        all_pvcs[idx]["used"] = used_percentage
+                        all_pvcs[idx]["capacity"] =  total_capacity_str
+                        if used_percentage > threshold:
+                            alert_pvcs.append(all_pvcs[idx])
 
-        if du_output and not du_output.stderr:
-            used_space = du_output.stdout.strip()
-            for idx, space in enumerate([used_space]):
-                space = space.split()
-                used_percentage = int(space[-2].replace('%', ''))
-                total_capacity_str = space[1].replace('%', '')
-                all_pvcs[idx]["used"] = used_percentage
-                all_pvcs[idx]["capacity"] =  total_capacity_str
-                if used_percentage > threshold:
-                    alert_pvcs.append(all_pvcs[idx])
-
-        alert_pvcs_all_services.extend(alert_pvcs)
+            alert_pvcs_all_services.extend(alert_pvcs)
     if services_without_pvcs:
         print("Following services do not have any PVCs attached:")
         for service in services_without_pvcs:

--- a/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
+++ b/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
@@ -97,8 +97,10 @@ def k8s_check_service_pvc_utilization(handle, service_name: str = "", namespace:
         labels_dict = json.loads(response.stdout.replace("'", "\""))
         label_selector = ",".join([f"{k}={v}" for k, v in labels_dict.items()])
 
-        # Fetch the pod attached to this service
-        get_pod_command = f"kubectl get pods -n {namespace} -l {label_selector} -o=jsonpath='{{.items[0].metadata.name}}'"
+        # Fetch the pod attached to this service.
+        # The safer option is to try with the * option. Having a specific index like 0 or 1
+        # will lead to ApiException. 
+        get_pod_command = f"kubectl get pods -n {namespace} -l {label_selector} -o=jsonpath='{{.items[*].metadata.name}}'"
         response = handle.run_native_cmd(get_pod_command)
         if not response or response.stderr:
             raise ApiException(f"Error while executing command ({get_pod_command}): {response.stderr if response else 'empty response'}")

--- a/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
+++ b/Kubernetes/legos/k8s_check_service_pvc_utilization/k8s_check_service_pvc_utilization.py
@@ -145,6 +145,9 @@ def k8s_check_service_pvc_utilization(handle, service_name: str = "", namespace:
         
         for element in pod_and_pvc_names:
             pod_name, claim_name = element.split(':')
+            if not claim_name:
+                # Skip if Volume Claim name is empty.
+                continue 
 
             # Fetch the Pod JSON 
             # We need to get the container name (if any) from the Pod's JSON. This is needed


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Fixes [EN-5324]


* While getting the pod name based of service label, the regression that was caused was by indexing with a specific index, like 0. It would be safer to index it with `*`.



### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

```
root@awesome-awesome-runbooks-0:~/test# unskript-ctl.sh run check --name k8s_check_service_pvc_utilization
Running: 100%|████████████████████████████████████████████████████████| 3/3 [00:04<00:00,  1.50s/it]

╒═══════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                       │ Result   │   Failed Count │ Error   │
╞═══════════════════════════════════╪══════════╪════════════════╪═════════╡
│ Check K8s service PVC utilization │  PASS    │              0 │ N/A     │
╘═══════════════════════════════════╧══════════╧════════════════╧═════════╛
```

#### Video that display the combination of tests that were done. 

`Note: The Print statements were put deliberately to show the output at each level. These statements were removed before checking in`

##### Combination tested

* SVC with PODs Associated with it 
* SVC with no POD associated with it 
* SVC with POD associated but no mount point (OUTPUT:  PVC MOUNTS LENGTH 0)
* SVC with POD associated and 1 mount point
* SVC with POD associated and has more than 1 mount point
* SVC with POD in a container and has 1 or more mount points
* SVC with POD not in a container that has 1 or more mount points 

** All tests were set with Threshold set to 70% 


The combination listed above tests the impact of changing the `0` index to `*`. The impact
of changing had ramification of how the code after the replacement behaved.  

Here is the total time it took to execute with namespace and all services under it.

```
real	1m44.931s
user	0m18.681s
sys	0m7.315s
```

Here is the total time it took to execute a given service in a given namespace.

```
real	0m5.842s
user	0m1.204s
sys	0m0.298s
```

https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/605f4c7d-a5be-4ffb-baa2-dbbae8245643




### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5324]: https://unskript.atlassian.net/browse/EN-5324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ