### PR TITLE
Fixed UT fixes for missing checks in report

### DIFF
--- a/unskript-ctl/templates/last_cell_content.j2
+++ b/unskript-ctl/templates/last_cell_content.j2
@@ -1,34 +1,47 @@
 from unskript.legos.utils import CheckOutput, CheckOutputStatus
 global w 
 
+all_outputs = []
+other_outputs = []
 try:
     if 'w' in globals():
         if w.check_run:
             for id,output in w.check_output.items():
                 output = json.loads(output)
                 output['id'] = id
-                print(json.dumps(output))
+                all_outputs.append(output)
             # Lets check if we have errored_checks or timeout_checks
             # exists, if yes then lets dump the output 
             if hasattr(w, 'check_uuid_entry_function_map'):
                 if hasattr(w, 'timeout_checks') and len(w.timeout_checks):
                     for name, err_msg in w.timeout_checks.items():
                         _id = w.check_uuid_entry_function_map.get(name)
-                        print(json.dumps({
+                        other_outputs.append({
                             "status": 3,
                             "objects": None,
                             "error": err_msg,
                             "id": str(_id)
-                        }))
+                        })
                 if hasattr(w, 'errored_checks') and len(w.errored_checks):
                     for name, err_msg in w.errored_checks.items():
                         _id = w.check_uuid_entry_function_map.get(name)
-                        print(json.dumps({
+                        other_outputs.append({
                             "status": 3,
                             "objects": None,
                             "error": err_msg,
                             "id": str(_id)
-                        }))
+                        })
+            if other_outputs:
+               for _other in other_outputs:
+                  for _output in all_outputs:
+                     # Lets eliminate duplicate entries in the output
+                     # We could have double accounted failed and error timeout 
+                     # case 
+                     if _other.get('id') == _output.get('id'):
+                         _output = _other
+
+            for _output in all_outputs:
+                print(json.dumps(_output))
         else:
             print(json.dumps("Not a check run"))
     else:

--- a/unskript-ctl/unskript_ctl_factory.py
+++ b/unskript-ctl/unskript_ctl_factory.py
@@ -79,7 +79,7 @@ class UctlLogger(logging.Logger):
     def dump_to_file(self, msg):
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         with open(self.log_file_name, 'a') as f:
-            f.write(timestamp + ' : ' + msg + '\n')
+            f.write(timestamp + ' : ' + str(msg) + '\n')
 
 # This is the Base class, Abstract class that shall be used by all the other
 # classes that are implemented. This class is implemented as a Singleton class

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -338,9 +338,10 @@ class Checks(ChecksFactory):
             for idx,c in enumerate(checks_list[:]):
                 _entry_func = c.get('metadata', {}).get('action_entry_function', '')
                 _action_uuid = c.get('metadata', {}).get('action_uuid', '')
+                _check_name = c.get('metadata', {}).get('action_title', '')
                 idx += 1
                 self.script_to_check_mapping[f"check_{idx}"] =  _entry_func
-                self.prioritized_checks_to_id_mapping[str(_action_uuid)] = _entry_func
+                self.prioritized_checks_to_id_mapping[str(_action_uuid)] = _check_name
                 exec_timeout = per_check_timeout.get(_entry_func, execution_timeout)
                 f.write(f"@timeout(seconds={exec_timeout}, error_message=\"Check check_{idx} timed out\")\n")
                 check_name = f"def check_{idx}():"

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -103,7 +103,6 @@ class Checks(ChecksFactory):
                 self.logger.error("Output is None from check's output")
                 self._error('OUTPUT IS EMPTY FROM CHECKS RUN!')
                 sys.exit(0)
-
             with open(output_file, 'w', encoding='utf-8') as f:
                 f.write(json.dumps(outputs))
             if len(outputs) == 0:
@@ -179,18 +178,20 @@ class Checks(ChecksFactory):
                 _action_uuid = payload.get('id')
                 if _action_uuid:
                     c_name = self.connector_types[idx] + ':' + self.prioritized_checks_to_id_mapping[_action_uuid]
+                    p_check_name = self.prioritized_checks_to_id_mapping[_action_uuid]
                 else:
                     c_name = self.connector_types[idx] + ':' + self.check_names[idx]
+                    p_check_name = self.check_names[idx]
                
                 if ids and CheckOutputStatus(payload.get('status')) == CheckOutputStatus.SUCCESS:
                     result_table.append([
-                        self.prioritized_checks_to_id_mapping[payload.get('id')],
+                        p_check_name,
                         self.TBL_CELL_CONTENT_PASS,
                         0,
                         'N/A'
                         ])
                     checks_per_priority_per_result_list[priority]['PASS'].append([
-                        self.prioritized_checks_to_id_mapping[payload.get('id')],
+                        p_check_name,
                         ids[idx],
                         self.connector_types[idx]]
                         )
@@ -198,14 +199,14 @@ class Checks(ChecksFactory):
                     failed_objects = payload.get('objects')
                     failed_result[c_name] = failed_objects
                     result_table.append([
-                        self.prioritized_checks_to_id_mapping[payload.get('id')],
+                        p_check_name,
                         self.TBL_CELL_CONTENT_FAIL,
                         len(failed_objects),
                         self.parse_failed_objects(failed_object=failed_objects)
                         ])
                     failed_result_available = True
                     checks_per_priority_per_result_list[priority]['FAIL'].append([
-                        self.prioritized_checks_to_id_mapping[payload.get('id')],
+                        p_check_name,
                         ids[idx],
                         self.connector_types[idx]
                         ])
@@ -219,14 +220,14 @@ class Checks(ChecksFactory):
                         failed_result_available = True
                     error_msg = payload.get('error') if payload.get('error') else self.parse_failed_objects(failed_object=failed_objects)
                     result_table.append([
-                        self.prioritized_checks_to_id_mapping[payload.get('id')],
+                        p_check_name,
                         self.TBL_CELL_CONTENT_ERROR,
                         0,
                         pprint.pformat(error_msg, width=30)
                         ])
                     checks_per_priority_per_result_list[priority]['ERROR'].append([
                         # self.check_names[idx],
-                        self.prioritized_checks_to_id_mapping[payload.get('id')],
+                        p_check_name,
                         ids[idx],
                         self.connector_types[idx]
                         ])


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

* The index overflow happened because the result was double accounted for Failed and Errored case. 
* There was also an issue with fmt string when logging. Fixed that too


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

```
unskript@awesome-awesome-runbooks-0:~$ unskript-ctl.sh run check --type k8s,vault,postgres,redis,kafka,elasticsearch,mongodb --info --script /tmp/hello.sh --report
Running: 100%|████████████████████████████████████████████████████| 105/105 [04:35<00:00,  2.62s/it]

╒══════════════════════════════════════════════════════╤══════════╤════════════════╤══════════════════════════════════════════════════╕
│ Checks Name                                          │ Result   │   Failed Count │ Error                                            │
╞══════════════════════════════════════════════════════╪══════════╪════════════════╪══════════════════════════════════════════════════╡
│ vault_get_service_health                             │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ redis_get_cluster_health                             │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ redis_list_large_keys                                │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ k8s_get_expiring_cluster_certificate                 │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get all K8s Pods in ImagePullBackOff State           │  FAIL    │              1 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ k8s_check_worker_cpu_utilization                     │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get Kubernetes Failed Deployments                    │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get expiring secret certificates                     │  FAIL    │              2 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get Kubernetes Unbound PVCs                          │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get all K8s Pods in CrashLoopBackOff State           │  FAIL    │              1 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ k8s_get_nodes_pressure                               │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Check the status of K8s CronJob pods                 │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ k8s_get_offline_nodes                                │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Detect K8s service crashes                           │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get all K8s Pods in Terminating State                │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get Kubernetes Error PODs from All Jobs              │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get Deployment Status                                │  FAIL    │              1 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get Kubernetes PODS with high restart                │  FAIL    │              2 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ k8s_check_service_status                             │  ERROR   │              0 │ ('check_52.<locals>.k8s_check_service_status() ' │
│                                                      │          │                │  'missing 1 required '                           │
│                                                      │          │                │  'positional argument: '                         │
│                                                      │          │                │  "'endpoints'")                                  │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get K8s services exceeding memory utilization        │  FAIL    │              1 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get K8S OOMKilled Pods                               │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get Kubernetes PODs in not Running State             │  FAIL    │              3 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get K8s get pending pods                             │  FAIL    │              1 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get All Evicted PODS From Namespace                  │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get K8S Cluster Health                               │  FAIL    │              1 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Check K8s service PVC utilization                    │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ Get K8S Service with no associated endpoints         │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ k8s_get_nodes_with_insufficient_resources            │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ elasticsearch_compare_cluster_disk_size_to_threshold │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ elasticsearch_check_health_status                    │  FAIL    │              1 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ elasticsearch_get_index_health                       │  FAIL    │             27 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ elasticsearch_check_large_index_size                 │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ postgresql_get_server_status                         │  ERROR   │              0 │ ('Not able to connect to '                       │
│                                                      │          │                │  'PostGreSQL, error None, '                      │
│                                                      │          │                │  'code None')                                    │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ postgresql_long_running_queries                      │  ERROR   │              0 │ ('Not able to connect to '                       │
│                                                      │          │                │  'PostGreSQL, error None, '                      │
│                                                      │          │                │  'code None')                                    │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ postgresql_check_active_connections                  │  ERROR   │              0 │ ('Not able to connect to '                       │
│                                                      │          │                │  'PostGreSQL, error None, '                      │
│                                                      │          │                │  'code None')                                    │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ postgresql_check_locks                               │  ERROR   │              0 │ ('Not able to connect to '                       │
│                                                      │          │                │  'PostGreSQL, error None, '                      │
│                                                      │          │                │  'code None')                                    │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ postgresql_get_cache_hit_ratio                       │  ERROR   │              0 │ ('Not able to connect to '                       │
│                                                      │          │                │  'PostGreSQL, error None, '                      │
│                                                      │          │                │  'code None')                                    │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ postgresql_check_unused_indexes                      │  ERROR   │              0 │ ('Not able to connect to '                       │
│                                                      │          │                │  'PostGreSQL, error None, '                      │
│                                                      │          │                │  'code None')                                    │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ mongodb_get_server_status                            │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ mongodb_check_large_index_size                       │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ mongodb_compare_disk_size_to_threshold               │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ kafka_broker_health_check                            │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ kafka_check_lag_change                               │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ kafka_topic_partition_health_check                   │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ kafka_check_offline_partitions                       │  ERROR   │              0 │ 'Connection time-out'                            │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ kafka_get_topics_with_lag                            │  PASS    │              0 │ N/A                                              │
├──────────────────────────────────────────────────────┼──────────┼────────────────┼──────────────────────────────────────────────────┤
│ lb_custom_check                                      │  FAIL    │             35 │ N/A                                              │
╘══════════════════════════════════════════════════════╧══════════╧════════════════╧══════════════════════════════════════════════════╛

k8s:Get all K8s Pods in ImagePullBackOff State
Failed Objects:
- - container: lightbeam-policy-consumer
    namespace: lightbeam
    pod: lightbeam-policy-consumer-65d546cc4d-x6nsx

 
k8s:Get expiring secret certificates
Failed Objects:
- - days_remaining: -124
    namespace: lightbeam
    secret_name: lbdemoeg
    status: Expired
  - days_remaining: -367
    namespace: lightbeam
    secret_name: vault-tls-server
    status: Expired
- - days_remaining: -124
    namespace: unskript
    secret_name: lbdemoeg
    status: Expired
  - days_remaining: -93
    namespace: unskript
    secret_name: lbunskript1
    status: Expired
  - days_remaining: -104
    namespace: unskript
    secret_name: letsencrypt-cert-unskript
    status: Expired

 
k8s:Get all K8s Pods in CrashLoopBackOff State
Failed Objects:
- - container: lightbeam-api-gateway
    namespace: lightbeam
    pod: lightbeam-api-gateway-5cdfb4b69-bqr8w

 
k8s:Get Deployment Status
Failed Objects:
- - deployment_name: lightbeam-policy-consumer
    namespace: lightbeam

 
k8s:Get Kubernetes PODS with high restart
Failed Objects:
- - name: lightbeam-api-gateway-5cdfb4b69-bqr8w
    namespace: lightbeam
  - name: lightbeam-text-extraction-7cf9f6c8b9-c9qp9
    namespace: lightbeam
- - name: audit-6d84f4dcf4-rnjpc
    namespace: unskript
  - name: calendar-7ddd547fcc-hfzff
    namespace: unskript
  - name: connectors-748c49c879-nsr2s
    namespace: unskript
  - name: events-f6dc98b4d-nksch
    namespace: unskript
  - name: lambda-f4b7b9666-jms6s
    namespace: unskript
  - name: legos-7d95656795-fz9tp
    namespace: unskript
  - name: notifications-b46dfb877-764x6
    namespace: unskript
  - name: privileges-5c555f847f-lppqb
    namespace: unskript
  - name: skynet-8c56f6cbc-qqfq4
    namespace: unskript
  - name: tenantmgr-858f4b46bc-thdrt
    namespace: unskript
  - name: workflows-6746455b6c-z2ljk
    namespace: unskript

 
k8s:k8s_check_service_status
Failed Objects:
- 'check_52.<locals>.k8s_check_service_status() missing 1 required positional argument:
  ''endpoints'''

 
k8s:Get K8s services exceeding memory utilization
Failed Objects:
- - container_name: kafka-connect
    memory_request_bytes: 268435456
    memory_usage_bytes: 750780416
    namespace: lightbeam
    pod: lb-kafka-connect-5c6846cdbd-jkx2k
    service: lb-kafka-connect
    utilization_percentage: 279.69

 
k8s:Get Kubernetes PODs in not Running State
Failed Objects:
- - name: ingress-kong-69fdcf9b7c-x2j4t
    namespace: lightbeam
    status: Failed
  - name: jr-pkg-test
    namespace: lightbeam
    status: Failed
  - name: kafka-ui-558c57f65f-6cxt7
    namespace: lightbeam
    status: Failed
  - name: lb-argo-workflows-controller-7f4d9d8fb9-484mk
    namespace: lightbeam
    status: Failed
  - name: lb-argo-workflows-server-5dd6b9956b-57h9s
    namespace: lightbeam
    status: Failed
  - name: lb-workflow-executor-6d4777bb8f-qbwgf
    namespace: lightbeam
    status: Failed
  - name: lightbeam-datahub-gms-graphql-6b47fcd8ff-nh4vw
    namespace: lightbeam
    status: Failed
  - name: lightbeam-files-service-69bf959f5c-c688m
    namespace: lightbeam
    status: Failed
  - name: lightbeam-policy-consumer-65d546cc4d-x6nsx
    namespace: lightbeam
    status: Pending
  - name: lightbeam-schema-registry-694887697d-vclw8
    namespace: lightbeam
    status: Failed
- - name: cert-manager-cainjector-6c58576757-z94hq
    namespace: cert-manager
    status: Failed
- - name: enterprise-gateway-85b75f659c-8hclf
    namespace: unskript
    status: Failed
  - name: nginx-server-749fd77cf-qr84l
    namespace: unskript
    status: Failed
  - name: remote-tunnel-server-7487cb947c-wpqwj
    namespace: unskript
    status: Failed

 
k8s:Get K8s get pending pods
Failed Objects:
- - - lightbeam-policy-consumer-65d546cc4d-x6nsx
    - lightbeam

 
k8s:Get K8S Cluster Health
Failed Objects:
- - issue: Pod is not running.
    name: lb-argo-workflows-server-5dd6b9956b-57h9s
    namespace: lightbeam
    type: Pod
  - issue: Pod is not running.
    name: ingress-kong-69fdcf9b7c-x2j4t
    namespace: lightbeam
    type: Pod
  - issue: Pod is not running.
    name: kafka-ui-558c57f65f-6cxt7
    namespace: lightbeam
    type: Pod

 
elasticsearch:elasticsearch_check_health_status
Failed Objects:
- cluster_name: lightbeam-elasticsearch
  status: yellow
  unassigned_shards: 28

 
elasticsearch:elasticsearch_get_index_health
Failed Objects:
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: datajobindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338676152'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: datajobindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: WvCZnbllTWmG7XsOIgnOIQ
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411774854
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: WvCZnbllTWmG7XsOIgnOIQ
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: mlmodelindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338672355'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: mlmodelindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: 9A3EHTWBQZqc8LGX-siIfA
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411778639
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: 9A3EHTWBQZqc8LGX-siIfA
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: mlmodelgroupindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338674363'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: mlmodelgroupindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: AFcdZSqkTaiyxxbj0PrU0w
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411776480
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: AFcdZSqkTaiyxxbj0PrU0w
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: dataflowindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338675770'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: dataflowindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: -0zL4n1FQyqFOcRSiSR11A
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411775402
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: -0zL4n1FQyqFOcRSiSR11A
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: usagestats_v1
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338678758'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: usagestats_v1
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: uzlzWIdIQriLPYL0Wu81-w
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411772499
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: uzlzWIdIQriLPYL0Wu81-w
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: corpuserindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338670981'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: corpuserindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: Erev82flSG2hWtf9J0LSWw
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411780259
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: Erev82flSG2hWtf9J0LSWw
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: dataprocessindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338672940'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: dataprocessindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: sQAsi78QSUK5DS1pErNirQ
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411778383
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: sQAsi78QSUK5DS1pErNirQ
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: chartindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338678053'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: chartindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: rBVlCYS5Qp6SxBAjF62Pjw
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411773276
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: rBVlCYS5Qp6SxBAjF62Pjw
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: tagindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338676529'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: tagindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: pXTn56fpTn-m3JMi5oAffQ
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411774873
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: pXTn56fpTn-m3JMi5oAffQ
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: mlmodeldeploymentindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338670149'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: mlmodeldeploymentindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: oyXXs3F9Tp6Gi1Uk3MRrUw
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411781292
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: oyXXs3F9Tp6Gi1Uk3MRrUw
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: dashboardindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338678437'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: dashboardindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: 2g4M2JIiQ52WJAdPOvYVqg
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411773125
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: 2g4M2JIiQ52WJAdPOvYVqg
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: databaseindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338673859'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: databaseindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: HYTNN__kSWqkzYC5CtV7dg
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411777693
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: HYTNN__kSWqkzYC5CtV7dg
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: datasetindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338677657'
    max_ngram_diff: '17'
    max_result_window: '100000'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: datasetindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: vknE0LRQRviNL9ApccTQMg
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411774046
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: vknE0LRQRviNL9ApccTQMg
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: databaseschemaindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338671867'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: databaseschemaindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: rQVs7wMPREm0jQiHbe0IKQ
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 2
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411779716
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 1
  status: open
  store.size: 226b
  tasks: {}
  uuid: rQVs7wMPREm0jQiHbe0IKQ
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: mlfeatureindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338675363'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: mlfeatureindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: WHFRRO57TZ2YdWZ39XVO7Q
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411776393
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: WHFRRO57TZ2YdWZ39XVO7Q
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: dataplatformindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338670548'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: dataplatformindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: RApKYrtjSwC1q1LSicOxwA
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411781206
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: RApKYrtjSwC1q1LSicOxwA
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: glossarynodeindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338674983'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: glossarynodeindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: Q0P3GRb8TcKuPeoBeXUKmA
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411776886
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: Q0P3GRb8TcKuPeoBeXUKmA
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: lb_tables_green
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    creation_date: '1690338870222'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: lb_tables_green
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: j61h8jEmQbCih__UCnfX0A
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411581704
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: j61h8jEmQbCih__UCnfX0A
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: graph_service_v1
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338669641'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: graph_service_v1
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: rJgaVXYLSb6EHiVfYPOXzw
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411782301
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: rJgaVXYLSb6EHiVfYPOXzw
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: lb_tables_blue
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    creation_date: '1690338869916'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: lb_tables_blue
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: 5b2xp1xwSjWPnGQfKo0sQQ
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 1
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411582148
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 1
  status: open
  store.size: 226b
  tasks: {}
  uuid: 5b2xp1xwSjWPnGQfKo0sQQ
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: mlfeaturetableindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338673350'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: mlfeaturetableindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: AvO22CKnRgKniPv0kO_y3Q
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411778686
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: AvO22CKnRgKniPv0kO_y3Q
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: generic_datasource_document
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    creation_date: '1690338869601'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: generic_datasource_document
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: iJIrWJa8S8-6jAD76bOmrw
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411582574
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: iJIrWJa8S8-6jAD76bOmrw
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: glossarytermindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338676942'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: glossarytermindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: sYAZqTFBRcKNpcaJuCRQew
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411775294
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: sYAZqTFBRcKNpcaJuCRQew
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: drive
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        my_ngram_analyzer:
          filter:
          - lowercase
          tokenizer: my_ngram_tokenizer
        my_ngram_analyzer_search:
          tokenizer: lowercase
      tokenizer:
        my_ngram_tokenizer:
          max_gram: '20'
          min_gram: '1'
          token_chars:
          - letter
          type: ngram
    creation_date: '1690338869119'
    max_ngram_diff: '20'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: drive
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: dF49ZbshQoy5_ZFZvbW-tg
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411583175
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: dF49ZbshQoy5_ZFZvbW-tg
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: api_stats
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    creation_date: '1690338869365'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: api_stats
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: 9q6zG5xARrue6_jMg3c4aA
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 6
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411583042
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: 9q6zG5xARrue6_jMg3c4aA
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: mlprimarykeyindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338677257'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: mlprimarykeyindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: q308-9L7Rl-EROJK0iJuBw
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411775014
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: q308-9L7Rl-EROJK0iJuBw
- docs.count: '0'
  docs.deleted: '0'
  health: yellow
  index: corpgroupindex_v2
  pri: '1'
  pri.store.size: 226b
  rep: '1'
  settings:
    analysis:
      analyzer:
        browse_path_hierarchy:
          filter:
          - lowercase
          tokenizer: path_hierarchy
        custom_keyword:
          filter:
          - lowercase
          - asciifolding
          tokenizer: keyword
        partial:
          filter:
          - custom_delimiter
          - lowercase
          - partial_filter
          tokenizer: main_tokenizer
        partial_urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          - partial_filter
          tokenizer: urn_char_group
        slash_pattern:
          filter:
          - lowercase
          tokenizer: slash_tokenizer
        urn_component:
          filter:
          - lowercase
          - urn_stop_filter
          tokenizer: urn_char_group
        word_delimited:
          filter:
          - custom_delimiter
          - lowercase
          tokenizer: main_tokenizer
      filter:
        custom_delimiter:
          preserve_original: 'true'
          split_on_numerics: 'false'
          type: word_delimiter
        partial_filter:
          max_gram: '20'
          min_gram: '3'
          type: edge_ngram
        urn_stop_filter:
          stopwords:
          - urn
          - li
          - mlmodeldeployment
          - dataplatform
          - corpuser
          - corpgroup
          - databaseschema
          - mlmodel
          - dataprocess
          - mlfeaturetable
          - database
          - mlmodelgroup
          - glossarynode
          - mlfeature
          - dataflow
          - datajob
          - tag
          - glossaryterm
          - mlprimarykey
          - dataset
          - chart
          - dashboard
          type: stop
      normalizer:
        keyword_normalizer:
          filter:
          - lowercase
          - asciifolding
      tokenizer:
        main_tokenizer:
          pattern: '[ ./]'
          type: pattern
        slash_tokenizer:
          pattern: '[/]'
          type: pattern
        urn_char_group:
          pattern: '[:\s(),]'
          type: pattern
    creation_date: '1690338671437'
    max_ngram_diff: '17'
    number_of_replicas: '1'
    number_of_shards: '1'
    provided_name: corpgroupindex_v2
    routing:
      allocation:
        include:
          _tier_preference: data_content
    uuid: KJJ1YCKtSTWYDBTcrjoRYQ
    version:
      created: '7170099'
  stats:
    completion:
      size_in_bytes: 0
    docs:
      count: 0
      deleted: 0
    fielddata:
      evictions: 0
      memory_size_in_bytes: 0
    flush:
      periodic: 0
      total: 1
      total_time_in_millis: 0
    get:
      current: 0
      exists_time_in_millis: 0
      exists_total: 0
      missing_time_in_millis: 0
      missing_total: 0
      time_in_millis: 0
      total: 0
    indexing:
      delete_current: 0
      delete_time_in_millis: 0
      delete_total: 0
      index_current: 0
      index_failed: 0
      index_time_in_millis: 0
      index_total: 0
      is_throttled: false
      noop_update_total: 0
      throttle_time_in_millis: 0
    merges:
      current: 0
      current_docs: 0
      current_size_in_bytes: 0
      total: 0
      total_auto_throttle_in_bytes: 20971520
      total_docs: 0
      total_size_in_bytes: 0
      total_stopped_time_in_millis: 0
      total_throttled_time_in_millis: 0
      total_time_in_millis: 0
    query_cache:
      cache_count: 0
      cache_size: 0
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
      total_count: 0
    recovery:
      current_as_source: 0
      current_as_target: 0
      throttle_time_in_millis: 0
    refresh:
      external_total: 2
      external_total_time_in_millis: 0
      listeners: 0
      total: 2
      total_time_in_millis: 0
    request_cache:
      evictions: 0
      hit_count: 0
      memory_size_in_bytes: 0
      miss_count: 0
    search:
      fetch_current: 0
      fetch_time_in_millis: 0
      fetch_total: 0
      open_contexts: 0
      query_current: 0
      query_time_in_millis: 0
      query_total: 0
      scroll_current: 0
      scroll_time_in_millis: 0
      scroll_total: 0
      suggest_current: 0
      suggest_time_in_millis: 0
      suggest_total: 0
    segments:
      count: 0
      doc_values_memory_in_bytes: 0
      file_sizes: {}
      fixed_bit_set_memory_in_bytes: 0
      index_writer_memory_in_bytes: 0
      max_unsafe_auto_id_timestamp: -1
      memory_in_bytes: 0
      norms_memory_in_bytes: 0
      points_memory_in_bytes: 0
      stored_fields_memory_in_bytes: 0
      term_vectors_memory_in_bytes: 0
      terms_memory_in_bytes: 0
      version_map_memory_in_bytes: 0
    shard_stats:
      total_count: 1
    store:
      reserved_in_bytes: 0
      size_in_bytes: 226
      total_data_set_size_in_bytes: 226
    translog:
      earliest_last_modified_age: 21411780935
      operations: 0
      size_in_bytes: 55
      uncommitted_operations: 0
      uncommitted_size_in_bytes: 55
    warmer:
      current: 0
      total: 1
      total_time_in_millis: 0
  status: open
  store.size: 226b
  tasks: {}
  uuid: KJJ1YCKtSTWYDBTcrjoRYQ

 
postgresql:postgresql_get_server_status
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_long_running_queries
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_check_active_connections
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_check_locks
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_get_cache_hit_ratio
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
postgresql:postgresql_check_unused_indexes
Failed Objects:
- Not able to connect to PostGreSQL, error None, code None

 
kafka:kafka_check_offline_partitions
Failed Objects:
- Connection time-out

 
k8s:lb_custom_check
Failed Objects:
'Hello Fri Mar 29 22:15:21 UTC 2024

  '

 
Execution script /tmp/hello.sh
OUTPUT FILE /unskript/data/execution/run_output-2024-03-29T22_15_26.934522/run_output.txt


Information Gathering Action Results
Running: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:55<00:00,  9.20s/it]

k8s/k8s_get_all_resources_utilization_info



Using incluster config

Pods:
No pods found in logging namespace.

Jobs:
No jobs found in logging namespace.

Persistentvolumeclaims:
No persistentvolumeclaims found in logging namespace.

Using incluster config

Pods:
+--------------+------------------------------------------+---------+---------------+-------------------+
|  Namespace   |                   Name                   | Status  | CPU Usage (m) | Memory Usage (Mi) |
+--------------+------------------------------------------+---------+---------------+-------------------+
| cert-manager |      cert-manager-584f85f6cf-nll6v       | Running |      2m       |       35Mi        |
| cert-manager | cert-manager-cainjector-6c58576757-bqgqj | Running |      1m       |       50Mi        |
| cert-manager |  cert-manager-webhook-75d68f6fb9-7pwnl   | Running |      1m       |       14Mi        |
+--------------+------------------------------------------+---------+---------------+-------------------+

Jobs:
No jobs found in cert-manager namespace.

Persistentvolumeclaims:
No persistentvolumeclaims found in cert-manager namespace.

Using incluster config

Pods:
+-----------+------------------------------------------------------+---------+---------------+-------------------+
| Namespace |                         Name                         | Status  | CPU Usage (m) | Memory Usage (Mi) |
+-----------+------------------------------------------------------+---------+---------------+-------------------+
| lightbeam |                       curlpod                        | Running |      0m       |        0Mi        |
| lightbeam |            ingress-kong-69fdcf9b7c-plqft             | Running |      7m       |       334Mi       |
| lightbeam |              kafka-ui-558c57f65f-tgnxc               | Running |      2m       |       274Mi       |
| lightbeam |    lb-argo-workflows-controller-7f4d9d8fb9-lwgjj     | Running |      7m       |       19Mi        |
| lightbeam |      lb-argo-workflows-server-5dd6b9956b-gzdxk       | Running |      1m       |       19Mi        |
| lightbeam |          lb-kafka-connect-5c6846cdbd-jkx2k           | Running |      12m      |       716Mi       |
| lightbeam |                    lb-keycloak-0                     | Running |      4m       |       574Mi       |
| lightbeam |       lb-prometheus-operator-6ccd9c9469-hmrgp        | Running |      1m       |       27Mi        |
| lightbeam |                  lb-redis-master-0                   | Running |      14m      |        5Mi        |
| lightbeam |                 lb-redis-replicas-0                  | Running |      32m      |        4Mi        |
| lightbeam |                 lb-redis-replicas-1                  | Running |      35m      |        4Mi        |
| lightbeam |                 lb-redis-replicas-2                  | Running |      39m      |        6Mi        |
| lightbeam |                      lb-vault-0                      | Running |      10m      |       83Mi        |
| lightbeam |        lb-workflow-executor-6d4777bb8f-qgkkc         | Running |      4m       |       11Mi        |
| lightbeam |        lightbeam-api-gateway-5cdfb4b69-bqr8w         | Running |      0m       |        0Mi        |
| lightbeam |        lightbeam-datahub-gms-7b68f6fc7f-j8bm4        | Running |      8m       |       389Mi       |
| lightbeam |    lightbeam-datahub-gms-graphql-6b47fcd8ff-hwpbz    | Running |      3m       |       203Mi       |
| lightbeam | lightbeam-datasource-stats-aggregator-6d7686b8-ntrr4 | Running |      25m      |       72Mi        |
| lightbeam |           lightbeam-elasticsearch-master-0           | Running |      13m      |      1090Mi       |
| lightbeam |       lightbeam-files-service-69bf959f5c-qr7gv       | Running |      1m       |        8Mi        |
| lightbeam |         lightbeam-frontend-6c7d59d869-55n8s          | Running |      0m       |       31Mi        |
| lightbeam |                  lightbeam-kafka-0                   | Running |      69m      |      1112Mi       |
| lightbeam |              lightbeam-kafka-exporter-0              | Running |      13m      |       12Mi        |
| lightbeam |             lightbeam-kafka-zookeeper-0              | Running |      11m      |       362Mi       |
| lightbeam |           lightbeam-minio-6cf5844654-vlvsv           | Running |      5m       |       81Mi        |
| lightbeam |         lightbeam-mongo-aggr-28529176-kwrjx          | Pending |      N/A      |        N/A        |
| lightbeam |                 lightbeam-mongodb-0                  | Running |     534m      |       697Mi       |
| lightbeam |             lightbeam-mongodb-arbiter-0              | Running |      14m      |       72Mi        |
| lightbeam |      lightbeam-policy-consumer-65d546cc4d-x6nsx      | Pending |      N/A      |        N/A        |
| lightbeam |       lightbeam-policy-engine-76d5667bf8-mxfv4       | Running |      31m      |       151Mi       |
| lightbeam |      lightbeam-presidio-server-7c89f7f4bd-xhqdr      | Running |      22m      |      3759Mi       |
| lightbeam |  lightbeam-prometheus-pushgateway-6c4cf77496-l96f2   | Running |      1m       |       12Mi        |
| lightbeam |                  lightbeam-qdrant-0                  | Running |      2m       |       12Mi        |
| lightbeam |       lightbeam-report-engine-65dfdd5c7-gr4w4        | Running |      12m      |       72Mi        |
| lightbeam |      lightbeam-schema-registry-694887697d-hqwxm      | Running |      7m       |       201Mi       |
| lightbeam |      lightbeam-text-extraction-7cf9f6c8b9-c9qp9      | Running |      23m      |      2797Mi       |
| lightbeam |        lightbeam-tika-server-75485bf8fd-rvdm5        | Running |      3m       |       195Mi       |
| lightbeam |       local-path-provisioner-6cc89d4f76-6f96q        | Running |      3m       |       11Mi        |
| lightbeam |                      postgres-0                      | Running |      16m      |       43Mi        |
| lightbeam |              prometheus-lb-prometheus-0              | Running |      29m      |       91Mi        |
| lightbeam |        vault-agent-injector-6c7d69ff46-llbwm         | Running |      6m       |       12Mi        |
+-----------+------------------------------------------------------+---------+---------------+-------------------+

Jobs:
+-----------+-------------------------------------------+----------+
|           |                   Name                    |  Status  |
+-----------+-------------------------------------------+----------+
| lightbeam |              kong-migrations              | Complete |
| lightbeam |     lb-bloom-filter-builder-28528200      | Complete |
| lightbeam |     lb-bloom-filter-builder-28528560      | Complete |
| lightbeam |     lb-bloom-filter-builder-28528920      | Complete |
| lightbeam |          lb-workflow-gc-28527840          | Complete |
| lightbeam |   lightbeam-alert-handler-job-28172295    |  Failed  |
| lightbeam |   lightbeam-alert-handler-job-28529169    | Complete |
| lightbeam |   lightbeam-alert-handler-job-28529172    | Complete |
| lightbeam |   lightbeam-alert-handler-job-28529175    | Complete |
| lightbeam |            lightbeam-bootstrap            | Complete |
| lightbeam | lightbeam-datahub-elasticsearch-setup-job | Complete |
| lightbeam |     lightbeam-datahub-kafka-setup-job     | Complete |
| lightbeam |   lightbeam-datahub-postgres-setup-job    | Complete |
| lightbeam |       lightbeam-mongo-aggr-28172293       |  Failed  |
| lightbeam |       lightbeam-mongo-aggr-28529173       | Complete |
| lightbeam |       lightbeam-mongo-aggr-28529174       | Complete |
| lightbeam |       lightbeam-mongo-aggr-28529175       | Complete |
| lightbeam |       lightbeam-mongo-aggr-28529176       | Unknown  |
| lightbeam |       lightbeam-post-install-setup        | Complete |
+-----------+-------------------------------------------+----------+

Persistentvolumeclaims:
+-----------+--------------------------------------------------------+--------+
|           |                          Name                          | Status |
+-----------+--------------------------------------------------------+--------+
| lightbeam |         data-lightbeam-elasticsearch-master-0          | Bound  |
| lightbeam |                 data-lightbeam-kafka-0                 | Bound  |
| lightbeam |            data-lightbeam-kafka-zookeeper-0            | Bound  |
| lightbeam |              datadir-lightbeam-mongodb-0               | Bound  |
| lightbeam |              lb-keycloakdir-lb-keycloak-0              | Bound  |
| lightbeam |                lightbeam-minio-pv-claim                | Bound  |
| lightbeam |            lightbeam-postgresql-postgres-0             | Bound  |
| lightbeam | prometheus-lb-prometheus-db-prometheus-lb-prometheus-0 | Bound  |
| lightbeam |           qdrant-storage-lightbeam-qdrant-0            | Bound  |
| lightbeam |              redis-data-lb-redis-master-0              | Bound  |
| lightbeam |             redis-data-lb-redis-replicas-0             | Bound  |
| lightbeam |             redis-data-lb-redis-replicas-1             | Bound  |
| lightbeam |             redis-data-lb-redis-replicas-2             | Bound  |
| lightbeam |                 vault-claim-lb-vault-0                 | Bound  |
+-----------+--------------------------------------------------------+--------+

Using incluster config

Pods:
+-----------+-----------------------------------------------------------------+---------+---------------+-------------------+
| Namespace |                              Name                               | Status  | CPU Usage (m) | Memory Usage (Mi) |
+-----------+-----------------------------------------------------------------+---------+---------------+-------------------+
| unskript  |                     audit-6d84f4dcf4-rnjpc                      | Running |      5m       |       31Mi        |
| unskript  |                    calendar-7ddd547fcc-hfzff                    | Running |      5m       |       26Mi        |
| unskript  |                   connectors-748c49c879-nsr2s                   | Running |      5m       |       29Mi        |
| unskript  |               enterprise-gateway-85b75f659c-qh4kl               | Running |      4m       |       62Mi        |
| unskript  |                     events-f6dc98b4d-nksch                      | Running |      6m       |       26Mi        |
| unskript  |           jovyan-b865bf79-edde-4c1b-9f55-5e8d1e212e4a           | Running |      1m       |       76Mi        |
| unskript  |                    kernel-image-puller-dmrnd                    | Running |      0m       |       52Mi        |
| unskript  |                     lambda-f4b7b9666-jms6s                      | Running |      6m       |       27Mi        |
| unskript  |                     legos-7d95656795-fz9tp                      | Running |      6m       |       28Mi        |
| unskript  |                            mongodb-0                            | Running |     642m      |       262Mi       |
| unskript  |                        mongodb-arbiter-0                        | Running |      13m      |       66Mi        |
| unskript  |                  nginx-server-749fd77cf-dbncz                   | Running |      1m       |        1Mi        |
| unskript  |                  notifications-b46dfb877-764x6                  | Running |      5m       |       30Mi        |
| unskript  |                   privileges-5c555f847f-lppqb                   | Running |      9m       |       28Mi        |
| unskript  |                         redis-master-0                          | Running |      26m      |        4Mi        |
| unskript  |                        redis-replicas-0                         | Running |      35m      |        4Mi        |
| unskript  |                        redis-replicas-1                         | Running |      40m      |        3Mi        |
| unskript  |                        redis-replicas-2                         | Running |      41m      |        3Mi        |
| unskript  |              remote-tunnel-server-7487cb947c-9lwzz              | Running |      4m       |       116Mi       |
| unskript  |                     skynet-8c56f6cbc-qqfq4                      | Running |      96m      |       483Mi       |
| unskript  |                   tenantmgr-858f4b46bc-thdrt                    | Running |      5m       |       29Mi        |
| unskript  | unskript-72b534ed-b892-4917-b4c0-67be4b3a8ea6-res-dd9d9d88wwqbs | Running |      10m      |       140Mi       |
| unskript  |                      util-8469b7875d-l5vgt                      | Running |      0m       |        0Mi        |
| unskript  |                   workflows-6746455b6c-z2ljk                    | Running |      5m       |       28Mi        |
+-----------+-----------------------------------------------------------------+---------+---------------+-------------------+

Jobs:
No jobs found in unskript namespace.

Persistentvolumeclaims:
+----------+-----------------------------+--------+
|          |            Name             | Status |
+----------+-----------------------------+--------+
| unskript |      datadir-mongodb-0      | Bound  |
| unskript |  redis-data-redis-master-0  | Bound  |
| unskript | redis-data-redis-replicas-0 | Bound  |
| unskript | redis-data-redis-replicas-1 | Bound  |
| unskript | redis-data-redis-replicas-2 | Bound  |
| unskript |       rts-openvpn-pvc       | Bound  |
+----------+-----------------------------+--------+

###

k8s/k8s_get_versioning_info



Using incluster config
Versions:
kubectl: Client Version: v1.23.1
kubernetes: Client Version: v1.23.1
Server Version: v1.23.17
docker: Not found

###

k8s/k8s_get_node_status_and_resource_utilization



Using incluster config
+-----------+--------+---------------+------------------+
| Node Name | Status | CPU Usage (%) | Memory Usage (%) |
+-----------+--------+---------------+------------------+
|  lb-inst  | Ready  |      96       |        63        |
+-----------+--------+---------------+------------------+

###
2024-03-29 22:16:23,074 - UnskriptCtlLogger - INFO - Slack Message was sent successfully!
INFO:botocore.credentials:Found credentials in environment variables.
2024-03-29 22:16:25,451 - UnskriptCtlLogger - INFO - Email notification sent to  XX@XXX.COM
2024-03-29 22:16:25,454 - UnskriptCtlLogger - INFO - Successfully sent Email notification via AWS SES.
unskript@awesome-awesome-runbooks-0:~$ 
unskript@awesome-awesome-runbooks-0:~$ 
unskript@awesome-awesome-runbooks-0:~$ 
unskript@awesome-awesome-runbooks-0:~$ 

```
#### Email notification

<img width="784" alt="Screenshot 2024-03-29 at 3 18 59 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/20b83cf4-42c4-4541-88fb-549428ee7302">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
