### PR TITLE
Fixed issue with timedout checks skipping in report

### DIFF
--- a/unskript-ctl/templates/last_cell_content.j2
+++ b/unskript-ctl/templates/last_cell_content.j2
@@ -7,6 +7,20 @@ try:
                 output = json.loads(output)
                 output['id'] = id
                 print(json.dumps(output))
+            # Lets take care of Timed out checks too. That output
+            # will be not included in the workflow output. Lets findout
+            # and explictly add them to the output
+            if len(w.check_output.keys()) < len(w.check_uuids):
+                existing_ids = [x for x in w.check_output.keys()]
+                missing_ids = [item for item in w.check_uuids if item not in existing_ids]
+                for id in missing_ids:
+                    temp_dict = {
+                        "status": 3,
+                        "objects": None,
+                        "error": "Check Timeout",
+                        "id": str(id)
+                    }
+                    print(json.dumps(temp_dict))
         else:
             print(json.dumps("Not a check run"))
     else:

--- a/unskript-ctl/templates/last_cell_content.j2
+++ b/unskript-ctl/templates/last_cell_content.j2
@@ -1,4 +1,5 @@
 from unskript.legos.utils import CheckOutput, CheckOutputStatus
+global w 
 
 try:
     if 'w' in globals():
@@ -7,20 +8,27 @@ try:
                 output = json.loads(output)
                 output['id'] = id
                 print(json.dumps(output))
-            # Lets take care of Timed out checks too. That output
-            # will be not included in the workflow output. Lets findout
-            # and explictly add them to the output
-            if len(w.check_output.keys()) < len(w.check_uuids):
-                existing_ids = [x for x in w.check_output.keys()]
-                missing_ids = [item for item in w.check_uuids if item not in existing_ids]
-                for id in missing_ids:
-                    temp_dict = {
-                        "status": 3,
-                        "objects": None,
-                        "error": "Check Timeout",
-                        "id": str(id)
-                    }
-                    print(json.dumps(temp_dict))
+            # Lets check if we have errored_checks or timeout_checks
+            # exists, if yes then lets dump the output 
+            if hasattr(w, 'check_uuid_entry_function_map'):
+                if hasattr(w, 'timeout_checks') and len(w.timeout_checks):
+                    for name, err_msg in w.timeout_checks.items():
+                        _id = w.check_uuid_entry_function_map.get(name)
+                        print(json.dumps({
+                            "status": 3,
+                            "objects": None,
+                            "error": err_msg,
+                            "id": str(_id)
+                        }))
+                if hasattr(w, 'errored_checks') and len(w.errored_checks):
+                    for name, err_msg in w.errored_checks.items():
+                        _id = w.check_uuid_entry_function_map.get(name)
+                        print(json.dumps({
+                            "status": 3,
+                            "objects": None,
+                            "error": err_msg,
+                            "id": str(_id)
+                        }))
         else:
             print(json.dumps("Not a check run"))
     else:

--- a/unskript-ctl/templates/template_script.j2
+++ b/unskript-ctl/templates/template_script.j2
@@ -51,15 +51,29 @@ def _run_function(fname):
                             poll_forever=False,
                             check_success= lambda v: v is not None)
             return response
-        except polling2.TimeoutException:
+        except polling2.TimeoutException as e:
             # Polling timeout
             if _logger:
                 _logger.debug(f"Execution completed for {fn} <-> {chk_name}")
+            
+            if not hasattr(w, 'timeout_checks'):
+                w.timeout_checks = {}
+            w.timeout_checks.update({chk_name: str(e).replace(fname,"")})
+            if _logger:
+                _logger.debug(f"TIMEOUT CHECKS {w.timeout_checks}")
+
         except Exception as e:
             # If one of the action fails dump the exception on console and proceed further
             print(str(e))
             if _logger:
                 _logger.debug(str(e))
+
+            if not hasattr(w, 'errored_checks'):
+                w.errored_checks = {}
+            w.errored_checks.update({chk_name: str(e).replace(fname,"")})
+            if _logger:
+                _logger.debug(f"ERRORED CHECKS {w.errored_checks}")
+
         finally:
             if _logger:
                 _logger.debug(f"Completed Execution of {fn} <-> {chk_name}")
@@ -72,6 +86,7 @@ def do_run_(logger = None, script_to_check_mapping = {}):
     from tqdm import tqdm
     global _logger 
     global _script_to_check_mapping
+    global w
 
     output = None
     if logger:

--- a/unskript-ctl/unskript_ctl_factory.py
+++ b/unskript-ctl/unskript_ctl_factory.py
@@ -313,8 +313,9 @@ class ConfigParserFactory(UnskriptFactory):
         # Explicitly fetch and map checks for each priority level using the constants
         for priority_level in [CHECK_PRIORITY_P0, CHECK_PRIORITY_P1, CHECK_PRIORITY_P2]:
             priority_checks = priority_config.get(priority_level, [])
-            for check_name in priority_checks:
-                checks_priority[check_name] = priority_level
+            if priority_checks:
+                for check_name in priority_checks:
+                    checks_priority[check_name] = priority_level
 
         return checks_priority
 

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -391,7 +391,8 @@ class Checks(ChecksFactory):
                     for index, value in enumerate(v):
                         first_cell_content += f'{k}{index} = \"{value}\"' + '\n'
         first_cell_content += f'''w = Workflow(env, secret_store_cfg, None, global_vars=globals(), check_uuids={self.check_uuids})''' + '\n'
-        temp_map = {key: value for key, value in zip(self.check_entry_functions, self.check_uuids)}
+        # temp_map = {key: value for key, value in zip(self.check_entry_functions, self.check_uuids)}
+        temp_map = dict(zip(self.check_entry_functions, self.check_uuids))
         first_cell_content += f'''w.check_uuid_entry_function_map = {temp_map}'''
 
         return first_cell_content

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -182,13 +182,13 @@ class Checks(ChecksFactory):
                
                 if ids and CheckOutputStatus(payload.get('status')) == CheckOutputStatus.SUCCESS:
                     result_table.append([
-                        self.check_names[idx],
+                        self.prioritized_checks_to_id_mapping[payload.get('id')],
                         self.TBL_CELL_CONTENT_PASS,
                         0,
                         'N/A'
                         ])
                     checks_per_priority_per_result_list[priority]['PASS'].append([
-                        self.check_names[idx],
+                        self.prioritized_checks_to_id_mapping[payload.get('id')],
                         ids[idx],
                         self.connector_types[idx]]
                         )
@@ -196,14 +196,14 @@ class Checks(ChecksFactory):
                     failed_objects = payload.get('objects')
                     failed_result[c_name] = failed_objects
                     result_table.append([
-                        self.check_names[idx],
+                        self.prioritized_checks_to_id_mapping[payload.get('id')],
                         self.TBL_CELL_CONTENT_FAIL,
                         len(failed_objects),
                         self.parse_failed_objects(failed_object=failed_objects)
                         ])
                     failed_result_available = True
                     checks_per_priority_per_result_list[priority]['FAIL'].append([
-                        self.check_names[idx],
+                        self.prioritized_checks_to_id_mapping[payload.get('id')],
                         ids[idx],
                         self.connector_types[idx]
                         ])
@@ -217,13 +217,14 @@ class Checks(ChecksFactory):
                         failed_result_available = True
                     error_msg = payload.get('error') if payload.get('error') else self.parse_failed_objects(failed_object=failed_objects)
                     result_table.append([
-                        self.check_names[idx],
+                        self.prioritized_checks_to_id_mapping[payload.get('id')],
                         self.TBL_CELL_CONTENT_ERROR,
                         0,
                         pprint.pformat(error_msg, width=30)
                         ])
                     checks_per_priority_per_result_list[priority]['ERROR'].append([
-                        self.check_names[idx],
+                        # self.check_names[idx],
+                        self.prioritized_checks_to_id_mapping[payload.get('id')],
                         ids[idx],
                         self.connector_types[idx]
                         ])

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -390,7 +390,9 @@ class Checks(ChecksFactory):
                 if v:
                     for index, value in enumerate(v):
                         first_cell_content += f'{k}{index} = \"{value}\"' + '\n'
-        first_cell_content += f'''w = Workflow(env, secret_store_cfg, None, global_vars=globals(), check_uuids={self.check_uuids})'''
+        first_cell_content += f'''w = Workflow(env, secret_store_cfg, None, global_vars=globals(), check_uuids={self.check_uuids})''' + '\n'
+        temp_map = {key: value for key, value in zip(self.check_entry_functions, self.check_uuids)}
+        first_cell_content += f'''w.check_uuid_entry_function_map = {temp_map}'''
 
         return first_cell_content
 


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
[EN-5391]

* Fixed an issue that timeout-checks were not included in reports
* Fixed issue about listing the Checks with results based on the priority checks


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Unit Testing
```
unskript@awesome-awesome-runbooks-0:~/test$ unskript-ctl.sh run check --type kafka --script /tmp/hello.sh  --report
Running: 100%|████████████████████████████████████████████████████████| 6/6 [00:06<00:00,  1.17s/it]

╒════════════════════════════════════╤══════════╤════════════════╤═════════════════╕
│ Checks Name                        │ Result   │   Failed Count │ Error           │
╞════════════════════════════════════╪══════════╪════════════════╪═════════════════╡
│ kafka_broker_health_check          │  PASS    │              0 │ N/A             │
├────────────────────────────────────┼──────────┼────────────────┼─────────────────┤
│ kafka_topic_partition_health_check │  PASS    │              0 │ N/A             │
├────────────────────────────────────┼──────────┼────────────────┼─────────────────┤
│ kafka_check_lag_change             │  ERROR   │              0 │ 'Check Timeout' │
├────────────────────────────────────┼──────────┼────────────────┼─────────────────┤
│ kafka_check_offline_partitions     │  ERROR   │              0 │ 'Check Timeout' │
├────────────────────────────────────┼──────────┼────────────────┼─────────────────┤
│ kafka_get_topics_with_lag          │  ERROR   │              0 │ 'Check Timeout' │
╘════════════════════════════════════╧══════════╧════════════════╧═════════════════╛

kafka:kafka_check_lag_change
Failed Objects:
- Check Timeout

 
kafka:kafka_check_offline_partitions
Failed Objects:
- Check Timeout

 
kafka:kafka_get_topics_with_lag
Failed Objects:
- Check Timeout

 
Execution script /tmp/hello.sh
OUTPUT FILE /unskript/data/execution/run_output-2024-03-26T23_00_07.619686/run_output.txt
2024-03-26 23:00:09,021 - UnskriptCtlLogger - INFO - Slack Message was sent successfully!
INFO:botocore.credentials:Found credentials in environment variables.
2024-03-26 23:00:11,350 - UnskriptCtlLogger - INFO - Email notification sent to jayasimha@unskript.com
2024-03-26 23:00:11,353 - UnskriptCtlLogger - INFO - Successfully sent Email notification via AWS SES.
unskript@awesome-awesome-runbooks-0:~/test$ 

```
### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5391]: https://unskript.atlassian.net/browse/EN-5391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ