### PR TITLE
Remove print statement from resource utilization info lego

### DIFF
--- a/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
+++ b/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
@@ -58,7 +58,6 @@ def k8s_get_all_resources_utilization_info(handle, namespace: str = "") -> Dict:
     pod_utilization_cmd = f"kubectl top pods {namespace_option} --no-headers"
     pod_utilization = handle.run_native_cmd(pod_utilization_cmd)
     if pod_utilization.stderr:
-        print(f"Error occurred while fetching pod utilization: {pod_utilization.stderr}")
         pass
 
     pod_utilization_lines = pod_utilization.stdout.split('\n')

--- a/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
+++ b/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
@@ -90,6 +90,9 @@ def k8s_get_all_resources_utilization_info(handle, namespace: str = "") -> Dict:
 
             if resource == 'pods':
                 status = item['status']['phase']
+                 # Skip pods in Succeeded or Completed state as they dont have any utilization
+                if status in ['Succeeded', 'Completed', 'Failed']:
+                    continue
                 key = (ns, name)
                 cpu_usage, memory_usage = utilization_map.get(key, ('N/A', 'N/A'))
                 data[resource].append([ns, name, status, cpu_usage, memory_usage])


### PR DESCRIPTION
## Description

1. Feedback received: the latest report looks good but I see an error in at few places: `Error occurred while fetching pod utilization:` Please check.
2. Removed pods that are in Suceeded, Completed and Failed state.

### Testing
<img width="1005" alt="Screenshot 2024-03-19 at 6 37 31 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/8171be6e-a318-4d4e-aaef-15d82b2fde8d">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
