### PR TITLE
YAML changes for diagnostic feature

### DIFF
--- a/unskript-ctl/unskript_ctl_factory.py
+++ b/unskript-ctl/unskript_ctl_factory.py
@@ -319,3 +319,13 @@ class ConfigParserFactory(UnskriptFactory):
 
         return checks_priority
 
+    def get_diagnostic_commands(self):
+        # Retrieves the diagnostic commands for checks defined under the 'checks' section in the YAML configuration.
+        checks_section = self._get('checks')
+        diagnostic_commands_section = checks_section.get('diagnostic_commands', {})
+
+        if not isinstance(diagnostic_commands_section, dict):
+            self.logger.error("The 'diagnostic_commands' section is not properly formatted.")
+            return {}
+
+        return diagnostic_commands_section


### PR DESCRIPTION
## Description
[EN-5397](https://unskript.atlassian.net/browse/EN-5397)


### Testing
New YAML:
```
checks:
  # Arguments common to all checks, like region, namespace, etc.
  arguments:
    global:
      #core services
      core_services: [lightbeam-api-gateway, lb-argo-workflows-server, lightbeam-frontend, kong-proxy, lightbeam-kafka, kafka-ui, lb-kafka-connect, lightbeam-kafka-metrics, lb-keycloak, lightbeam-mongodb-headless, lightbeam-elasticsearch-master, lb-vault, lightbeam-tika-server, lightbeam-presidio-server, lightbeam-text-extraction, lightbeam-text-extraction-non-ocr]
      # Memory utilization services
      services: [lightbeam-api-gateway, lightbeam-frontend, kong-proxy, lightbeam-kafka, kafka-ui, lb-keycloak, lightbeam-mongodb, lightbeam-elasticsearch-master, lb-vault, lightbeam-tika-server, lightbeam-presidio-server, lightbeam-text-extraction, lightbeam-text-extraction-non-ocr]
      matrix:
       namespace: [lightbeam, logging, cert-manager, unskript]
  diagnostic_commands:
    vault_get_service_health:
      - "vault status"
      - "kubectl logs deployment/lb-vault -n lightbeam"
    redis_list_large_keys:
      - "redis-cli --bigkeys"
    k8s_get_pending_pods:
      - "kubectl get pods --field-selector=status.phase=Pending -n lightbeam"
      - "kubectl describe pods --all-namespaces | grep -E 'ImagePullBackOff|ErrImagePull'"
# Info section
info:
  arguments:
    global:
      namespace_to_check_bandwidth: lightbeam
      matrix:
        namespace: [lightbeam, logging, unskript, cert-manager]
```
<img width="1499" alt="Screenshot 2024-03-28 at 4 31 49 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/9de57098-5717-4e9e-bc26-a97769ff2f30">



### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5397]: https://unskript.atlassian.net/browse/EN-5397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ