### PR TITLE
Modified Logic of checks to consider time based interval to declare check result

### DIFF
--- a/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
+++ b/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
@@ -94,6 +94,7 @@ def k8s_get_oomkilled_pods(handle, namespace: str = "", time_interval_to_check=2
             last_state = container_status.last_state
             if last_state and last_state.terminated and last_state.terminated.reason == "OOMKilled":
                 termination_time = last_state.terminated.finished_at
+                termination_time = termination_time.replace(tzinfo=timezone.utc)
                 # If termination time is greater than interval_time_to_check meaning
                 # the POD has gotten OOMKilled in the last 24 hours, so lets flag it!
                 if termination_time and termination_time >= interval_time_to_check:

--- a/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
+++ b/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
@@ -3,6 +3,8 @@
 # All rights reserved.
 #
 import pprint
+import datetime
+from datetime import timezone 
 from typing import Tuple, Optional
 from pydantic import BaseModel, Field
 from kubernetes import client
@@ -15,6 +17,11 @@ class InputSchema(BaseModel):
         description='Kubernetes Namespace Where the Service exists',
         title='K8S Namespace',
     )
+    time_interval_to_check: int = Field(
+        24,
+        description='Time interval in hours. This time window is used to check if POD good OOMKilled. Default is 24 hours.',
+        title="Time Interval"
+    )
 
 
 
@@ -24,7 +31,7 @@ def k8s_get_oomkilled_pods_printer(output):
     pprint.pprint(output)
     
 
-def k8s_get_oomkilled_pods(handle, namespace: str = "") -> Tuple:
+def k8s_get_oomkilled_pods(handle, namespace: str = "", time_interval_to_check=24) -> Tuple:
     """k8s_get_oomkilled_pods This function returns the pods that have OOMKilled event in the container last states
 
     :type handle: Object
@@ -61,21 +68,32 @@ def k8s_get_oomkilled_pods(handle, namespace: str = "") -> Tuple:
     if pods is None:
         raise ApiException("No pods returned from the Kubernetes API.")
 
+    # Get Current Time in UTC
+    current_time = datetime.datetime.now(timezone.utc)
+    # Get time interval to check (or 24 hour) reference and convert to UTC
+    interval_time_to_check = current_time - datetime.timedelta(hours=time_interval_to_check)
+    interval_time_to_check = interval_time_to_check.replace(tzinfo=timezone.utc)
+
+    
     for pod in pods:
         pod_name = pod.metadata.name
         namespace = pod.metadata.namespace
-
+        
         # Ensure container_statuses is not None before iterating
         container_statuses = pod.status.container_statuses
         if container_statuses is None:
             continue
-
+        
         # Check each pod for OOMKilled state
         for container_status in container_statuses:
             container_name = container_status.name
             last_state = container_status.last_state
             if last_state and last_state.terminated and last_state.terminated.reason == "OOMKilled":
-                result.append({"pod": pod_name, "namespace": namespace, "container": container_name})
-
+                termination_time = last_state.terminated.finished_at
+                # If termination time is greater than interval_time_to_check meaning
+                # the POD has gotten OOMKilled in the last 24 hours, so lets flag it!
+                if termination_time and termination_time >= interval_time_to_check:
+                    result.append({"pod": pod_name, "namespace": namespace, "container": container_name})
+    
     return (False, result) if result else (True, None)
 

--- a/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
+++ b/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
@@ -40,6 +40,10 @@ def k8s_get_oomkilled_pods(handle, namespace: str = "", time_interval_to_check=2
     :type namespace: str
     :param namespace: (Optional)String, K8S Namespace as python string
 
+    :type time_interval_to_check: int
+    :param time_interval_to_check: (Optional) Integer, in hours, the interval within which the
+            state of the POD should be checked.
+
     :rtype: Status, List of objects of pods, namespaces, and containers that are in OOMKilled state
     """
     result = []

--- a/Kubernetes/legos/k8s_get_pods_with_high_restart/k8s_get_pods_with_high_restart.py
+++ b/Kubernetes/legos/k8s_get_pods_with_high_restart/k8s_get_pods_with_high_restart.py
@@ -77,6 +77,7 @@ def k8s_get_pods_with_high_restart(handle, namespace: str = '', threshold: int =
             if restart_count > threshold:
                 if last_state and last_state.terminated:
                     termination_time = last_state.terminated.finished_at
+                    termination_time = termination_time.replace(tzinfo=timezone.utc)
                     # We compare if the termination time is within the last 24 hours, if yes
                     # then we need to add it to the retval and return the list back
                     if termination_time and termination_time >= interval_time_to_check:

--- a/Kubernetes/legos/k8s_get_pods_with_high_restart/k8s_get_pods_with_high_restart.py
+++ b/Kubernetes/legos/k8s_get_pods_with_high_restart/k8s_get_pods_with_high_restart.py
@@ -2,11 +2,15 @@
 # Copyright (c) 2023 unSkript.com
 # All rights reserved.
 #
+import datetime 
+from datetime import timezone
 from typing import Tuple
 from pydantic import BaseModel, Field
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 
+# Constants used in this file
+INTERVAL_TO_CHECK = 24  # In hours
 
 class InputSchema(BaseModel):
     namespace: str = Field(
@@ -54,10 +58,28 @@ def k8s_get_pods_with_high_restart(handle, namespace: str = '', threshold: int =
         raise Exception(f"Error occurred while accessing Kubernetes API: {e}")
 
     retval = []
+    
+    # It is not enough to check if the restart count is more than the threshold 
+    # we should check if the last time the pod got restarted is not within the 24 hours.
+    # If it is, then we need to flag it. If not, it could be that the pod restarted at 
+    # some time, but have been stable since then. 
+
+    # Lets take current time and reference time that is 24 hours ago.
+    current_time = datetime.datetime.now(timezone.utc)
+    interval_time_to_check = current_time - datetime.timedelta(hours=INTERVAL_TO_CHECK)
+    interval_time_to_check = interval_time_to_check.replace(tzinfo=timezone.utc)
+
     for pod in pods:
         for container_status in pod.status.container_statuses or []:
             restart_count = container_status.restart_count
+            last_state = container_status.last_state
+
             if restart_count > threshold:
-                retval.append({'name': pod.metadata.name, 'namespace': pod.metadata.namespace})
+                if last_state and last_state.terminated:
+                    termination_time = last_state.terminated.finished_at
+                    # We compare if the termination time is within the last 24 hours, if yes
+                    # then we need to add it to the retval and return the list back
+                    if termination_time and termination_time >= interval_time_to_check:
+                        retval.append({'name': pod.metadata.name, 'namespace': pod.metadata.namespace})
 
     return (False, retval) if retval else (True, None)

--- a/unskript-ctl/diagnostics.py
+++ b/unskript-ctl/diagnostics.py
@@ -125,8 +125,8 @@ class DiagnosticsScript:
         diag_commands = self.get_diagnostic_commands_for_failed_checks()
 
         if not diag_commands:
-            print("ERROR: No diagnostic command found. Please define them in the YAML configuration file")
-            sys.exit(0)
+            print("Skipping Diagnostics: No diagnostic command found. You can define them in the YAML configuration file")
+            return 
 
         diag_outputs = self.execute_diagnostics(diag_commands)
 
@@ -134,7 +134,7 @@ class DiagnosticsScript:
             diag_file = os.path.join(self.args.output_dir_path, 'diagnostics.yaml')
             self.write_to_yaml_file(diag_outputs, diag_file)
         else:
-            print("ERROR: Nothing to write, diagnostic outputs are empty!")
+            print("WARNING: Nothing to write, diagnostic outputs are empty!")
 
 
 def main(args):

--- a/unskript-ctl/templates/last_cell_content.j2
+++ b/unskript-ctl/templates/last_cell_content.j2
@@ -1,8 +1,13 @@
 from unskript.legos.utils import CheckOutput, CheckOutputStatus
 global w 
+global _logger
 
 all_outputs = []
 other_outputs = []
+if _logger:
+   _logger.debug(f"ERRORED CHECKS ARE: {w.errored_checks}")
+   _logger.debug(f"TIMED OUT CHECKS ARE: {w.timeout_checks}")
+
 try:
     if 'w' in globals():
         if w.check_run:
@@ -39,9 +44,14 @@ try:
                      # case 
                      if _other.get('id') == _output.get('id'):
                          _output = _other
-
+            
+            if not all_outputs:
+                all_outputs = other_outputs
+ 
             for _output in all_outputs:
                 print(json.dumps(_output))
+                if _logger:
+                    _logger.debug(_output)
         else:
             print(json.dumps("Not a check run"))
     else:

--- a/unskript-ctl/templates/last_cell_content.j2
+++ b/unskript-ctl/templates/last_cell_content.j2
@@ -36,6 +36,7 @@ try:
                             "error": err_msg,
                             "id": str(_id)
                         })
+                        
             if other_outputs:
                for _other in other_outputs:
                   for _output in all_outputs:
@@ -43,15 +44,20 @@ try:
                      # We could have double accounted failed and error timeout 
                      # case 
                      if _other.get('id') == _output.get('id'):
-                         _output = _other
+                         _output.update(_other)
+                         if _logger:
+                             _logger.debug(f"FOUND DUPLICATE FOR {_other.get('id')}")
+
+            existing_ids = set(output.get('id') for output in all_outputs)
+            unique_other_outputs = [other_output for other_output in other_outputs if other_output.get('id') not in existing_ids]
+            if unique_other_outputs:
+                all_outputs.extend(unique_other_outputs)
             
             if not all_outputs:
                 all_outputs = other_outputs
  
-            for _output in all_outputs + other_outputs:
+            for _output in all_outputs:
                 print(json.dumps(_output))
-                if _logger:
-                    _logger.debug(_output)
         else:
             print(json.dumps("Not a check run"))
     else:

--- a/unskript-ctl/templates/last_cell_content.j2
+++ b/unskript-ctl/templates/last_cell_content.j2
@@ -48,7 +48,7 @@ try:
             if not all_outputs:
                 all_outputs = other_outputs
  
-            for _output in all_outputs:
+            for _output in all_outputs + other_outputs:
                 print(json.dumps(_output))
                 if _logger:
                     _logger.debug(_output)

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -884,7 +884,11 @@ class InfoAction(ChecksFactory):
                     for index, value in enumerate(v):
                         first_cell_content += f'{k}{index} = \"{value}\"' + '\n'
 
-        first_cell_content += '''w = Workflow(env, secret_store_cfg, None, global_vars=globals(), check_uuids=None)'''
+        first_cell_content += '''w = Workflow(env, secret_store_cfg, None, global_vars=globals(), check_uuids=None)''' + '\n'
+        temp_map = dict(zip(self.check_entry_functions, self.check_uuids))
+        first_cell_content += f'''w.check_uuid_entry_function_map = {temp_map}''' + '\n'
+        first_cell_content += '''w.errored_checks = {}''' + '\n'
+        first_cell_content += '''w.timeout_checks = {}''' + '\n'
         return first_cell_content
 
     def get_timeout_decorator_function(self, execution_timeout):

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -58,7 +58,7 @@ class Checks(ChecksFactory):
         # Prioritized checks to uuid mapping
         self.prioritized_checks_to_id_mapping = {}
         self.map_entry_function_to_check_name = {}
-        self.map_entry_function_to_connector = {}
+        self.map_check_name_to_connector = {}
 
         for k,v in self.checks_globals.items():
             os.environ[k] = json.dumps(v)
@@ -179,13 +179,11 @@ class Checks(ChecksFactory):
 
                 _action_uuid = payload.get('id')
                 if _action_uuid:
+                    #c_name = self.connector_types[idx] + ':' + self.prioritized_checks_to_id_mapping[_action_uuid]
                     p_check_name = self.prioritized_checks_to_id_mapping[_action_uuid]
-                    p_connector_name = self.map_entry_function_to_connector[p_check_name]
-                    c_name = p_connector_name + ':' + self.prioritized_checks_to_id_mapping[_action_uuid]
                 else:
+                    #c_name = self.connector_types[idx] + ':' + self.check_names[idx]
                     p_check_name = self.check_names[idx]
-                    p_connector_name = self.map_entry_function_to_connector[p_check_name]
-                    c_name = p_connector_name + ':' + self.check_names[idx]
                 if p_check_name in self.check_entry_functions:
                     p_check_name = self.map_entry_function_to_check_name.get(p_check_name)
                 if ids and CheckOutputStatus(payload.get('status')) == CheckOutputStatus.SUCCESS:
@@ -198,12 +196,12 @@ class Checks(ChecksFactory):
                     checks_per_priority_per_result_list[priority]['PASS'].append([
                         p_check_name,
                         ids[idx],
-                        # self.connector_types[idx]
-                        p_connector_name
-                        ]
+                        # self.connector_types[idx]]
+                        self.map_check_name_to_connector[p_check_name]]
                         )
                 elif ids and CheckOutputStatus(payload.get('status')) == CheckOutputStatus.FAILED:
                     failed_objects = payload.get('objects')
+                    c_name = self.map_check_name_to_connector[p_check_name] + ':' + p_check_name
                     failed_result[c_name] = failed_objects
                     result_table.append([
                         p_check_name,
@@ -216,14 +214,14 @@ class Checks(ChecksFactory):
                         p_check_name,
                         ids[idx],
                         # self.connector_types[idx]
-                        p_connector_name
+                        self.map_check_name_to_connector[p_check_name]
                         ])
                 elif ids and CheckOutputStatus(payload.get('status')) == CheckOutputStatus.RUN_EXCEPTION:
                     if payload.get('error') is not None:
                         failed_objects = payload.get('error')
                         if isinstance(failed_objects, str) is True:
                             failed_objects = [failed_objects]
-                        # c_name = self.connector_types[idx] + ':' + self.check_names[idx]
+                        c_name = self.map_check_name_to_connector[p_check_name] + ':' + p_check_name
                         failed_result[c_name] = failed_objects
                         failed_result_available = True
                     error_msg = payload.get('error') if payload.get('error') else self.parse_failed_objects(failed_object=failed_objects)
@@ -238,7 +236,7 @@ class Checks(ChecksFactory):
                         p_check_name,
                         ids[idx],
                         # self.connector_types[idx]
-                        p_connector_name
+                        self.map_check_name_to_connector[p_check_name]
                         ])
             except Exception as e:
                 self.logger.error(e)
@@ -390,8 +388,7 @@ class Checks(ChecksFactory):
         if len(list_of_checks) == 0:
             return None
         self.check_uuids, self.check_names, self.connector_types, self.check_entry_functions = self._common.get_code_cell_name_and_uuid(list_of_actions=list_of_checks)
-        # Create a connector to entry function map
-        self.map_entry_function_to_connector = dict(zip(self.check_entry_functions, self.connector_types))
+        self.map_check_name_to_connector = dict(zip(self.check_names, self.connector_types))
         first_cell_content = self._common.get_first_cell_content()
 
         if self.checks_globals and len(self.checks_globals):
@@ -895,11 +892,7 @@ class InfoAction(ChecksFactory):
                     for index, value in enumerate(v):
                         first_cell_content += f'{k}{index} = \"{value}\"' + '\n'
 
-        first_cell_content += '''w = Workflow(env, secret_store_cfg, None, global_vars=globals(), check_uuids=None)''' + '\n'
-        temp_map = dict(zip(self.check_entry_functions, self.check_uuids))
-        first_cell_content += f'''w.check_uuid_entry_function_map = {temp_map}''' + '\n'
-        first_cell_content += '''w.errored_checks = {}''' + '\n'
-        first_cell_content += '''w.timeout_checks = {}''' + '\n'
+        first_cell_content += '''w = Workflow(env, secret_store_cfg, None, global_vars=globals(), check_uuids=None)'''
         return first_cell_content
 
     def get_timeout_decorator_function(self, execution_timeout):


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Fixes [EN-5354] [EN-5383]

* Added time based check before declaring a check is passed or failed.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Unit testing for k8s_get_oomkilled_pods
```
unskript@awesome-awesome-runbooks-0:~$ unskript-ctl.sh run  check --name k8s_get_oomkilled_pods 
Running: 100%|████████████████████████████████████████████████████████| 6/6 [00:05<00:00,  1.20it/s]

╒════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name            │ Result   │   Failed Count │ Error   │
╞════════════════════════╪══════════╪════════════════╪═════════╡
│ Get K8S OOMKilled Pods │  FAIL    │              1 │ N/A     │
╘════════════════════════╧══════════╧════════════════╧═════════╛

k8s:Get K8S OOMKilled Pods
Failed Objects:
- - container: memory-demo-ctr
    namespace: vanila
    pod: memory-demo

 
Function 'k8s_diagnostics' is accessible.
```
#### Unit testing k8s_get_pods_with_high_restart 
```
unskript@awesome-awesome-runbooks-0:~$ unskript-ctl.sh run check --name k8s_get_pods_with_high_restart
Running: 100%|████████████████████████████████████████████████████████| 6/6 [00:04<00:00,  1.31it/s]

╒═══════════════════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name                           │ Result   │   Failed Count │ Error   │
╞═══════════════════════════════════════╪══════════╪════════════════╪═════════╡
│ Get Kubernetes PODS with high restart │  FAIL    │              2 │ N/A     │
╘═══════════════════════════════════════╧══════════╧════════════════╧═════════╛

k8s:Get Kubernetes PODS with high restart
Failed Objects:
- - name: lightbeam-api-gateway-5cdfb4b69-bqr8w
    namespace: lightbeam
- - name: memory-demo
    namespace: vanila

 
Function 'k8s_diagnostics' is accessible.
unskript@awesome-awesome-runbooks-0:~$ 
```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5354]: https://unskript.atlassian.net/browse/EN-5354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-5383]: https://unskript.atlassian.net/browse/EN-5383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ