### PR TITLE
Update check error pods from all jobs to use kubectl

### DIFF
--- a/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
+++ b/Kubernetes/legos/k8s_get_all_resources_utilization_info/k8s_get_all_resources_utilization_info.py
@@ -93,7 +93,7 @@ def k8s_get_all_resources_utilization_info(handle, namespace: str = "") -> Dict:
             if resource == 'pods':
                 status = item['status']['phase']
                  # Skip pods in Succeeded or Completed state as they dont have any utilization
-                if status in ['Succeeded', 'Completed', 'Failed']:
+                if status in ['Succeeded', 'Completed', 'Failed','Pending']:
                     continue
                 key = (ns, name)
                 cpu_usage, memory_usage = utilization_map.get(key, ('N/A', 'N/A'))

--- a/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
+++ b/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
@@ -29,6 +29,10 @@ def k8s_get_oomkilled_pods_printer(output):
     if output is None:
         return
     pprint.pprint(output)
+
+def format_datetime(dt):
+    # Format datetime to a string 'YYYY-MM-DD HH:MM:SS UTC'
+    return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
     
 
 def k8s_get_oomkilled_pods(handle, namespace: str = "", time_interval_to_check=24) -> Tuple:
@@ -98,7 +102,7 @@ def k8s_get_oomkilled_pods(handle, namespace: str = "", time_interval_to_check=2
                 # If termination time is greater than interval_time_to_check meaning
                 # the POD has gotten OOMKilled in the last 24 hours, so lets flag it!
                 if termination_time and termination_time >= interval_time_to_check:
-                    result.append({"pod": pod_name, "namespace": namespace, "container": container_name})
+                    result.append({"pod": pod_name, "namespace": namespace, "container": container_name, "termination_time":termination_time,"interval_time_to_check": interval_time_to_check})
     
     return (False, result) if result else (True, None)
 

--- a/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
+++ b/Kubernetes/legos/k8s_get_oomkilled_pods/k8s_get_oomkilled_pods.py
@@ -102,7 +102,9 @@ def k8s_get_oomkilled_pods(handle, namespace: str = "", time_interval_to_check=2
                 # If termination time is greater than interval_time_to_check meaning
                 # the POD has gotten OOMKilled in the last 24 hours, so lets flag it!
                 if termination_time and termination_time >= interval_time_to_check:
-                    result.append({"pod": pod_name, "namespace": namespace, "container": container_name, "termination_time":termination_time,"interval_time_to_check": interval_time_to_check})
+                    formatted_termination_time = format_datetime(termination_time)
+                    formatted_interval_time_to_check = format_datetime(interval_time_to_check)
+                    result.append({"pod": pod_name, "namespace": namespace, "container": container_name, "termination_time":formatted_termination_time,"interval_time_to_check": formatted_interval_time_to_check})
     
     return (False, result) if result else (True, None)
 

--- a/Kubernetes/legos/k8s_get_pods_with_high_restart/k8s_get_pods_with_high_restart.py
+++ b/Kubernetes/legos/k8s_get_pods_with_high_restart/k8s_get_pods_with_high_restart.py
@@ -30,6 +30,10 @@ def k8s_get_pods_with_high_restart_printer(output):
 
     print(output)
 
+def format_datetime(dt):
+    # Format datetime to a string 'YYYY-MM-DD HH:MM:SS UTC'
+    return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+
 def k8s_get_pods_with_high_restart(handle, namespace: str = '', threshold: int = 25) -> Tuple:
     """k8s_get_pods_with_high_restart This function finds out PODS that have
        high restart count and returns them as a list of dictionaries
@@ -81,6 +85,8 @@ def k8s_get_pods_with_high_restart(handle, namespace: str = '', threshold: int =
                     # We compare if the termination time is within the last 24 hours, if yes
                     # then we need to add it to the retval and return the list back
                     if termination_time and termination_time >= interval_time_to_check:
-                        retval.append({'name': pod.metadata.name, 'namespace': pod.metadata.namespace})
+                        formatted_termination_time = format_datetime(termination_time)
+                        formatted_interval_time_to_check = format_datetime(interval_time_to_check)
+                        retval.append({"pod": pod.metadata.name, "namespace": pod.metadata.namespace, "termination_time":formatted_termination_time,"interval_time_to_check": formatted_interval_time_to_check})
 
     return (False, retval) if retval else (True, None)


### PR DESCRIPTION
## Description
1. Getting this error while running k8s_get_error_pods_from_all_jobs check:
`- module 'kubernetes.client' has no attribute 'models'`

Which was permeating to other checks run after this check.

Resolved it by using kubectl instead of kubernetes python client for check implementation

2. Add termination time and interval time to oomkilled pods and high restart pods check

### Testing
- Using jit script
```
(unskript) unskript@lb-unskript-0:/tmp$ python jit_script.py
Using incluster config
JOB NAME: kong-migrations
JOB NAME: lb-bloom-filter-builder-28547640
PODS IN JOB lb-bloom-filter-builder-28547640: lb-bloom-filter-builder-28547640-7prn6
JOB NAME: lb-bloom-filter-builder-28548000
PODS IN JOB lb-bloom-filter-builder-28548000: lb-bloom-filter-builder-28548000-27zhj
JOB NAME: lb-bloom-filter-builder-28548360
PODS IN JOB lb-bloom-filter-builder-28548360: lb-bloom-filter-builder-28548360-sqsd6
JOB NAME: lb-mssql-scanner-6618d01ef02c1460716fdda4-manual
PODS IN JOB lb-mssql-scanner-6618d01ef02c1460716fdda4-manual: lb-mssql-scanner-6618d01ef02c1460716fdda4-manual-52chd
JOB NAME: lb-mssql-scanner-6618d1f4c1a2aa009ee61004-manual
JOB NAME: lb-mssql-scanner-6618d717c1a2aa009ee61006-manual
PODS IN JOB lb-mssql-scanner-6618d717c1a2aa009ee61006-manual: lb-mssql-scanner-6618d717c1a2aa009ee61006-manual-5q6t9
JOB NAME: lb-workflow-gc-28545120
JOB NAME: lb-workflow-gc-28546560
JOB NAME: lb-workflow-gc-28548000
JOB NAME: lightbeam-alert-handler-job-28524255
JOB NAME: lightbeam-alert-handler-job-28548492
PODS IN JOB lightbeam-alert-handler-job-28548492: lightbeam-alert-handler-job-28548492-7btjm
JOB NAME: lightbeam-alert-handler-job-28548495
PODS IN JOB lightbeam-alert-handler-job-28548495: lightbeam-alert-handler-job-28548495-grq4v
JOB NAME: lightbeam-alert-handler-job-28548498
PODS IN JOB lightbeam-alert-handler-job-28548498: lightbeam-alert-handler-job-28548498-rbftq
JOB NAME: lightbeam-bootstrap
JOB NAME: lightbeam-datahub-elasticsearch-setup-job
JOB NAME: lightbeam-datahub-kafka-setup-job
JOB NAME: lightbeam-datahub-postgres-setup-job
JOB NAME: lightbeam-post-install-setup
{"status": 1, "objects": null, "error": "", "id": "d7a1da167d056a912739fce8c4571c6863050f52d6e19495971277057e709857"}
None
```
- Using unskript ctl cmd

<img width="829" alt="Screenshot 2024-04-12 at 2 40 23 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/45378429-0960-40ac-a2d3-1be0fc0c64be">

- OOMKilled
```
RESULT [{'pod': 'prometheus-lightbeam-prometheus-prometheus-0', 'namespace': 'monitoring', 'container': 'prometheus', 'termination_time': '2024-04-12 10:00:20 UTC', 'interval_time_to_check': '2024-04-11 10:03:10 UTC'}]
```
- High restarts
```
{"status": 2, "objects": [{"pod": "prometheus-lightbeam-prometheus-prometheus-0", "namespace": "monitoring", "termination_time": "2024-04-12 10:06:00 UTC", "interval_time_to_check": "2024-04-11 10:10:07 UTC"}], "error": "", "id": "feb60351fb3290f22855cc68f4741e24cd930debb326724e977ad9e450c49c74"}
```
### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
