### PR TITLE
Update all_resources_utilization info lego

### DIFF
--- a/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
+++ b/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
@@ -22,7 +22,7 @@ def k8s_get_all_resources_utilization_info_printer(data):
 
         print(f"\n{resource.capitalize()}:")
         if not rows:  # Check if the resource list is empty
-            print(f"No {resource} found in {namespace} namespace.")
+            # print(f"No {resource} found in {namespace} namespace.")
             continue  # Skip to the next resource
 
         if resource == 'pods':
@@ -50,7 +50,9 @@ def k8s_get_all_resources_utilization_info(handle, namespace: str = "") -> Dict:
 
     namespace_option = f"--namespace={namespace}" if namespace else "--all-namespaces"
 
-    resources = ['pods', 'jobs', 'persistentvolumeclaims']
+    resources = ['pods', 'jobs' 
+    # 'persistentvolumeclaims'
+    ]
     data = {resource: [] for resource in resources}
     data['namespace'] = namespace  # Store namespace in data dict
 
@@ -97,12 +99,19 @@ def k8s_get_all_resources_utilization_info(handle, namespace: str = "") -> Dict:
                 cpu_usage, memory_usage = utilization_map.get(key, ('N/A', 'N/A'))
                 data[resource].append([ns, name, status, cpu_usage, memory_usage])
             else:
+                status = None
                 if resource == 'jobs':
                     conditions = item['status'].get('conditions', [])
                     if conditions:
                         status = conditions[-1]['type']
-                elif resource == 'persistentvolumeclaims':
-                    status = item['status']['phase']
-                data[resource].append([ns, name, status])
+                        if status in ['Complete']:
+                            continue
+                # elif resource == 'persistentvolumeclaims':
+                #     status = item['status']['phase']
+                if status is not None:
+                    data[resource].append([ns, name, status])
+
+    # If resource has no objects to display, filter it out
+    data = {k: v for k, v in data.items() if v}
 
     return data


### PR DESCRIPTION
## Description

As per feedback:
1. Show only failed and Unknown jobs
2. Remove PVC info

### Testing

- Namespace without any jobs
```
unskript@awesome-awesome-runbooks-0:/tmp/jit$ python jit_info_script3.py
Using incluster config

Pods:
+--------------+------------------------------------------+---------+---------------+-------------------+
|  Namespace   |                   Name                   | Status  | CPU Usage (m) | Memory Usage (Mi) |
+--------------+------------------------------------------+---------+---------------+-------------------+
| cert-manager |      cert-manager-584f85f6cf-nll6v       | Running |      1m       |       35Mi        |
| cert-manager | cert-manager-cainjector-6c58576757-bqgqj | Running |      1m       |       63Mi        |
| cert-manager |  cert-manager-webhook-75d68f6fb9-7pwnl   | Running |      1m       |       13Mi        |
+--------------+------------------------------------------+---------+---------------+-------------------+
```
- Namespace with pods and jobs
```
Pods:
+-----------+------------------------------------------------------+---------+---------------+-------------------+
| Namespace |                         Name                         | Status  | CPU Usage (m) | Memory Usage (Mi) |
+-----------+------------------------------------------------------+---------+---------------+-------------------+
| lightbeam |                       curlpod                        | Running |      0m       |        0Mi        |
| lightbeam |            ingress-kong-69fdcf9b7c-plqft             | Running |      5m       |       338Mi       |
| lightbeam |              kafka-ui-558c57f65f-tgnxc               | Running |      2m       |       272Mi       |
| lightbeam |    lb-argo-workflows-controller-7f4d9d8fb9-lwgjj     | Running |      4m       |       18Mi        |
| lightbeam |      lb-argo-workflows-server-5dd6b9956b-gzdxk       | Running |      1m       |       18Mi        |
| lightbeam |          lb-kafka-connect-5c6846cdbd-jkx2k           | Running |      7m       |       717Mi       |
| lightbeam |                    lb-keycloak-0                     | Running |      3m       |       581Mi       |
| lightbeam |       lb-prometheus-operator-6ccd9c9469-hmrgp        | Running |      2m       |       27Mi        |
| lightbeam |                  lb-redis-master-0                   | Running |      15m      |        5Mi        |
| lightbeam |                 lb-redis-replicas-0                  | Running |      20m      |        4Mi        |
| lightbeam |                 lb-redis-replicas-1                  | Running |      19m      |        4Mi        |
| lightbeam |                 lb-redis-replicas-2                  | Running |      19m      |        5Mi        |
| lightbeam |                      lb-vault-0                      | Running |      7m       |       80Mi        |
| lightbeam |        lb-workflow-executor-6d4777bb8f-qgkkc         | Running |      2m       |       11Mi        |
| lightbeam |        lightbeam-api-gateway-5cdfb4b69-bqr8w         | Running |      0m       |        0Mi        |
| lightbeam |        lightbeam-datahub-gms-7b68f6fc7f-j8bm4        | Running |      5m       |       389Mi       |
| lightbeam |    lightbeam-datahub-gms-graphql-6b47fcd8ff-hwpbz    | Running |      2m       |       203Mi       |
| lightbeam | lightbeam-datasource-stats-aggregator-6d7686b8-ntrr4 | Running |      10m      |       72Mi        |
| lightbeam |           lightbeam-elasticsearch-master-0           | Running |      5m       |      1092Mi       |
| lightbeam |       lightbeam-files-service-69bf959f5c-qr7gv       | Running |      1m       |        8Mi        |
| lightbeam |         lightbeam-frontend-6c7d59d869-55n8s          | Running |      1m       |       24Mi        |
| lightbeam |                  lightbeam-kafka-0                   | Running |      30m      |      1112Mi       |
| lightbeam |              lightbeam-kafka-exporter-0              | Running |      1m       |       12Mi        |
| lightbeam |             lightbeam-kafka-zookeeper-0              | Running |      10m      |       362Mi       |
| lightbeam |           lightbeam-minio-6cf5844654-vlvsv           | Running |      1m       |       84Mi        |
| lightbeam |         lightbeam-mongo-aggr-28547309-45wg4          | Running |      N/A      |        N/A        |
| lightbeam |                 lightbeam-mongodb-0                  | Running |     413m      |       736Mi       |
| lightbeam |             lightbeam-mongodb-arbiter-0              | Running |      8m       |       72Mi        |
| lightbeam |      lightbeam-policy-consumer-65d546cc4d-x6nsx      | Pending |      N/A      |        N/A        |
| lightbeam |       lightbeam-policy-engine-76d5667bf8-mxfv4       | Running |      13m      |       151Mi       |
| lightbeam |      lightbeam-presidio-server-7c89f7f4bd-xhqdr      | Running |      11m      |      3759Mi       |
| lightbeam |  lightbeam-prometheus-pushgateway-6c4cf77496-l96f2   | Running |      1m       |       11Mi        |
| lightbeam |                  lightbeam-qdrant-0                  | Running |      1m       |       12Mi        |
| lightbeam |       lightbeam-report-engine-65dfdd5c7-gr4w4        | Running |      6m       |       71Mi        |
| lightbeam |      lightbeam-schema-registry-694887697d-hqwxm      | Running |      5m       |       205Mi       |
| lightbeam |      lightbeam-text-extraction-7cf9f6c8b9-c9qp9      | Running |      15m      |      2797Mi       |
| lightbeam |        lightbeam-tika-server-75485bf8fd-rvdm5        | Running |      2m       |       195Mi       |
| lightbeam |       local-path-provisioner-6cc89d4f76-6f96q        | Running |      2m       |       11Mi        |
| lightbeam |                      postgres-0                      | Running |      8m       |       44Mi        |
| lightbeam |              prometheus-lb-prometheus-0              | Running |      14m      |       91Mi        |
| lightbeam |        vault-agent-injector-6c7d69ff46-llbwm         | Running |      5m       |       12Mi        |
+-----------+------------------------------------------------------+---------+---------------+-------------------+

Jobs:
+-----------+--------------------------------------+--------+
|           |                 Name                 | Status |
+-----------+--------------------------------------+--------+
| lightbeam | lightbeam-alert-handler-job-28172295 | Failed |
| lightbeam |    lightbeam-mongo-aggr-28172293     | Failed |
+-----------+--------------------------------------+--------+
```
- Namespace without pods  and jobs
```
unskript@awesome-awesome-runbooks-0:/tmp/jit$ python jit_info_script3.py
Using incluster config
```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
