### PR TITLE
Get vault secret for smtp 

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -184,18 +184,21 @@ notification:
     #    - Sendgrid - Sendgrid
     provider: ""
     SMTP:
+      vault-secret-path: ""
       smtp-host: ""
       smtp-user: ""
       smtp-password: ""
       to-email: ""
       from-email: ""
     SES:
+      vault-secret-path: ""
       access_key: ""
       secret_access: ""
       region: ""
       to-email: ""
       from-email: ""
     Sendgrid:
+      vault-secret-path: ""
       api_key: ""
       to-email: ""
       from-email: ""


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

[EN-5462] 

* Added support to get `credential` from vault 
* Added support to specify vault-secret-path in the config yaml file 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Unit Testing 
```
unskript@lb-unskript-0:~/test$ unskript-ctl.sh run check --type vault --info --report
Running: 100%|████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 23.08it/s]

╒══════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name              │ Result   │   Failed Count │ Error   │
╞══════════════════════════╪══════════╪════════════════╪═════════╡
│ Get Vault service health │  PASS    │              0 │ N/A     │
╘══════════════════════════╧══════════╧════════════════╧═════════╛



Information Gathering Action Results
Running: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 21/21 [03:06<00:00,  8.88s/it]

mongodb/mongodb_get_metrics



Total Memory: 7698 MB
Database    Collection                                 Index Size (KB)    Storage Size (KB)
----------  ---------------------------------------  -----------------  -------------------
admin       system.version                                          20         20
admin       system.keys                                             36         36
admin       system.users                                            40         20
config      transactions                                            56         12
config      image_collection                                        32         32
config      system.preimages                                         0          4
config      tenantMigrationDonors                                    8          4
config      tenantMigrationRecipients                                8          4
config      system.indexBuilds                                      24         24
config      settings                                                20         20
config      system.sessions                                        112         64
config      external_validation_keys                                 8          4
lightbeam   task                                                  3512       1448
lightbeam   file_share_internal                                     32         24
lightbeam   template                                               108         36
lightbeam   project                                                 40         36
lightbeam   dsr_ticket                                              36         36
lightbeam   kafka_topic_priority                                    20         20
lightbeam   datasource_object_statistics                           516        400
lightbeam   configuration                                           36         36
lightbeam   ropa_process_topic_question                              4          4
lightbeam   dsr_attachment                                           8          4
lightbeam   drive                                                   72         60
lightbeam   scheduled_workflow                                      72         36
lightbeam   workflow                                                72         52
lightbeam   ropa_process_report_activity                            36         36
lightbeam   group_summary                                          168         92
lightbeam   ticket_store_projects                                    4          4
lightbeam   policy_filters                                          72         36
lightbeam   duplicate_records                                     1408       1448
lightbeam   identifier                                              72        220
lightbeam   ticket_reporter                                          4          4
lightbeam   database_record                                          4          4
lightbeam   policy_type                                             72         36
lightbeam   upgrade_job_state                                       40         36
lightbeam   ropa_process_topic                                      36         60
lightbeam   alert                                                   72         36
lightbeam   locks_kv                                                36         36
lightbeam   bloom_filter_builds                                     20         36
lightbeam   dsr_report                                              36         36
lightbeam   pii_record_hash                                          4          4
lightbeam   violation                                               36         36
lightbeam   annotation_feedback                                      4          4
lightbeam   sot_identifier                                           4          4
lightbeam   notification                                            36        164
lightbeam   job_state                                                4          4
lightbeam   datasource_internal                                     36         36
lightbeam   directory                                              152         92
lightbeam   historical_datasource_stats                             72        132
lightbeam   blob_columns                                            40         36
lightbeam   annotation                                               4          4
lightbeam   schedule_report                                          4          4
lightbeam   identifier_set                                          72         44
lightbeam   dsr_request                                             36         36
lightbeam   ropa_process_activity                                   72         36
lightbeam   im_channel                                              60         36
lightbeam   tickets                                                  8          4
lightbeam   im_member                                               20         36
lightbeam   archived_document                                       12         60
lightbeam   job_history                                             40         36
lightbeam   marker                                                  72         96
lightbeam   pii_record                                           19460      34268
lightbeam   annotation_classes                                      72         36
lightbeam   historical_datasource                                   72         36
lightbeam   erased_user_entities                                    36         36
lightbeam   entity_type                                             56         36
lightbeam   version                                                 20         36
lightbeam   ropa_process_topic_comment                               4          4
lightbeam   document                                             49468      41876
lightbeam   datasource_static_config                                20         20
lightbeam   partner_sender_stats                                    72         36
lightbeam   context_management_records                               8          4
lightbeam   template_stats                                          36         36
lightbeam   log_template                                             8          4
lightbeam   sot_configuration                                       20         20
lightbeam   doc_analytics                                           20         20
lightbeam   archived_pii_record                                     12         36
lightbeam   search_engine_index                                      4          4
lightbeam   historical_datasource_object_statistics               1768       3312
lightbeam   user_entity                                           9912       8564
lightbeam   sub_alert                                              160        260
lightbeam   document_action                                          4          4
lightbeam   hourly_aggregate_counts                                 68         32
lightbeam   policy                                                  72         40
lightbeam   schema_changelog                                       164        124
lightbeam   global_stats                                            20         36
lightbeam   alert_users                                             40         36
lightbeam   label                                                   36         36
lightbeam   annotation_file                                          4          4
lightbeam   partner                                                 36         44
lightbeam   workflow_definition                                     72         60
lightbeam   archived_attribute_instance                             24         24
lightbeam   pii_record_diff                                          4          4
lightbeam   datasource_stats                                        72         52
lightbeam   attribute_instance                                   87392      46828
lightbeam   policy_actions                                          20         20
lightbeam   residency                                                4          4
lightbeam   site                                                    36         36
lightbeam   datasource_metadata                                     20         36
lightbeam   mail                                                   144         72
lightbeam   table_scan_history                                      44         80
lightbeam   datasource_progress                                     92        176
lightbeam   dsr_email_template                                      36        120
lightbeam   datasource                                             152         36
lightbeam   ropa_process_report_form                                36         36
lightbeam   folder                                                 124        108
lightbeam   file_share                                              68         32
lightbeam   profile_map                                              4          4
lightbeam   document_label_set                                     144         36
lightbeam   datasource_arch_upgrade_v2                              32         32
lightbeam   no_scan_document                                        80         36
lightbeam   bucket                                                  36         52
lightbeam   dsr_form_builder                                        72        224
lightbeam   gmail_job_history                                       72         36
lightbeam   sub_alert_history                                       20         20
lightbeam   notification_configuration                               8          4
lightbeam   datasource_user_summary                                108         36
lightbeam   dsr_lightbeam_web                                       20         36
lightbeam   alert_history                                           36         36
local       system.rollback.id                                      20         36
local       replset.minvalid                                        20         20
local       replset.oplogTruncateAfterPoint                         20         36
local       replset.election                                        20         36
local       oplog.rs                                                 0          1.84255e+06
local       system.replset                                          20         36
local       system.views                                            20         20
local       replset.initialSyncId                                   20         20
local       startup_log                                             36         36

###

k8s/k8s_get_service_images



Using incluster config
No data available

Using incluster config
No labels found for service kubelet in namespace lightbeam. Skipping...
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| Service (Namespace)                                    | Images                                                                                                                 |
+========================================================+========================================================================================================================+
| kafka-ui (lightbeam)                                   | docker_io/fastcomply/kafka-ui@sha256:bd7a547604941608fb83d8700b6ef15de1ab57ed8de5859c1084e306164946b1                  |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| kong-proxy (lightbeam)                                 | docker_io/fastcomply/kong-oidc@sha256:d44b17a99e105311370eb723395b345862001abefe9ba9363c8b5d6c400a0839                 |
|                                                        | fastcomply/kong-ingress-controller:1.0.0                                                                               |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| kong-validation-webhook (lightbeam)                    | docker_io/fastcomply/kong-oidc@sha256:d44b17a99e105311370eb723395b345862001abefe9ba9363c8b5d6c400a0839                 |
|                                                        | fastcomply/kong-ingress-controller:1.0.0                                                                               |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-argo-workflows-server (lightbeam)                   | docker_io/fastcomply/argocli@sha256:1f8ba8e8202794e1a4d6388958d412994b0f681d1589a2bb4a249c649c57394b                   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-kafka-connect (lightbeam)                           | docker_io/fastcomply/lightbeam-kafka-connect@sha256:951c8502d204aac65a3f77907100ba1dadb6e93b387d953f8af048bda7f8556e   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-keycloak (lightbeam)                                | docker_io/fastcomply/lb-keycloak@sha256:9411b62bc432f5b1013dfa01a7b58abbfefbefe888e713d1575c2cbd3a0267c8               |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-keycloak-headless (lightbeam)                       | docker_io/fastcomply/lb-keycloak@sha256:9411b62bc432f5b1013dfa01a7b58abbfefbefe888e713d1575c2cbd3a0267c8               |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-redis-cache-headless (lightbeam)                    | docker_io/fastcomply/redis@sha256:54cfcc889e1bae14e9b8cdd20763b867f8b05d76524fd5c44245d058615ac285                     |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-redis-cache-master (lightbeam)                      | docker_io/fastcomply/redis@sha256:54cfcc889e1bae14e9b8cdd20763b867f8b05d76524fd5c44245d058615ac285                     |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-redis-headless (lightbeam)                          | docker_io/fastcomply/redis@sha256:54cfcc889e1bae14e9b8cdd20763b867f8b05d76524fd5c44245d058615ac285                     |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-redis-master (lightbeam)                            | docker_io/fastcomply/redis@sha256:54cfcc889e1bae14e9b8cdd20763b867f8b05d76524fd5c44245d058615ac285                     |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-seaweedfs-svc (lightbeam)                           | docker_io/fastcomply/seaweedfs@sha256:94bfa0e727ef06d1ea0af191b62a9eb12b24ab93954b46c34096adccc0d3a634                 |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-unskript (lightbeam)                                | docker_io/fastcomply/lb-unskript:latest                                                                                |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-vault (lightbeam)                                   | docker_io/fastcomply/vault@sha256:e95f46376b39654f4be020c7be91ac88b6729b6b506e48516bef3b140a901bd5                     |
|                                                        | docker_io/fastcomply/vault-unseal@sha256:289ea3ac6c99ad6925d428a40b2b3d30e3b1a86d19f7672466c3de5d6d5658d2              |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lb-vault-ui (lightbeam)                                | docker_io/fastcomply/vault@sha256:e95f46376b39654f4be020c7be91ac88b6729b6b506e48516bef3b140a901bd5                     |
|                                                        | docker_io/fastcomply/vault-unseal@sha256:289ea3ac6c99ad6925d428a40b2b3d30e3b1a86d19f7672466c3de5d6d5658d2              |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-airbyte-server-svc (lightbeam)               | docker_io/fastcomply/airbyte-server:0.40.3                                                                             |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-airbyte-temporal-svc (lightbeam)             | docker_io/fastcomply/temporalio-auto-setup:1.7.0                                                                       |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-airbyte-webapp-svc (lightbeam)               | docker_io/fastcomply/airbyte-webapp:0.40.3                                                                             |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-api-gateway (lightbeam)                      | docker_io/fastcomply/api-gateway@sha256:59efa3a6bf64df19aa05de752ea9ca118ca4e6a9fa8a3a1322d0a4449ef1e96d               |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-datahub-gms (lightbeam)                      | docker_io/fastcomply/datahub-gms:latest                                                                                |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-datahub-gms-graphql (lightbeam)              | docker_io/fastcomply/datahub-gms-graphql-service:latest                                                                |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-elasticsearch-master (lightbeam)             | docker_io/fastcomply/lightbeam-elasticsearch@sha256:ee423afa77b55e58c7af1462c526d067864314e44b4e8a8df80b8a58bb3d150f   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-elasticsearch-master-headless (lightbeam)    | docker_io/fastcomply/lightbeam-elasticsearch@sha256:ee423afa77b55e58c7af1462c526d067864314e44b4e8a8df80b8a58bb3d150f   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-elasticsearch-nodeport-service (lightbeam)   | docker_io/fastcomply/lightbeam-elasticsearch@sha256:ee423afa77b55e58c7af1462c526d067864314e44b4e8a8df80b8a58bb3d150f   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-files-service (lightbeam)                    | docker_io/fastcomply/rex@sha256:91bcf82357f6b2a07aa1b0e6fc66cd5a6fa54214f3f942fcbf35550f22d18736                       |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-frontend (lightbeam)                         | docker_io/fastcomply/frontend@sha256:839837015ebb66298c44df0d41ce7b5f1614267ee1be7e97ae360a9f02898046                  |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-kafka (lightbeam)                            | docker_io/fastcomply/kafka@sha256:b3005ebcd93b288ac5c4bb22766b72146a4f4a6f09c7acff51752df881cb678c                     |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-kafka-headless (lightbeam)                   | docker_io/fastcomply/kafka@sha256:b3005ebcd93b288ac5c4bb22766b72146a4f4a6f09c7acff51752df881cb678c                     |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-kafka-metrics (lightbeam)                    | docker_io/fastcomply/kafka-exporter@sha256:687fd464aaf171a746eeb05074a7a84e93f982f9c8a7d58cc68eefebfadadc54            |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-kafka-zookeeper (lightbeam)                  | docker_io/fastcomply/zookeeper@sha256:d87cf0c9697f2c6cf7516bf8b188220eef1e3a6644aa3791a4f0fac2783eac82                 |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-kafka-zookeeper-headless (lightbeam)         | docker_io/fastcomply/zookeeper@sha256:d87cf0c9697f2c6cf7516bf8b188220eef1e3a6644aa3791a4f0fac2783eac82                 |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-kafka-zookeeper-metrics (lightbeam)          | docker_io/fastcomply/zookeeper@sha256:d87cf0c9697f2c6cf7516bf8b188220eef1e3a6644aa3791a4f0fac2783eac82                 |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-mongodb-arbiter-headless (lightbeam)         | docker_io/fastcomply/mongodb@sha256:b0baa95ed91d834ea1f167c909a8e642aea9b9c01bf209d2b62842539638f32e                   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-mongodb-headless (lightbeam)                 | docker_io/fastcomply/mongodb@sha256:b0baa95ed91d834ea1f167c909a8e642aea9b9c01bf209d2b62842539638f32e                   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-mongodb-nodeport-service (lightbeam)         | docker_io/fastcomply/mongodb@sha256:b0baa95ed91d834ea1f167c909a8e642aea9b9c01bf209d2b62842539638f32e                   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-policy-engine (lightbeam)                    | No images found                                                                                                        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-presidio-server (lightbeam)                  | No images found                                                                                                        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-prometheus (lightbeam)                       | docker_io/fastcomply/prometheus@sha256:db03207fa305e4232ae907f04e51fac42ea4c7ca8359812562ed5c8bcc8e34e5                |
|                                                        | docker_io/fastcomply/prometheus-config-reloader:v0.68.0                                                                |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-prometheus-pushgateway (lightbeam)           | docker_io/fastcomply/pushgateway@sha256:71baaf14c915baf382564613e7d9f7edcbc872777f4ca346db8ec2b95644ed1d               |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-qdrant (lightbeam)                           | docker_io/fastcomply/qdrant@sha256:016706b184cf86f58e4102a0b1a9b689f9827081c601c755fabd7723e6daf616                    |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-qdrant-headless (lightbeam)                  | docker_io/fastcomply/qdrant@sha256:016706b184cf86f58e4102a0b1a9b689f9827081c601c755fabd7723e6daf616                    |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-report-engine (lightbeam)                    | docker_io/fastcomply/report-engine@sha256:a9e6ce775191deb8a07b28a13b4e52b92a6d08cde1ab9b8ae76a66303ab189cc             |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-schema-registry (lightbeam)                  | docker_io/fastcomply/cp-schema-registry@sha256:dc1d2b841f8f4bf715c96867a6d7d544adc505f58caf5239ea17b59e63623c47        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-text-extraction (lightbeam)                  | No images found                                                                                                        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-text-extraction-headless (lightbeam)         | No images found                                                                                                        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-text-extraction-non-ocr (lightbeam)          | docker_io/fastcomply/gotenberg@sha256:9d098f6de665d5e278bbf7e0a4445a54d3c6f8163637f1c7e81be51fa373ebb9                 |
|                                                        | docker_io/fastcomply/text-extraction-non-ocr@sha256:9561ce9c0858485cd73d5e75fcbb4ea2e679364d572bc77252feac38aa205aa7   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-text-extraction-non-ocr-headless (lightbeam) | docker_io/fastcomply/gotenberg@sha256:9d098f6de665d5e278bbf7e0a4445a54d3c6f8163637f1c7e81be51fa373ebb9                 |
|                                                        | docker_io/fastcomply/text-extraction-non-ocr@sha256:9561ce9c0858485cd73d5e75fcbb4ea2e679364d572bc77252feac38aa205aa7   |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| lightbeam-tika-server (lightbeam)                      | No images found                                                                                                        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| mssql-deployment (lightbeam)                           | mcr.microsoft.com/mssql/server:2019-latest                                                                             |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| postgres (lightbeam)                                   | docker_io/fastcomply/bitnami-postgres-exporter@sha256:4c28049ac3a78556845abf0f0f988f4709f40669e90aabf19d80ae6bb5547e33 |
|                                                        | docker_io/fastcomply/bitnami-postgresql@sha256:375e74034540f158cb19b0898b298fe05ff7a0554ac4f706f794e615f94d73c0        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| postgres-metrics (lightbeam)                           | docker_io/fastcomply/bitnami-postgres-exporter@sha256:4c28049ac3a78556845abf0f0f988f4709f40669e90aabf19d80ae6bb5547e33 |
|                                                        | docker_io/fastcomply/bitnami-postgresql@sha256:375e74034540f158cb19b0898b298fe05ff7a0554ac4f706f794e615f94d73c0        |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| prometheus-operated (lightbeam)                        | docker_io/fastcomply/prometheus@sha256:db03207fa305e4232ae907f04e51fac42ea4c7ca8359812562ed5c8bcc8e34e5                |
|                                                        | docker_io/fastcomply/prometheus-config-reloader:v0.68.0                                                                |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| vault-agent-injector-svc (lightbeam)                   | docker_io/fastcomply/vault-k8s@sha256:a8e5351c5f2a0240ae60440acfd712b52bdd48b5b5f6a1095a1678f322785cb1                 |
+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+

Using incluster config
No data available

Using incluster config
+----------------------------------------+--------------------------------------------------+
| Service (Namespace)                    | Images                                           |
+========================================+==================================================+
| lb-cert-manager (cert-manager)         | quay.io/jetstack/cert-manager-controller:v0.15.1 |
+----------------------------------------+--------------------------------------------------+
| lb-cert-manager-webhook (cert-manager) | quay.io/jetstack/cert-manager-webhook:v0.15.1    |
+----------------------------------------+--------------------------------------------------+

###

k8s/k8s_measure_worker_node_network_bandwidth



Using incluster config
Forbidden: The service account does not have permission to create/delete daemonset.

###

k8s/k8s_get_node_status_and_resource_utilization



Using incluster config
+-----------------+--------+---------------+------------------+
|    Node Name    | Status | CPU Usage (%) | Memory Usage (%) |
+-----------------+--------+---------------+------------------+
| sandbox-cluster | Ready  |      10       |        47        |
+-----------------+--------+---------------+------------------+

###

mongodb/mongodb_get_write_conflicts



Potential Write Conflicts: 0

###

k8s/k8s_get_all_resources_utilization_info



Using incluster config

Pods:
+-----------+--------------------------------------------------------+---------+---------------+-------------------+
| Namespace |                          Name                          | Status  | CPU Usage (m) | Memory Usage (Mi) |
+-----------+--------------------------------------------------------+---------+---------------+-------------------+
| lightbeam |             ingress-kong-7875555f6f-wrtg5              | Running |      2m       |       162Mi       |
| lightbeam |                kafka-ui-6844f5688-86wxb                | Running |      2m       |       303Mi       |
| lightbeam |      lb-argo-workflows-controller-84b9f76f6-gzn7c      | Running |      4m       |       60Mi        |
| lightbeam |       lb-argo-workflows-server-55987f744f-757tf        | Running |      1m       |       29Mi        |
| lightbeam |           lb-kafka-connect-54cf568fbb-rtjhd            | Running |      4m       |       699Mi       |
| lightbeam |                     lb-keycloak-0                      | Running |      2m       |       594Mi       |
| lightbeam |         lb-prometheus-operator-9c7f88667-mrg9k         | Running |      1m       |       27Mi        |
| lightbeam |                lb-redis-cache-master-0                 | Running |      7m       |        3Mi        |
| lightbeam |                   lb-redis-master-0                    | Running |      5m       |       13Mi        |
| lightbeam |                     lb-seaweedfs-0                     | Running |      2m       |       165Mi       |
| lightbeam |           lb-serviceability-86c5f595d7-5kdnq           | Running |      0m       |        1Mi        |
| lightbeam |                     lb-unskript-0                      | Running |      0m       |       103Mi       |
| lightbeam |                       lb-vault-0                       | Running |      5m       |       261Mi       |
| lightbeam |     lightbeam-airbyte-pod-sweeper-6f4466c868-ffvjs     | Running |      6m       |       87Mi        |
| lightbeam |      lightbeam-airbyte-scheduler-c49d78b59-vmww7       | Running |      1m       |       144Mi       |
| lightbeam |       lightbeam-airbyte-server-797588c4fd-kcvwn        | Running |      1m       |       988Mi       |
| lightbeam |      lightbeam-airbyte-temporal-6cf549c645-bpwz5       | Running |      19m      |       71Mi        |
| lightbeam |       lightbeam-airbyte-webapp-6c4f4f4f95-9m2wr        | Running |      0m       |       13Mi        |
| lightbeam |        lightbeam-airbyte-worker-8df47dd99-kn8lh        | Running |      1m       |       264Mi       |
| lightbeam |         lightbeam-api-gateway-66946f69b8-846pz         | Running |      23m      |      1486Mi       |
| lightbeam |         lightbeam-datahub-gms-668d4f6d54-w6b9l         | Running |      3m       |       872Mi       |
| lightbeam |     lightbeam-datahub-gms-graphql-6bcf6cf846-bvh4c     | Running |      1m       |       819Mi       |
| lightbeam | lightbeam-datasource-stats-aggregator-67587c7f48-dg2b5 | Running |      9m       |       103Mi       |
| lightbeam |            lightbeam-elasticsearch-master-0            | Running |      3m       |      1175Mi       |
| lightbeam |        lightbeam-files-service-679fb47c55-nwcq4        | Running |      0m       |       59Mi        |
| lightbeam |          lightbeam-frontend-68bbb4fdb4-cb9n2           | Running |      1m       |       715Mi       |
| lightbeam |                   lightbeam-kafka-0                    | Running |      40m      |      1356Mi       |
| lightbeam |               lightbeam-kafka-exporter-0               | Running |      16m      |       25Mi        |
| lightbeam |              lightbeam-kafka-zookeeper-0               | Running |      4m       |       382Mi       |
| lightbeam |                  lightbeam-mongodb-0                   | Running |      85m      |      7884Mi       |
| lightbeam |              lightbeam-mongodb-arbiter-0               | Running |      4m       |       89Mi        |
| lightbeam |   lightbeam-prometheus-pushgateway-674576d985-c4h8s    | Running |      1m       |       18Mi        |
| lightbeam |                   lightbeam-qdrant-0                   | Running |      1m       |       377Mi       |
| lightbeam |        lightbeam-report-engine-6bf9d7764c-fnk5w        | Running |      4m       |       111Mi       |
| lightbeam |       lightbeam-schema-registry-86f57d9877-785x2       | Running |      3m       |       344Mi       |
| lightbeam |   lightbeam-text-extraction-non-ocr-6548bb8fc9-crnlk   | Running |      7m       |      1912Mi       |
| lightbeam |        local-path-provisioner-696ff46c78-6r6ww         | Running |      1m       |       16Mi        |
| lightbeam |           mssql-deployment-6688f86548-gq49k            | Running |      6m       |      1095Mi       |
| lightbeam |         policy-ops-5mwht-policy-ops-1749067927         | Running |      3m       |       181Mi       |
| lightbeam |                       postgres-0                       | Running |      3m       |       124Mi       |
| lightbeam |               prometheus-lb-prometheus-0               | Running |      3m       |       273Mi       |
| lightbeam |     unmute-alerts-1707264000-policy-ops-2769931040     | Running |      4m       |       180Mi       |
| lightbeam |          vault-agent-injector-68c774ddc-jxrz4          | Running |      2m       |       24Mi        |
+-----------+--------------------------------------------------------+---------+---------------+-------------------+

Jobs:
+-----------+----------------------------------+--------+
|           |               Name               | Status |
+-----------+----------------------------------+--------+
| lightbeam | lb-bloom-filter-builder-28482480 | Failed |
| lightbeam |      lb-pre-upgrade-manager      | Failed |
| lightbeam |     lb-workflow-gc-28478880      | Failed |
| lightbeam |     lb-workflow-gc-28480320      | Failed |
| lightbeam |     lb-workflow-gc-28481760      | Failed |
+-----------+----------------------------------+--------+

Using incluster config

Using incluster config

Pods:
+--------------+---------------------------------------------+---------+---------------+-------------------+
|  Namespace   |                    Name                     | Status  | CPU Usage (m) | Memory Usage (Mi) |
+--------------+---------------------------------------------+---------+---------------+-------------------+
| cert-manager |      lb-cert-manager-699b8459b6-6hh2s       | Running |      3m       |       58Mi        |
| cert-manager | lb-cert-manager-cainjector-847ddd59c9-2njxc | Running |      2m       |       67Mi        |
| cert-manager |  lb-cert-manager-webhook-6fc965dcdd-47k8z   | Running |      1m       |       17Mi        |
+--------------+---------------------------------------------+---------+---------------+-------------------+

Using incluster config

###

mongodb/mongodb_get_replica_set



+--------------------------------------------------------------------------------------------------+---------+
| Replica Name                                                                                     | Role    |
+==================================================================================================+=========+
| lightbeam-mongodb-0.lightbeam-mongodb-headless.lightbeam.svc.cluster.local:27017                 | PRIMARY |
+--------------------------------------------------------------------------------------------------+---------+
| lightbeam-mongodb-arbiter-0.lightbeam-mongodb-arbiter-headless.lightbeam.svc.cluster.local:27017 | ARBITER |
+--------------------------------------------------------------------------------------------------+---------+

###

kafka/kafka_get_topic_health



Group ID: 64df0c9f7c5e4444d31bb75a-ui-te-group
  Topic: 659e4000422551364ed0344c-ps
<snip> 

###

redis/redis_get_keys_count



{'Matched keys count': 39}

###
Skipping Diagnostics: No diagnostic command found. You can define them in the YAML configuration file
2024-04-18 00:00:51,868 - UnskriptCtlLogger - INFO - Slack Notification disabled
2024-04-18 00:00:52,095 - UnskriptCtlLogger - INFO - Notification sent successfully to XX@XXXX.com
2024-04-18 00:00:52,096 - UnskriptCtlLogger - INFO - Successfully sent Email notification via SMTP.


```
### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5462]: https://unskript.atlassian.net/browse/EN-5462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ