### PR TITLE
Update logic of K8s cluster health check 

### DIFF
--- a/Kubernetes/legos/k8s_get_cluster_health/k8s_get_cluster_health.py
+++ b/Kubernetes/legos/k8s_get_cluster_health/k8s_get_cluster_health.py
@@ -74,30 +74,45 @@ def check_node_health(node_api):
     return health_issues
 
 def check_pod_health(handle, core_services, namespace):
-    health_issues = []
-    namespaces = [namespace] if namespace else get_namespaces(handle)
+        health_issues = []
+        namespaces = [namespace] if namespace else get_namespaces(handle)
 
-    for ns in namespaces:
-        if core_services:
-            for service in core_services:
-                label_selector = get_label_selector_for_service(handle, ns, service)
-                if label_selector:
-                    command = f"kubectl get pods -n {ns} -l {label_selector} -o=jsonpath='{{.items[?(@.status.phase!=\"Running\")].metadata.name}}'"
-                    pods_not_running = execute_kubectl_command(handle, command)
-                    if pods_not_running:
-                        for pod_name in pods_not_running.split():
-                            health_issues.append({"type": "Pod", "name": pod_name, "namespace": ns, "issue": "Pod is not running."})
-                else:
-                    print(f"Service {service} not found or has no selectors in namespace {ns}. Skipping...")
-        else:
-            # Check all pods in the namespace if no specific services are given
-            command = f"kubectl get pods -n {ns} -o=jsonpath='{{.items[?(@.status.phase!=\"Running\")].metadata.name}}'"
-            pods_not_running = execute_kubectl_command(handle, command)
-            if pods_not_running:
-                for pod_name in pods_not_running.split():
-                    health_issues.append({"type": "Pod", "name": pod_name, "namespace": ns, "issue": "Pod is not running."})
+        for ns in namespaces:
+            if core_services:
+                for service in core_services:
+                    label_selector = get_label_selector_for_service(handle, ns, service)
+                    if label_selector:
+                        # Get all pods for the service
+                        command_pods = f"kubectl get pods -n {ns} -l {label_selector} -o=json"
+                        pods_info = execute_kubectl_command(handle, command_pods)
+                        if pods_info:
+                            pods_data = json.loads(pods_info)
+                            total_pods = len(pods_data['items'])
+                            running_pods = sum(1 for item in pods_data['items'] if item['status']['phase'] == "Running")
 
-    return health_issues
+                            # Check if at least 70% of pods are running
+                            if total_pods > 0:
+                                running_percentage = (running_pods / total_pods) * 100
+                                if running_percentage < 70:
+                                    health_issues.append({
+                                        "type": "Pod",
+                                        "name": service,
+                                        "namespace": ns,
+                                        "issue": f"Insufficient running pods. Only {running_pods} out of {total_pods} are running."
+                                    })
+                        else:
+                            print(f"No pods found for service {service} in namespace {ns}.")
+                    else:
+                        print(f"No label selector found for service {service} in namespace {ns}. Skipping...")
+            else:
+                # Check all pods in the namespace if no specific services are given
+                command = f"kubectl get pods -n {ns} -o=jsonpath='{{.items[?(@.status.phase!=\"Running\")].metadata.name}}'"
+                pods_not_running = execute_kubectl_command(handle, command)
+                if pods_not_running:
+                    for pod_name in pods_not_running.split():
+                        health_issues.append({"type": "Pod", "name": pod_name, "namespace": ns, "issue": "Pod is not running."})
+
+        return health_issues
 
 def check_deployment_health(handle, core_services, namespace):
     health_issues = []

--- a/Mongo/legos/mongodb_compare_disk_size_to_threshold/mongodb_compare_disk_size_to_threshold.py
+++ b/Mongo/legos/mongodb_compare_disk_size_to_threshold/mongodb_compare_disk_size_to_threshold.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 class InputSchema(BaseModel):
     threshold: Optional[float] = Field(
-        52428800, # 50GB in KB
+        83886080 , # 80GB in KB
         description='Threshold for disk size in KB.', 
         title='Threshold (in KB)'
     )
@@ -24,7 +24,7 @@ def mongodb_compare_disk_size_to_threshold_printer(output):
         print(f"Alert! Disk size of {alert['totalDiskSize']} KB for database {alert['db']} exceeds threshold of {alert['threshold']} KB.")
 
 
-def mongodb_compare_disk_size_to_threshold(handle, threshold: float=52428800) -> Tuple:
+def mongodb_compare_disk_size_to_threshold(handle, threshold: float=83886080) -> Tuple:
     """
     mongodb_compare_disk_size_to_threshold compares the total disk size used by MongoDB to a given threshold.
 

--- a/Postgresql/legos/postgresql_get_cache_hit_ratio/postgresql_get_cache_hit_ratio.json
+++ b/Postgresql/legos/postgresql_get_cache_hit_ratio/postgresql_get_cache_hit_ratio.json
@@ -4,7 +4,7 @@
     "action_type": "LEGO_TYPE_POSTGRESQL",
     "action_entry_function": "postgresql_get_cache_hit_ratio",
     "action_needs_credential": true,
-    "action_is_check": true,
+    "action_is_check": false,
     "action_supports_poll": true,
     "action_output_type": "ACTION_OUTPUT_TYPE_LIST",
     "action_supports_iteration": true,

--- a/Postgresql/legos/postgresql_get_server_status/postgresql_get_server_status.py
+++ b/Postgresql/legos/postgresql_get_server_status/postgresql_get_server_status.py
@@ -2,94 +2,38 @@
 # Copyright (c) 2023 unSkript, Inc
 # All rights reserved.
 ##
-from typing import Tuple, Optional
-from pydantic import BaseModel, Field
+from typing import Tuple
+from pydantic import BaseModel
 
 
 class InputSchema(BaseModel):
-    connection_threshold: Optional[int] = Field(
-        10000,
-        title='Connection threshold',
-        description='Threshold for the number of connections considered abnormal. Default- 10000 clients')
-    cache_hit_ratio_threshold: Optional[int] = Field(
-        90,
-        title='Cache hit ratio threshold (in %)',
-        description='Threshold for the cache hit ratio considered abnormal. Default- 90%')
-    blocked_query_threshold: Optional[int] = Field(
-        10000,
-        title='Blocked query threshold',
-        description='TThreshold for the number of blocked queries considered abnormal. Default- 10000')
+    pass
 
 
 def postgresql_get_server_status_printer(output):
-    is_healthy, server_status_info = output
+    if output[0]:
+        print("PostgreSQL Server Status: Reachable")
+    else:
+        error_message = output[1]['message'] if output[1] else "Unknown error"
+        print("PostgreSQL Server Status: Unreachable")
+        print(f"Error: {error_message}")
 
-    print("PostgreSQL Server Status:")
-    print(f"  Overall Health: {'Healthy' if is_healthy else 'Unhealthy'}")
-    print(f"  Total Connections: {server_status_info['total_connections']}")
-    print(f"  Cache Hit Ratio: {server_status_info['cache_hit_ratio']}%")
-    print(f"  Blocked Queries: {server_status_info['blocked_queries']}")
-
-    abnormal_metrics = server_status_info.get('abnormal_metrics')
-    if abnormal_metrics:
-        print("\nAbnormal Metrics:")
-        for metric in abnormal_metrics:
-            print(f"  - {metric}")
-
-def postgresql_get_server_status(handle, connection_threshold: int = 10000, cache_hit_ratio_threshold: int = 90, blocked_query_threshold: int = 10000) -> Tuple:
+def postgresql_get_server_status(handle) -> Tuple:
     """
-    Returns the status of the PostgreSQL instance.
+    Returns a simple status indicating the reachability of the PostgreSQL server.
 
     :type handle: object
     :param handle: PostgreSQL connection object
 
-    :type handle: object
-    :param connection_threshold: Threshold for the number of connections considered abnormal
-
-    :type handle: object
-    :param cache_hit_ratio_threshold: Threshold for the cache hit ratio considered abnormal
-
-    :type handle: object
-    :param blocked_query_threshold: Threshold for the number of blocked queries considered abnormal
-
-    :return: Tuple containing a status and a dictionary with detailed information
+    :return: Tuple containing a boolean indicating success and optional error message
     """
-    server_status_info = {}
-    abnormal_metrics = []
-
     try:
         cur = handle.cursor()
-
-        # Check total number of connections
-        cur.execute("SELECT COUNT(*) FROM pg_stat_activity;")
-        total_connections = cur.fetchone()[0]
-        server_status_info['total_connections'] = total_connections
-        if total_connections > connection_threshold:
-            abnormal_metrics.append(f"High number of connections: {total_connections}")
-
-        # Check cache hit ratio
-        cur.execute("SELECT sum(heap_blks_hit) / sum(heap_blks_hit + heap_blks_read) * 100 AS ratio FROM pg_statio_user_tables;")
-        cache_hit_ratio = cur.fetchone()[0]
-        server_status_info['cache_hit_ratio'] = cache_hit_ratio
-        if cache_hit_ratio < cache_hit_ratio_threshold:
-            abnormal_metrics.append(f"Cache hit ratio below {cache_hit_ratio_threshold}%: {cache_hit_ratio}")
-
-        # Check blocked queries
-        cur.execute("SELECT COUNT(*) FROM pg_locks WHERE granted = false;")
-        blocked_queries = cur.fetchone()[0]
-        server_status_info['blocked_queries'] = blocked_queries
-        if blocked_queries > blocked_query_threshold:
-            abnormal_metrics.append(f"Blocked queries above threshold: {blocked_queries}")
-
-        # Append abnormal metrics if any are found
-        if abnormal_metrics:
-            server_status_info['abnormal_metrics'] = abnormal_metrics
-            return (False, server_status_info)
-
-        return (True, server_status_info)
-
+        cur.execute("SELECT 1;")
+        cur.fetchone()
+        return (True, None)
     except Exception as e:
-        raise e
+        return (False, {"message": str(e)})
     finally:
         handle.close()
 


### PR DESCRIPTION
## Description
[EN-5441](https://unskript.atlassian.net/browse/EN-5441)

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
```
unskript@lb-unskript-0:/tmp$ python test.py
Using incluster config
Checking pod health across namespaces: ['lightbeam']
Namespace: lightbeam
Service: lightbeam-api-gateway
Label Selector for lightbeam-api-gateway: app=lightbeam-api-gateway
Total pods found for lightbeam-api-gateway: 1
Running pods for lightbeam-api-gateway: 1
Running percentage for lightbeam-api-gateway: 100.0%
Service: lb-argo-workflows-server
Label Selector for lb-argo-workflows-server: app.kubernetes.io/component=server,app.kubernetes.io/name=argo-workflows
Total pods found for lb-argo-workflows-server: 1
Running pods for lb-argo-workflows-server: 1
Running percentage for lb-argo-workflows-server: 100.0%
Service: lightbeam-frontend
Label Selector for lightbeam-frontend: app=lightbeam-frontend
Total pods found for lightbeam-frontend: 1
Running pods for lightbeam-frontend: 1
Running percentage for lightbeam-frontend: 100.0%
Service: kong-proxy
Label Selector for kong-proxy: app=lightbeam-kong-proxy
Total pods found for kong-proxy: 1
Running pods for kong-proxy: 1
Running percentage for kong-proxy: 100.0%
Service: lightbeam-kafka
Label Selector for lightbeam-kafka: app=lightbeam-kafka,app.kubernetes.io/component=lightbeam-kafka,app.kubernetes.io/instance=lightbeam-kafka,app.kubernetes.io/name=lightbeam-kafka
Total pods found for lightbeam-kafka: 3
Running pods for lightbeam-kafka: 3
Running percentage for lightbeam-kafka: 100.0%
Service: kafka-ui
Label Selector for kafka-ui: app=kafka-ui
Total pods found for kafka-ui: 1
Running pods for kafka-ui: 1
Running percentage for kafka-ui: 100.0%
Service: lb-kafka-connect
Label Selector for lb-kafka-connect: app=lightbeam-kafka-connect
Total pods found for lb-kafka-connect: 1
Running pods for lb-kafka-connect: 1
Running percentage for lb-kafka-connect: 100.0%
Service: lightbeam-kafka-metrics
Label Selector for lightbeam-kafka-metrics: app=lightbeam-kafka-exporter,app.kubernetes.io/component=lightbeam-kafka-exporter
Total pods found for lightbeam-kafka-metrics: 1
Running pods for lightbeam-kafka-metrics: 1
Running percentage for lightbeam-kafka-metrics: 100.0%
Service: lb-keycloak
Label Selector for lb-keycloak: app.kubernetes.io/component=keycloak
Total pods found for lb-keycloak: 1
Running pods for lb-keycloak: 1
Running percentage for lb-keycloak: 100.0%
Service: lightbeam-mongodb-headless
Label Selector for lightbeam-mongodb-headless: app=lightbeam-mongodb,app.kubernetes.io/component=lightbeam-mongodb
Total pods found for lightbeam-mongodb-headless: 3
Running pods for lightbeam-mongodb-headless: 3
Running percentage for lightbeam-mongodb-headless: 100.0%
Service: lightbeam-elasticsearch-master
Label Selector for lightbeam-elasticsearch-master: app=lightbeam-elasticsearch-master
Total pods found for lightbeam-elasticsearch-master: 3
Running pods for lightbeam-elasticsearch-master: 3
Running percentage for lightbeam-elasticsearch-master: 100.0%
Service: lb-vault
Label Selector for lb-vault: app.kubernetes.io/instance=lb-vault,app.kubernetes.io/name=lb-vault,component=server
Total pods found for lb-vault: 1
Running pods for lb-vault: 1
Running percentage for lb-vault: 100.0%
Service: lightbeam-tika-server
Label Selector for lightbeam-tika-server: app=lightbeam-tika-server
Total pods found for lightbeam-tika-server: 1
Running pods for lightbeam-tika-server: 1
Running percentage for lightbeam-tika-server: 100.0%
Service: lightbeam-presidio-server
Label Selector for lightbeam-presidio-server: app=lightbeam-presidio-server
Total pods found for lightbeam-presidio-server: 2
Running pods for lightbeam-presidio-server: 2
Running percentage for lightbeam-presidio-server: 100.0%
Service: lightbeam-text-extraction
Label Selector for lightbeam-text-extraction: app=lightbeam-text-extraction
Total pods found for lightbeam-text-extraction: 4
Running pods for lightbeam-text-extraction: 4
Running percentage for lightbeam-text-extraction: 100.0%
Service: lightbeam-text-extraction-non-ocr
Warning: Error from server (NotFound): services "lightbeam-text-extraction-non-ocr" not found

No label selector found for service lightbeam-text-extraction-non-ocr in namespace lightbeam. Skipping...
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-api-gateway -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app.kubernetes.io/component=server,app.kubernetes.io/name=argo-workflows -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-frontend -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-kong-proxy -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-kafka,app.kubernetes.io/component=lightbeam-kafka,app.kubernetes.io/instance=lightbeam-kafka,app.kubernetes.io/name=lightbeam-kafka -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=kafka-ui -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-kafka-connect -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-kafka-exporter,app.kubernetes.io/component=lightbeam-kafka-exporter -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app.kubernetes.io/component=keycloak -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-mongodb,app.kubernetes.io/component=lightbeam-mongodb -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-elasticsearch-master -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app.kubernetes.io/instance=lb-vault,app.kubernetes.io/name=lb-vault,component=server -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-tika-server -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-presidio-server -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
No output for command: kubectl get deployments -n lightbeam -l app=lightbeam-text-extraction -o=jsonpath='{.items[?(@.status.readyReplicas!=@.status.replicas)].metadata.name}'
Warning: Error from server (NotFound): services "lightbeam-text-extraction-non-ocr" not found

Service lightbeam-text-extraction-non-ocr not found or has no selectors in namespace lightbeam. Skipping...
{"status": 1, "objects": null, "error": "", "id": "134d70d8685769e42fdf3b014e948b88e3d0efd0b9da0f5a2e60cf6f62069aad"}
None
```

### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5441]: https://unskript.atlassian.net/browse/EN-5441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ