### PR TITLE
Adding check_entry_function to output so that diagnostic script can use it

### DIFF
--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -90,6 +90,7 @@ class Checks(ChecksFactory):
                 if isinstance(d, dict) is False:
                     d = json.loads(d)
                 d['name'] = self.check_names[self.check_uuids.index(d.get('id'))]
+                d['check_entry_function'] = self.check_entry_functions[self.check_uuids.index(d.get('id'))]
                 output_list.append(d)
             outputs = output_list
         except Exception as e:
@@ -102,6 +103,7 @@ class Checks(ChecksFactory):
                 self.logger.error("Output is None from check's output")
                 self._error('OUTPUT IS EMPTY FROM CHECKS RUN!')
                 sys.exit(0)
+
             with open(output_file, 'w', encoding='utf-8') as f:
                 f.write(json.dumps(outputs))
             if len(outputs) == 0:


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* Adds `check_entry_function` to the execution output file.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Unit Testing
```
unskript@awesome-awesome-runbooks-0:/unskript/data/execution$ cat 9f0d1fbb-2df0-420c-89d3-ad308cca262a_output.txt | jq | more
[
  {
    "status": 1,
    "objects": null,
    "error": "",
    "id": "159ba9d99a6a388a1a0ec2b9462f4c1437beeca771a2ddd62cd9cbd32d3293c9",
    "name": "Get Kafka broker health",
    "check_entry_function": "kafka_broker_health_check"
  },
  {
    "status": 1,
    "objects": null,
    "error": "",
    "id": "99cafafecb730b73c1ea9a17d43e307ad2ee22e539d79b856f16dc074bf98dd7",
    "name": "Get Kafka topic partition health",
    "check_entry_function": "kafka_topic_partition_health_check"
  },
  {
    "status": 3,
    "objects": null,
    "error": "Check  timed out",
    "id": "2f0258c05fedc1bca62f6302ee04241b5e9e6ba8dc1c371fe8ba3044066b455c",
    "name": "Kafka check lag change",
    "check_entry_function": "kafka_check_lag_change"
  },
  {
    "status": 3,
    "objects": null,
    "error": "Check  timed out",
    "id": "473e81cd8bfb50718c2386bffd18fef456b8ec5c84d64078a47e1f82d3176750",
    "name": "Kafka Check Offline Partitions",
    "check_entry_function": "kafka_check_offline_partitions"
  },
  {
    "status": 3,
    "objects": null,
    "error": "Check  timed out",
    "id": "f884e7508699cdae8fabae7a808e44fd4abcd43f789175f79083a5c7aeaf45c7",
    "name": "Kafka get topics with lag",
    "check_entry_function": "kafka_get_topics_with_lag"
  }
]

```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
