### PR TITLE
En 5340 timeout checks in report

### DIFF
--- a/unskript-ctl/templates/template_script.j2
+++ b/unskript-ctl/templates/template_script.j2
@@ -49,7 +49,7 @@ def _run_function(fname):
                             timeout={{ execution_timeout }},
                             poll_forever=False,
                             check_success= lambda v: v is not None)
-            success = True
+            return response
         except polling2.TimeoutException:
             # Polling timeout
             if _logger:
@@ -59,6 +59,9 @@ def _run_function(fname):
             print(str(e))
             if _logger:
                 _logger.debug(str(e))
+        finally:
+            if _logger:
+                _logger.debug(f"Completed Execution of {fn} <-> {chk_name}")
     sys.stdout = sys.__stdout__
     
     return output, success

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -207,6 +207,7 @@ class Checks(ChecksFactory):
                             failed_objects = [failed_objects]
                         c_name = self.connector_types[idx] + ':' + self.check_names[idx]
                         failed_result[c_name] = failed_objects
+                        failed_result_available = True
                     error_msg = payload.get('error') if payload.get('error') else self.parse_failed_objects(failed_object=failed_objects)
                     result_table.append([
                         self.check_names[idx],
@@ -325,10 +326,8 @@ class Checks(ChecksFactory):
             f.write('\n\n')
             for idx,c in enumerate(checks_list[:]):
                 _entry_func = c.get('metadata', {}).get('action_entry_function', '')
-                _check_uuid = self.check_uuids[idx]
                 idx += 1
                 self.script_to_check_mapping[f"check_{idx}"] =  _entry_func
-                self.script_to_check_mapping[_check_uuid] = _entry_func
                 exec_timeout = per_check_timeout.get(_entry_func, execution_timeout)
                 f.write(f"@timeout(seconds={exec_timeout}, error_message=\"Check check_{idx} timed out\")\n")
                 check_name = f"def check_{idx}():"


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Fixes [EN-5340] [EN-5341]

This PR brings in two important fixes
* Timed out check listing in the report with the Count of errored checks
* Failed object to the check name was not considering the priority order 


<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Testing of P0/P1 Check
```
root@awesome-awesome-runbooks-0:~# unskript-ctl.sh run check --type postgres --report
Running: 100%|████████████████████████████████████████████████████████| 7/7 [02:02<00:00, 17.43s/it]

╒════════════════════════════════════════╤══════════╤════════════════╤═════════════════════════════╕
│ Checks Name                            │ Result   │   Failed Count │ Error                       │
╞════════════════════════════════════════╪══════════╪════════════════╪═════════════════════════════╡
│ Long Running PostgreSQL Queries        │  ERROR   │              0 │ ('Not able to connect to '  │
│                                        │          │                │  'PostGreSQL, error None, ' │
│                                        │          │                │  'code None')               │
├────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────┤
│ PostgreSQL Get Cache Hit Ratio         │  ERROR   │              0 │ ('Not able to connect to '  │
│                                        │          │                │  'PostGreSQL, error None, ' │
│                                        │          │                │  'code None')               │
├────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────┤
│ PostgreSQL check active connections    │  ERROR   │              0 │ ('Not able to connect to '  │
│                                        │          │                │  'PostGreSQL, error None, ' │
│                                        │          │                │  'code None')               │
├────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────┤
│ PostgreSQL Check Unused Indexes        │  ERROR   │              0 │ ('Not able to connect to '  │
│                                        │          │                │  'PostGreSQL, error None, ' │
│                                        │          │                │  'code None')               │
├────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────┤
│ PostgreSQL check for locks in database │  ERROR   │              0 │ ('Not able to connect to '  │
│                                        │          │                │  'PostGreSQL, error None, ' │
│                                        │          │                │  'code None')               │
├────────────────────────────────────────┼──────────┼────────────────┼─────────────────────────────┤
│ PostgreSQL get service status          │  ERROR   │              0 │ ('Not able to connect to '  │
│                                        │          │                │  'PostGreSQL, error None, ' │
│                                        │          │                │  'code None')               │
╘════════════════════════════════════════╧══════════╧════════════════╧═════════════════════════════╛

postgresql:postgresql_long_running_queries
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_get_cache_hit_ratio
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_check_active_connections
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_check_unused_indexes
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_check_locks
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_get_server_status
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None
```

#### Log file for P0/P1 Checks
```
2024-03-06 15:42:18 : Initializing UnskriptCtl
2024-03-06 15:42:18 : 	VERSION: 1.2.0 

2024-03-06 15:42:18 : 	AUTHORS: unSkript Authors 

2024-03-06 15:42:18 : 	BUILD_NUMBER: 1.5.31 

2024-03-06 15:42:18 : ConfigParserFactory instance initialized
2024-03-06 15:42:18 : Notification instance initialized
2024-03-06 15:42:18 : ConfigParserFactory instance initialized
2024-03-06 15:42:18 : Checks instance initialized
2024-03-06 15:42:18 : ConfigParserFactory instance initialized
2024-03-06 15:42:18 : Initialized Checks Class
2024-03-06 15:42:18 : CommonAction instance initialized
2024-03-06 15:42:18 : ConfigParserFactory instance initialized
2024-03-06 15:42:18 : Script instance initialized
2024-03-06 15:42:18 : ConfigParserFactory instance initialized
2024-03-06 15:42:18 : Initialized Script Class
2024-03-06 15:42:18 : PSS instance initialized
2024-03-06 15:42:18 : Checking if DB unskript_pss.db exists
2024-03-06 15:42:18 : DB unskript_pss.db Exists!
2024-03-06 15:42:18 : CodeSnippets instance initialized
2024-03-06 15:42:18 : Checking if DB snippets.db exists
2024-03-06 15:42:18 : DB snippets.db Exists!
2024-03-06 15:42:19 : Initialized DBInterface
2024-03-06 15:42:19 : Returning 6 UUIDs and 6 names
2024-03-06 15:42:19 : Starting to execute 6 number of checks
2024-03-06 15:42:19 : Starting to execute check <function check_1 at 0x7f7dd414d3a0> postgresql_long_running_queries
2024-03-06 15:42:40 : Execution completed for <function check_1 at 0x7f7dd414d3a0> <-> postgresql_long_running_queries
2024-03-06 15:42:40 : Completed Execution of <function check_1 at 0x7f7dd414d3a0> <-> postgresql_long_running_queries
2024-03-06 15:42:40 : Check check_1 failed
2024-03-06 15:42:40 : Starting to execute check <function check_2 at 0x7f7dd414d4e0> postgresql_get_cache_hit_ratio
2024-03-06 15:43:01 : Execution completed for <function check_2 at 0x7f7dd414d4e0> <-> postgresql_get_cache_hit_ratio
2024-03-06 15:43:01 : Completed Execution of <function check_2 at 0x7f7dd414d4e0> <-> postgresql_get_cache_hit_ratio
2024-03-06 15:43:01 : Check check_2 failed
2024-03-06 15:43:01 : Starting to execute check <function check_3 at 0x7f7dd414d620> postgresql_check_active_connections
2024-03-06 15:43:21 : Execution completed for <function check_3 at 0x7f7dd414d620> <-> postgresql_check_active_connections
2024-03-06 15:43:21 : Completed Execution of <function check_3 at 0x7f7dd414d620> <-> postgresql_check_active_connections
2024-03-06 15:43:21 : Check check_3 failed
2024-03-06 15:43:21 : Starting to execute check <function check_4 at 0x7f7dd414d760> postgresql_check_unused_indexes
2024-03-06 15:43:41 : Execution completed for <function check_4 at 0x7f7dd414d760> <-> postgresql_check_unused_indexes
2024-03-06 15:43:41 : Completed Execution of <function check_4 at 0x7f7dd414d760> <-> postgresql_check_unused_indexes
2024-03-06 15:43:41 : Check check_4 failed
2024-03-06 15:43:41 : Starting to execute check <function check_5 at 0x7f7dd414d8a0> postgresql_check_locks
2024-03-06 15:44:02 : Execution completed for <function check_5 at 0x7f7dd414d8a0> <-> postgresql_check_locks
2024-03-06 15:44:02 : Completed Execution of <function check_5 at 0x7f7dd414d8a0> <-> postgresql_check_locks
2024-03-06 15:44:02 : Check check_5 failed
2024-03-06 15:44:02 : Starting to execute check <function check_6 at 0x7f7dd414d9e0> postgresql_get_server_status
2024-03-06 15:44:22 : Execution completed for <function check_6 at 0x7f7dd414d9e0> <-> postgresql_get_server_status
2024-03-06 15:44:22 : Completed Execution of <function check_6 at 0x7f7dd414d9e0> <-> postgresql_get_server_status
2024-03-06 15:44:22 : Check check_6 failed
2024-03-06 15:44:22 : {"status": 3, "objects": null, "error": "Not able to connect to PostGreSQL, error None, code None", "id": "ef9f0f3dd00ef0972895ea006375f1a4496dca1b7266bc60fdfbd8ab4feee6c3"}
{"status": 3, "objects": null, "error": "Not able to connect to PostGreSQL, error None, code None", "id": "09f3d8f85ceed4fbcb1aa13ad9c9b61f379930e233281a79bde202576527002e"}
{"status": 3, "objects": null, "error": "Not able to connect to PostGreSQL, error None, code None", "id": "04e19856bc6babb725ef622cb96bcf761ba18478cc7dc70e1543a8feeb00641c"}
{"status": 3, "objects": null, "error": "Not able to connect to PostGreSQL, error None, code None", "id": "fc1f7112c37b46eed768f59361cc2d5a1feda8fa30313d4c6a4472d8a0f47f61"}
{"status": 3, "objects": null, "error": "Not able to connect to PostGreSQL, error None, code None", "id": "46f125c64d416cce23e2078f773b431820ec281a7d1210f75ffef9fba58bc160"}
{"status": 3, "objects": null, "error": "Not able to connect to PostGreSQL, error None, code None", "id": "87e9ff0722db197da178206513be0f31402e6a9b4b7941709b3d145702898d7a"}


```

#### Email Notification with P0/P1 Priority
<img width="953" alt="Screenshot 2024-03-06 at 7 52 19 AM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/5f052bad-a13f-44ba-b447-844d875c9486">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5340]: https://unskript.atlassian.net/browse/EN-5340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-5341]: https://unskript.atlassian.net/browse/EN-5341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ