### PR TITLE
Adding diagnostics support to be called by unskript_ctl

### DIFF
--- a/unskript-ctl/diagnostics.py
+++ b/unskript-ctl/diagnostics.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2024 unSkript.com
+# All rights reserved.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+#
+
+import argparse
+import json
+import os
+import sys
+import yaml
+
+# HERE WE NEED TO IMPORT THE WORKER.py file that has the 7 functions that will be
+# execute the equivalent of run_native_cmd 
+# import diagnostic_worker
+
+
+class DiagnosticsScript:
+    def __init__(self, args):
+        self.args = args
+
+    def get_failed_objects(self):
+        failed_objects_file = self.args.failed_objects_file
+        try:
+            with open(failed_objects_file, 'r') as file:
+                data = json.load(file)
+        except FileNotFoundError:
+            print(f"Error: File '{failed_objects_file}' not found.")
+            return []
+        except json.JSONDecodeError as e:
+            print(f"Error decoding JSON file '{failed_objects_file}': {e}")
+            return []
+        except Exception as e:
+            print(f"An unexpected error occurred while reading '{failed_objects_file}': {e}")
+            return []
+
+        if not isinstance(data, list):
+            print(f"Error: Invalid JSON data format in '{failed_objects_file}'.")
+            return []
+
+        all_failed_entry_functions = []
+        for entry in data:
+            if isinstance(entry, dict) and 'objects' in entry and entry['objects'] is not None:
+                all_failed_entry_functions.append(entry.get('action_entry_function', ''))
+
+        return all_failed_entry_functions
+
+    def get_diagnostic_commands(self):
+        yaml_file = self.args.yaml_file
+        try:
+            with open(yaml_file, 'r') as file:
+                data = yaml.safe_load(file)
+        except FileNotFoundError:
+            print(f"Error: File '{yaml_file}' not found.")
+            return {}
+        except yaml.YAMLError as e:
+            print(f"Error parsing YAML file '{yaml_file}': {e}")
+            return {}
+
+        if not isinstance(data, dict):
+            print(f"Error: Invalid YAML data format in '{yaml_file}'.")
+            return {}
+
+        diagnostics_commands = {}
+        if 'checks' in data and isinstance(data['checks'], dict) and 'diagnostics' in data['checks']:
+            for check_name, d_commands in data['checks']['diagnostics'].items():
+                if isinstance(d_commands, list):
+                    diagnostics_commands[check_name] = d_commands
+                else:
+                    print(f"Error: Invalid format for diagnostics commands under '{check_name}' in '{yaml_file}'.")
+        else:
+            print(f"Error: 'checks->diagnostics' section not found in '{yaml_file}'.")
+
+        return diagnostics_commands
+
+    def get_diagnostic_commands_for_failed_checks(self):
+        diagnostics_commands = self.get_diagnostic_commands()
+        failed_checks = self.get_failed_objects()
+        diagnostic_commands_for_failed_checks = {}
+
+        for failed_check in failed_checks:
+            if failed_check in diagnostics_commands:
+                diagnostic_commands_for_failed_checks[failed_check] = diagnostics_commands[failed_check]
+
+        return diagnostic_commands_for_failed_checks
+
+    def execute_diagnostics(self, diag_commands):
+        diag_outputs = {}
+        for entry_function, commands in diag_commands.items():
+            for prefix in self.calling_map:
+                if entry_function.startswith(prefix):
+                    try:
+                        function_name = self.calling_map.get(prefix)
+                        if function_name:
+                            function = globals().get(function_name)
+                            if function:
+                                diag_outputs[entry_function] = function(commands)
+                            else:
+                                raise ValueError(f"Function '{function_name}' not found in the global namespace.")
+                        else:
+                            raise ValueError(f"No function mapping found for prefix '{prefix}'.")
+                    except Exception as e:
+                        print(f"Error occurred while processing '{entry_function}': {e}")
+
+        if diag_outputs:
+            diag_file = os.path.join(self.args.output_dir_path, 'diagnostics.yaml')
+            self.write_to_yaml_file(diag_outputs, diag_file)
+        else:
+            print("ERROR: Nothing to write, diagnostic outputs is empty!")
+
+    def write_to_yaml_file(self, data, file_path):
+        with open(file_path, 'w') as file:
+            yaml.dump(data, file, default_flow_style=False)
+
+    def main(self):
+        if not os.path.exists(self.args.output_dir_path):
+            print(f"ERROR: Output directory {self.args.output_dir_path} does not exist!")
+            sys.exit(1)
+        
+        diag_commands = self.get_diagnostic_commands_for_failed_checks()
+
+        if not diag_commands:
+            print("ERROR: No diagnostic command found. Please define them in the YAML configuration file")
+            sys.exit(0)
+
+        diag_outputs = self.execute_diagnostics(diag_commands)
+
+        if diag_outputs:
+            diag_file = os.path.join(self.args.output_dir_path, 'diagnostics.yaml')
+            self.write_to_yaml_file(diag_outputs, diag_file)
+        else:
+            print("ERROR: Nothing to write, diagnostic outputs are empty!")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Diagnostic Script for unskript-ctl")
+    parser.add_argument("--yaml-file", '-y', help="Path to YAML file", required=True)
+    parser.add_argument("--failed-objects-file", '-f', help="Path to failed objects file", required=True)
+    parser.add_argument("--output-dir-path", '-o', help="Path to output directory", required=True)
+    args = parser.parse_args()
+
+    diagnostics_script = DiagnosticsScript(args)
+    diagnostics_script.main()

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -22,7 +22,9 @@ from unskript_utils import *
 from unskript_ctl_factory import *
 from unskript_ctl_version import *
 from unskript_ctl_upload_session_logs import upload_session_logs
+from diagnostics import main as diagnostics
 
+YAML_CONFIG_FILE = "/etc/unskript/unskript_ctl_config.yaml"
 
 # UnskriptCTL class that instantiates class instance of Checks, Script, Notification and DBInterface
 # This implementation is an example how to use the different components of unskript-ctl into a single
@@ -37,6 +39,7 @@ class UnskriptCtl(UnskriptFactory):
         self.logger.debug(f"\tBUILD_NUMBER: {get_version()} \n")
         self._config = ConfigParserFactory()
         self._notification = Notification()
+        self.uglobals = UnskriptGlobals()
         self._check = Checks()
         self._script = Script()
         self._checks_priority = self._config.get_checks_priority()
@@ -141,6 +144,24 @@ class UnskriptCtl(UnskriptFactory):
 
         if args.command == 'run' and args.info:
             self.run_info()
+        
+        if args.command == 'run' and args.check_command == 'check':
+            # call diagnostics
+            if self.uglobals.get('CURRENT_EXECUTION_RUN_DIRECTORY'):
+                output_dir = self.uglobals.get('CURRENT_EXECUTION_RUN_DIRECTORY')
+            else:
+                output_dir = os.path.join(UNSKRIPT_EXECUTION_DIR, self.uglobals.get('exec_id'))           
+            
+            failed_objects_file = os.path.join(UNSKRIPT_EXECUTION_DIR, self.uglobals.get('exec_id')) + '_output.txt'
+            diag_args = [
+                '--yaml-file',
+                YAML_CONFIG_FILE,
+                '--failed-objects-file',
+                failed_objects_file,
+                '--output-dir-path',
+                output_dir
+            ]
+            diagnostics(diag_args)
 
     def run_info(self):
         """This function runs the info gathering actions"""


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
Fixes [EN-5397]

* This PR brings in `diagnostics.py` which takes three inputs
     * YAML File (Configuration file)
     * Failed Objects file 
     * Output directory path where the diagnostics output to be stored
      
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5397]: https://unskript.atlassian.net/browse/EN-5397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ