### PR TITLE
Adding try/except running lego, info legos and script

### DIFF
--- a/unskript-ctl/templates/template_info_lego.j2
+++ b/unskript-ctl/templates/template_info_lego.j2
@@ -1,2 +1,5 @@
 if __name__ == "__main__":
-    action()
+    try:
+        action()
+    except Exception as e:
+        print(f"Exception Caught: {str(e)}")

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -132,15 +132,35 @@ class UnskriptCtl(UnskriptFactory):
                 parser.print_help()
                 sys.exit(0)
 
-            status_of_run = self._check.run(checks_list=check_list)
-            self.uglobals['status_of_run'] = status_of_run
-            self.update_audit_trail(collection_name='audit_trail', status_dict_list=status_of_run)
+            # Catch any exceptions when run_checks  
+            try:
+                status_of_run = self._check.run(checks_list=check_list)
+                self.uglobals['status_of_run'] = status_of_run
+                self.update_audit_trail(collection_name='audit_trail', status_dict_list=status_of_run)
+            except Exception as e:
+                # Lets ensure we set the failed object appropriately
+                self.uglobals['failed_result'] = {'result': [f'CHECK RUN CAUGHT AN EXCEPTION:  {str(e)}']}
+                self.logger.debug(f"Exception caught running checks! {str(e)}")
+                self.logger.error(f"ERROR! caught an exception while executing checks {str(e)}")
 
         if 'script' in args and args.command == 'run' and args.script not in ('', None):
-            self._script.run(script=args.script)
+            # Catch any exceptions when run scripts 
+            try:
+                self._script.run(script=args.script)
+            except Exception as e:
+                self.logger.debug(f"Exception caught running script! {str(e)}")
+                self.logger.error(f"ERROR! caught an exception while executing script {args.script}")
+                
 
         if args.command == 'run' and args.info:
-            self.run_info()
+            # Catch any exceptions when running info lego
+            try:
+                self.run_info()
+            except Exception as e:
+                self.logger.debug(f"Exception caught running info gathering legos! {str(e)}")
+                self.logger.error(f"ERROR! caught an exception while executing info gathering legos {str(e)}")
+                 
+
 
     def run_info(self):
         """This function runs the info gathering actions"""


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
[EN-5350]

* This PR brings in try/catch envelope that runs checks/info legos and scripts execution to unskript-ctl.sh
* We envelope try/catch before we call the run_check, run_info and run_script

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Running a Check with instrumented `raise exception`
```
root@awesome-awesome-runbooks-0:~# unskript-ctl.sh run check --name k8s_check_cronjob_pod_status --report
Running: 100%|████████████████████████████████████████████████████████| 5/5 [00:02<00:00,  2.39it/s]

╒══════════════════════════════════════╤══════════╤════════════════╤══════════════════════════════════╕
│ Checks Name                          │ Result   │   Failed Count │ Error                            │
╞══════════════════════════════════════╪══════════╪════════════════╪══════════════════════════════════╡
│ Check the status of K8s CronJob pods │  ERROR   │              0 │ ('Raising Exception for '        │
│                                      │          │                │  'k8s_check_cronjob_pod_status') │
╘══════════════════════════════════════╧══════════╧════════════════╧══════════════════════════════════╛

k8s:Check the status of K8s CronJob pods
Failed Objects:
- Raising Exception for k8s_check_cronjob_pod_status

 
2024-03-11 22:24:18,856 - UnskriptCtlLogger - INFO - Slack Message was sent successfully!
2024-03-11 22:24:19,560 - UnskriptCtlLogger - INFO - Notification sent successfully to XXX@XXX.COM
2024-03-11 22:24:19,562 - UnskriptCtlLogger - INFO - Successfully sent Email notification via Sendgrid.
```

####  Email Notification for Checks Lego
<img width="1079" alt="Screenshot 2024-03-11 at 3 29 25 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/09f11f42-974a-4ce6-9b9b-760fe7492403">


#### Explicitly inducing info lego 

```
root@awesome-awesome-runbooks-0:~# unskript-ctl.sh run --info --report


Information Gathering Action Results
Running: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.02s/it]

k8s/k8s_get_versioning_info



Using incluster config
Error while executing: Raising Exception for k8s_get_versioning_info
Execution Failed: Error: Raising Exception for k8s_get_versioning_info
  Task Parameters: {}
Execution: Raising Exception for k8s_get_versioning_info

###
2024-03-11 22:34:58,417 - UnskriptCtlLogger - INFO - Notification sent successfully to jayasimha@unskript.com
2024-03-11 22:34:58,417 - UnskriptCtlLogger - INFO - Successfully sent Email notification via Sendgrid.
root@awesome-awesome-runbooks-0:~# 
```

#### Email Notification for info lego
<img width="808" alt="Screenshot 2024-03-11 at 3 36 26 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/d10963c1-dcfc-4dcb-852b-d4d5ae0e2bee">


#### Artificially inducing sys exit in the script

```
root@awesome-awesome-runbooks-0:~# unskript-ctl.sh run --script /tmp/hello.sh --report 
Execution script /tmp/hello.sh
OUTPUT FILE /unskript/data/execution/unskript_script_run_output-2024-03-11T22_38_11.000196/unskript_script_run_output.txt
/tmp/hello.sh error, Command '['/tmp/hello.sh']' returned non-zero exit status 127.
2024-03-11 22:38:11,117 - UnskriptCtlLogger - INFO - ERROR: Nothing to send, Results Empty
2024-03-11 22:38:11,958 - UnskriptCtlLogger - INFO - Notification sent successfully to XXXX@XXX.COM
2024-03-11 22:38:11,959 - UnskriptCtlLogger - INFO - Successfully sent Email notification via Sendgrid.
root@awesome-awesome-runbooks-0:~# 
```
#### Email notification when script errors out 
<img width="740" alt="Screenshot 2024-03-11 at 3 39 48 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/328ba120-e271-47b7-9478-6c213daf9e38">



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5350]: https://unskript.atlassian.net/browse/EN-5350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ