### PR TITLE
Timeout per check enforcement

### DIFF
--- a/unskript-ctl/templates/first_cell_content.j2
+++ b/unskript-ctl/templates/first_cell_content.j2
@@ -1,5 +1,9 @@
 import json
 import concurrent.futures
+import threading
+import functools
+import polling2
+from polling2 import poll
 from unskript import nbparams
 from unskript.fwk.workflow import Task, Workflow
 from unskript.secrets import ENV_MODE, ENV_MODE_LOCAL

--- a/unskript-ctl/templates/template_info_lego.j2
+++ b/unskript-ctl/templates/template_info_lego.j2
@@ -1,0 +1,13 @@
+if __name__ == "__main__":
+    try:
+        poll(lambda: action(),
+            step=1, 
+            timeout={{ execution_timeout }}, 
+            poll_forever=False)
+    except polling2.TimeoutException: 
+        # Poll Timeout, since we are not checking
+        # Any return value, if the check has timed out the
+        # decorator function would automatically print the error_message
+        # about the timeout. 
+        print("Info gathering action returned after {{ execution_timeout }} seconds")
+        pass

--- a/unskript-ctl/templates/template_info_lego.j2
+++ b/unskript-ctl/templates/template_info_lego.j2
@@ -1,13 +1,2 @@
 if __name__ == "__main__":
-    try:
-        poll(lambda: action(),
-            step=1, 
-            timeout={{ execution_timeout }}, 
-            poll_forever=False)
-    except polling2.TimeoutException: 
-        # Poll Timeout, since we are not checking
-        # Any return value, if the check has timed out the
-        # decorator function would automatically print the error_message
-        # about the timeout. 
-        print("Info gathering action returned after {{ execution_timeout }} seconds")
-        pass
+    action()

--- a/unskript-ctl/templates/template_script.j2
+++ b/unskript-ctl/templates/template_script.j2
@@ -2,22 +2,28 @@ import signal
 import sys
 import os
 import io
+import threading
+import functools
 import polling2
 from polling2 import poll
 
 # Logger object
 _logger = None
 
+# Script to check mapping
+_script_to_check_mapping = {}
+
 class TimeoutException(Exception):
     pass
+
 
 def timeout_handler(signum, frame):
     raise TimeoutException("Checks timed out")
 
-def _run_function(fn):
+def _run_function(fname):
     global w
     l_cell = False
-    if fn == "last_cell":
+    if fname == "last_cell":
         l_cell = True
     output = None
     success = False 
@@ -28,36 +34,47 @@ def _run_function(fn):
         output = output_buffer.getvalue()
     else:
         try:
-            fn = globals().get(fn)
+            fn = globals().get(fname)
             if _logger:
-                # Since lego and lego_printer are nested within the check function
-                # we can use co_consts to extract the lego_printer and strip off the 
-                # _printer to get the lego function name
+                # Since we are using decorator for controlling the timeout, the earlier way of getting const.co_name
+                # would not work because, the decorator mapping mangles the function name with the wrapper. 
+                # We rely on the calling function to get the check name as a mapping (dictionary).
                 chk_name = ''
-                for const in fn.__code__.co_consts:
-                    if isinstance(const, type(fn.__code__)):
-                        if const.co_name.endswith('printer'):
-                            chk_name = const.co_name.replace('_printer','')
+                if _script_to_check_mapping:
+                    chk_name = _script_to_check_mapping.get(fname)
                 _logger.debug(f"Starting to execute check {fn} {chk_name}")
-            fn() 
+            
+            poll(globals().get(fname), 
+                            step=1, 
+                            timeout={{ execution_timeout }},
+                            poll_forever=False,
+                            check_success= lambda v: v is not None)
             success = True
+        except polling2.TimeoutException:
+            # Polling timeout
+            if _logger:
+                _logger.debug(f"Execution completed for {fn}")
         except Exception as e:
             # If one of the action fails dump the exception on console and proceed further
             print(str(e))
             if _logger:
                 _logger.debug(str(e))
     sys.stdout = sys.__stdout__
-    if _logger:
-        _logger.debug(f"Completed execution of check {fn}")
+    
     return output, success
 
-def do_run_(logger = None):
+def do_run_(logger = None, script_to_check_mapping = {}):
     import sys
     from tqdm import tqdm
     global _logger 
+    global _script_to_check_mapping
+
     output = None
     if logger:
         _logger = logger
+    
+    if script_to_check_mapping:
+        _script_to_check_mapping = script_to_check_mapping
 
     if _logger:
         _logger.debug("Starting to execute {{ num_checks }} number of checks")
@@ -65,32 +82,33 @@ def do_run_(logger = None):
     for i in tqdm(range({{ num_checks + 1 }}), desc="Running", leave=True, ncols=100):
         fn = "check_" + str(i)
         if hasattr(globals().get(fn), "__call__"):
-            try:
-                result = poll(lambda: _run_function(fn), 
-                                step=1, 
-                                timeout={{ execution_timeout }},
-                                poll_forever=False)
-                if result and not result[1]:
-                    print('\n. Check Did not complete')
-            except polling2.TimeoutException:
-                print("Timeout Reached")
-                continue
-            except Exception as e:
-                print(f" Exception Reached {str(e)}")
-                return 
+            result = _run_function(fn)
+            if _logger:
+                if result:
+                    if isinstance(result, tuple):
+                        if result[-1]:
+                            _logger.debug(f"Check {fn} was successful")
+                        else:
+                            _logger.debug(f"Check {fn} failed")
+                                    
     output, _ = _run_function('last_cell')
 
-    # We need to reset alarm because if any SIGALRM was triggred in the _run_function
-    # then any other operation like running info checks, or running script will also
-    # be subject to the same timeout restriction. Need to reset before running them.
-    signal.alarm(0)
+    # Lets dump the output in the log file so we can refer to the status of it 
+    # later on
+    if _logger:
+        if output:
+            _logger.debug(output)
+        else:
+            _logger.debug("No output for the checks run")
 
     return output
 
 if __name__ == "__main__":
     logger = None
+    script_to_check_mapping = None
     try:
         logger = sys.argv[1]
+        script_to_check_mapping = sys.argv[2]
     except:
         pass 
-    do_run_(logger)
+    do_run_(logger, script_to_check_mapping)

--- a/unskript-ctl/templates/template_script.j2
+++ b/unskript-ctl/templates/template_script.j2
@@ -35,16 +35,16 @@ def _run_function(fname):
     else:
         try:
             fn = globals().get(fname)
+            # We use the _script_to_check_mapping runbook_variable to explicitly map 
+            # check name to script name.
+            chk_name = ''
+            if _script_to_check_mapping:
+                chk_name = _script_to_check_mapping.get(fname)
+
             if _logger:
-                # Since we are using decorator for controlling the timeout, the earlier way of getting const.co_name
-                # would not work because, the decorator mapping mangles the function name with the wrapper. 
-                # We rely on the calling function to get the check name as a mapping (dictionary).
-                chk_name = ''
-                if _script_to_check_mapping:
-                    chk_name = _script_to_check_mapping.get(fname)
                 _logger.debug(f"Starting to execute check {fn} {chk_name}")
             
-            poll(globals().get(fname), 
+            response = poll(globals().get(fname), 
                             step=1, 
                             timeout={{ execution_timeout }},
                             poll_forever=False,
@@ -53,7 +53,7 @@ def _run_function(fname):
         except polling2.TimeoutException:
             # Polling timeout
             if _logger:
-                _logger.debug(f"Execution completed for {fn}")
+                _logger.debug(f"Execution completed for {fn} <-> {chk_name}")
         except Exception as e:
             # If one of the action fails dump the exception on console and proceed further
             print(str(e))

--- a/unskript-ctl/templates/timeout_handler.j2
+++ b/unskript-ctl/templates/timeout_handler.j2
@@ -2,7 +2,7 @@ import threading
 import functools
 
 
-def timeout(seconds=10, error_message="Function call timed out"):
+def timeout(seconds=60, error_message="Function call timed out"):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/unskript-ctl/templates/timeout_handler.j2
+++ b/unskript-ctl/templates/timeout_handler.j2
@@ -1,0 +1,30 @@
+import threading
+import functools
+
+
+def timeout(seconds=10, error_message="Function call timed out"):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # Container for storing function's result
+            result_container = [None]
+
+            # Define a target function for the thread that captures the return value
+            def target():
+                result_container[0] = func(*args, **kwargs)
+
+            # Start the thread
+            thread = threading.Thread(target=target)
+            thread.daemon = True
+            thread.start()
+            thread.join(seconds)
+
+            if thread.is_alive():
+                # If the thread is still alive after the timeout, raise a TimeoutError
+                raise TimeoutError(error_message)
+            else:
+                # Return the value stored in the container
+                return result_container[0]
+
+        return wrapper
+    return decorator

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -807,16 +807,9 @@ class InfoAction(ChecksFactory):
                         f.write('    ' + line.rstrip() + '\n')
                 f.write('\n')
                 # Now the Main section
-                f.write('if __name__ == "__main__":' + '\n')
-                f.write("    try:\n")
-                f.write("        poll(action(), \n") 
-                f.write("             step=1, \n") 
-                f.write("             timeout=execution_timeout, \n")
-                f.write("             poll_forever=False, \n")
-                f.write("             check_success= lambda v: v is not None)\n")
-                f.write("    except polling2.TimeoutException: \n")
-                f.write("        # Poll Timeout for the info lego \n")
-                f.write("        print(\"Timeout Occurred \") \n")
+                f.write(self.get_main_section_of_info_lego(execution_timeout=execution_timeout))
+                f.write('\n')
+                
 
         if os.path.exists(self.temp_jit_dir) is True:
             return True
@@ -862,7 +855,15 @@ class InfoAction(ChecksFactory):
 
         template = Template(content_template)
         return  template.render(execution_timeout=execution_timeout)
+
+    def get_main_section_of_info_lego(self, execution_timeout):
+        with open(os.path.join(os.path.dirname(__file__), 'templates/template_info_lego.j2'), 'r') as f:
+            content_template = f.read()
+
+        template = Template(content_template)
+        return  template.render(execution_timeout=execution_timeout)
     
+
     def insert_task_lines(self, list_of_actions: list):
         if list_of_actions and len(list_of_actions):
             return self._common.insert_task_lines(list_of_actions=list_of_actions)

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -340,8 +340,11 @@ class Checks(ChecksFactory):
                         l = l.replace('\n', '')
                         if l.startswith("from __future__"):
                             continue
-                        f.write('    ' + l.replace('\n', '') + '\n')
-                f.write('        return task.output \n')
+                        if 'task.execute' in l:
+                            f.write('        output =' + l.replace('\n', '') + '\n')
+                        else:
+                            f.write('    ' + l.replace('\n', '') + '\n')
+                f.write('        return output \n')
             f.write('\n')
             # Lets create the last cell content
             f.write('def last_cell():' + '\n')

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -757,6 +757,7 @@ class InfoAction(ChecksFactory):
                 self.logger.debug(result.stdout)
             except subprocess.TimeoutExpired as e:
                 self.logger.error(f"Timeout occurred while executing {script}: {str(e)}")
+                self.uglobals['info_action_results'][result_key] += '\n' + 'ACTION TIMEOUT'
                 return None
             except subprocess.CalledProcessError as e:
                 self.logger.error(f"Error executing {script}: {str(e)}")
@@ -809,9 +810,6 @@ class InfoAction(ChecksFactory):
             with open(jit_file, 'w') as f:
                 f.write(first_cell_content)
                 f.write('\n\n')
-                # f.write(timeout_decorator)
-                # f.write('\n\n')
-                # f.write(f"@timeout(seconds={execution_timeout}, error_message=\"Action timed out\")\n")
                 f.write('def action():' + '\n')
                 f.write('    global w' + '\n')
                 for lines in action.get('code'):

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -341,6 +341,7 @@ class Checks(ChecksFactory):
                         if l.startswith("from __future__"):
                             continue
                         f.write('    ' + l.replace('\n', '') + '\n')
+                f.write('        return task.output \n')
             f.write('\n')
             # Lets create the last cell content
             f.write('def last_cell():' + '\n')


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Change timeout logic for checks. Moved away from signal.alarm to decorator based timeout
* Info legos also has the timeout logic 

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Info legos with timeout run 

[temp_info_lego_test.txt](https://github.com/unskript/Awesome-CloudOps-Automation/files/14491942/temp_info_lego_test.txt)

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
