### PR TITLE
Upload failed objects JSON to S3

### DIFF
--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -43,7 +43,6 @@ class UnskriptCtl(UnskriptFactory):
         self._check = Checks()
         self._script = Script()
         self._checks_priority = self._config.get_checks_priority()
-        self.customer_name = os.getenv('CUSTOMER_NAME','UNKNOWN CUSTOMER NAME')
 
 
         self._db = DBInterface()
@@ -170,8 +169,7 @@ class UnskriptCtl(UnskriptFactory):
 
             print("Uploading run artifacts to S3...")
             uploader = S3Uploader()
-            if self.uglobals.get('CHECKS_OUTPUT'):
-                uploader.rename_and_upload(self.customer_name, self.uglobals.get('CHECKS_OUTPUT'))
+            uploader.rename_and_upload_other_items()
 
     def run_info(self):
         """This function runs the info gathering actions"""

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -43,6 +43,8 @@ class UnskriptCtl(UnskriptFactory):
         self._check = Checks()
         self._script = Script()
         self._checks_priority = self._config.get_checks_priority()
+        self.customer_name = os.getenv('CUSTOMER_NAME','UNKNOWN CUSTOMER NAME')
+
 
         self._db = DBInterface()
         # Create execution directory so all results
@@ -165,6 +167,11 @@ class UnskriptCtl(UnskriptFactory):
                 output_dir
             ]
             diagnostics(diag_args)
+
+            print("Uploading run artifacts to S3...")
+            uploader = S3Uploader()
+            if self.uglobals.get('CHECKS_OUTPUT'):
+                uploader.rename_and_upload(self.customer_name, self.uglobals.get('CHECKS_OUTPUT'))
 
     def run_info(self):
         """This function runs the info gathering actions"""

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -23,6 +23,7 @@ from unskript_ctl_factory import *
 from unskript_ctl_version import *
 from unskript_ctl_upload_session_logs import upload_session_logs
 from diagnostics import main as diagnostics
+from unskript_upload_results_to_s3 import S3Uploader
 
 YAML_CONFIG_FILE = "/etc/unskript/unskript_ctl_config.yaml"
 

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -118,7 +118,8 @@ class Checks(ChecksFactory):
             self._error(str(e))
         finally:
             self._common.update_exec_id()
-            output_file = os.path.join(UNSKRIPT_EXECUTION_DIR, self.uglobals.get('exec_id')) + '_output.txt'
+            output_file = os.path.join(self.uglobals.get('CURRENT_EXECUTION_RUN_DIRECTORY'), 
+                                       self.uglobals.get('exec_id')) + '_output.txt'
             if not outputs:
                 self.logger.error("Output is None from check's output")
                 self._error('OUTPUT IS EMPTY FROM CHECKS RUN!')

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -25,6 +25,7 @@ from tqdm import tqdm
 from unskript_utils import *
 from unskript_ctl_factory import ChecksFactory, ScriptsFactory
 from unskript.legos.utils import CheckOutputStatus
+from unskript_upload_results_to_s3 import S3Uploader
 
 
 # Implements Checks Class that is wrapper for All Checks Function
@@ -60,6 +61,7 @@ class Checks(ChecksFactory):
         self.map_entry_function_to_check_name = {}
         self.map_check_name_to_connector = {}
         self.check_name_to_id_mapping = {}
+        self.customer_name = os.getenv('CUSTOMER_NAME','UNKNOWN CUSTOMER NAME')
 
         for k,v in self.checks_globals.items():
             os.environ[k] = json.dumps(v)
@@ -182,6 +184,9 @@ class Checks(ChecksFactory):
         failed_result_available = False
         failed_result = {}
         checks_output = self.output_after_merging_checks(checks_output, self.check_uuids)
+        print("Uploading failed objects to S3...")
+        uploader = S3Uploader()
+        uploader.rename_and_upload(self.customer_name, checks_output)
         for result in checks_output:
             if result.get('skip') and result.get('skip') is True:
                 idx += 1

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -61,7 +61,7 @@ class Checks(ChecksFactory):
         self.map_entry_function_to_check_name = {}
         self.map_check_name_to_connector = {}
         self.check_name_to_id_mapping = {}
-        self.customer_name = os.getenv('CUSTOMER_NAME','UNKNOWN CUSTOMER NAME')
+        # self.customer_name = os.getenv('CUSTOMER_NAME','UNKNOWN CUSTOMER NAME')
 
         for k,v in self.checks_globals.items():
             os.environ[k] = json.dumps(v)
@@ -185,9 +185,11 @@ class Checks(ChecksFactory):
         failed_result_available = False
         failed_result = {}
         checks_output = self.output_after_merging_checks(checks_output, self.check_uuids)
-        print("Uploading failed objects to S3...")
-        uploader = S3Uploader()
-        uploader.rename_and_upload(self.customer_name, checks_output)
+        self.uglobals.create_property('CHECKS_OUTPUT')
+        self.uglobals['CHECKS_OUTPUT'] = checks_output
+        # print("Uploading failed objects to S3...")
+        # uploader = S3Uploader()
+        # uploader.rename_and_upload(self.customer_name, checks_output)
         for result in checks_output:
             if result.get('skip') and result.get('skip') is True:
                 idx += 1

--- a/unskript-ctl/unskript_ctl_run.py
+++ b/unskript-ctl/unskript_ctl_run.py
@@ -61,7 +61,6 @@ class Checks(ChecksFactory):
         self.map_entry_function_to_check_name = {}
         self.map_check_name_to_connector = {}
         self.check_name_to_id_mapping = {}
-        # self.customer_name = os.getenv('CUSTOMER_NAME','UNKNOWN CUSTOMER NAME')
 
         for k,v in self.checks_globals.items():
             os.environ[k] = json.dumps(v)
@@ -187,9 +186,9 @@ class Checks(ChecksFactory):
         checks_output = self.output_after_merging_checks(checks_output, self.check_uuids)
         self.uglobals.create_property('CHECKS_OUTPUT')
         self.uglobals['CHECKS_OUTPUT'] = checks_output
-        # print("Uploading failed objects to S3...")
-        # uploader = S3Uploader()
-        # uploader.rename_and_upload(self.customer_name, checks_output)
+        print("Uploading failed objects to S3...")
+        uploader = S3Uploader()
+        uploader.rename_and_upload_failed_objects(checks_output)
         for result in checks_output:
             if result.get('skip') and result.get('skip') is True:
                 idx += 1

--- a/unskript-ctl/unskript_upload_results_to_s3.py
+++ b/unskript-ctl/unskript_upload_results_to_s3.py
@@ -33,8 +33,8 @@ class S3Uploader:
 
     def rename_and_upload(self, customer_name, checks_output):
         today_date = datetime.now().strftime("%m_%d_%y")
-        file_name = f"{customer_name}_{today_date}.json"
-        folder_name = today_date
+        file_name = f"{customer_name}_{today_date}_failed_objects.json"
+        folder_name = customer_name
         file_path = f"{folder_name}/{file_name}"
 
         try:
@@ -71,5 +71,5 @@ class S3Uploader:
         except Exception as e:
             logger.debug(f"Unable to upload failed objetcs file to S3 bucket: {e}")
         # Remove the local file after upload
-        # logger.debug(f"Removing local file of check outputs json from /tmp: {local_file_name}")
+        logger.debug(f"Removing local file of check outputs json from /tmp: {local_file_name}")
         os.remove(local_file_name)

--- a/unskript-ctl/unskript_upload_results_to_s3.py
+++ b/unskript-ctl/unskript_upload_results_to_s3.py
@@ -76,7 +76,7 @@ class S3Uploader:
         if not folder_exists:
             logger.debug(f"Creating folder {folder_path} in the bucket")
             try:
-                self.s3_client.put_object(Bucket=self.bucket_name, Key=(folder_path))
+                self.s3_client.put_object(Bucket=self.bucket_name, Key=folder_path)
             except ClientError as e:
                 logger.debug(f"Failed to create folder: {e}")
 

--- a/unskript-ctl/unskript_upload_results_to_s3.py
+++ b/unskript-ctl/unskript_upload_results_to_s3.py
@@ -1,0 +1,75 @@
+import boto3
+from botocore.exceptions import NoCredentialsError, PartialCredentialsError, ClientError
+import os
+from datetime import datetime
+import json
+from unskript_ctl_factory import UctlLogger
+
+logger = UctlLogger('UnskriptDiagnostics')
+
+class S3Uploader:
+    def __init__(self):
+        logger.debug("Initializing S3Uploader")
+        aws_access_key_id = os.getenv('LIGHTBEAM_AWS_ACCESS_KEY_ID')
+        aws_secret_access_key = os.getenv('LIGHTBEAM_AWS_SECRET_ACCESS_KEY')
+        self.bucket_name = 'lightbeam-reports'
+
+        if not aws_access_key_id or not aws_secret_access_key:
+            logger.debug("AWS credentials are not set in environment variables")
+
+        self.bucket_name = 'lightbeam-reports'
+
+        try:
+            self.s3_client = boto3.client('s3',
+                                          aws_access_key_id=aws_access_key_id,
+                                          aws_secret_access_key=aws_secret_access_key,
+                                          )
+        except (NoCredentialsError, PartialCredentialsError) as e:
+            logger.debug("Invalid AWS credentials")
+            pass
+        except ClientError as e:
+            logger.debug(f"Client error: {e}")
+            pass
+
+    def rename_and_upload(self, customer_name, checks_output):
+        today_date = datetime.now().strftime("%m_%d_%y")
+        file_name = f"{customer_name}_{today_date}.json"
+        folder_name = today_date
+        file_path = f"{folder_name}/{file_name}"
+
+        try:
+            # Convert checks_output to JSON format
+            checks_output_json = json.dumps(checks_output, indent=2)
+        except json.JSONDecodeError:
+            logger.debug(f"Failed to decode JSON response for {customer_name}")
+
+        # Write JSON data to a local file
+        local_file_name = f"/tmp/{file_name}"
+        with open(local_file_name, 'w') as json_file:
+            json_file.write(checks_output_json)
+
+        # Check if the folder already exists in the bucket
+        try:
+            self.s3_client.head_object(Bucket=self.bucket_name, Key=f"{folder_name}/")
+            folder_exists = True
+        except:
+            folder_exists = False
+            logger.debug(f"S3 folder {folder_name} does not exist")
+
+        # Create folder if it doesn't exist
+        if not folder_exists:
+            # logger.debug(f"Creating folder {folder_name} in the bucket")
+            self.s3_client.put_object(Bucket=self.bucket_name, Key=(folder_name+'/'))
+
+        # Upload the JSON file
+        try:
+            logger.debug(f"Uploading file {file_name} to {self.bucket_name}/{file_path}")
+            self.s3_client.upload_file(local_file_name, self.bucket_name, file_path)
+            logger.debug(f"File {file_name} uploaded successfully to {self.bucket_name}/{folder_name}")
+        except NoCredentialsError:
+            logger.debug("Credentials not available")
+        except Exception as e:
+            logger.debug(f"Unable to upload failed objetcs file to S3 bucket: {e}")
+        # Remove the local file after upload
+        # logger.debug(f"Removing local file of check outputs json from /tmp: {local_file_name}")
+        os.remove(local_file_name)

--- a/unskript-ctl/unskript_upload_results_to_s3.py
+++ b/unskript-ctl/unskript_upload_results_to_s3.py
@@ -60,6 +60,9 @@ class S3Uploader:
             logger.debug(f"Failed to write JSON data to local file: {e}")
             return
 
+        # Initialize folder_exists
+        folder_exists = False
+        
         # Ensure the folder structure exists in the bucket
         try:
             self.s3_client.head_object(Bucket=self.bucket_name, Key=folder_path)


### PR DESCRIPTION
## Description
[EN-5468](https://unskript.atlassian.net/browse/EN-5468)
[EN-5465](https://unskript.atlassian.net/browse/EN-5465)

The idea is that the customer wants to see all the clusters reports summary on a dashboard. We need a common repository to store this data which then unctl container will pick.

Email will not be needed once we have the dashboard.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing

Uploaded checks output for Sanbox cluster and Internal Cluster. 

<img width="1156" alt="Screenshot 2024-05-27 at 3 05 02 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/2d92ba79-9763-4b81-96bc-e7060062bf2e">



#### Testing to upload directory contents
```
unskript@lb-unskript-0:~/test$ python ./upload.py 
unskript@lb-unskript-0:~$cd;  ls
test  unskript_ctl.log
unskript@lb-unskript-0:~$ tail unskript_ctl.log 
2024-05-29 22:37:10 : Uploading file /home/unskript/test/run_directory/metadata.txt to lightbeam-reports/local_test/2024/05/29/metadata.txt
2024-05-29 22:37:10 : File /home/unskript/test/run_directory/metadata.txt uploaded successfully to lightbeam-reports/local_test/2024/05/29/metadata.txt
2024-05-29 22:37:10 : Uploading file /home/unskript/test/run_directory/summary_report.pdf to lightbeam-reports/local_test/2024/05/29/summary_report.pdf
2024-05-29 22:37:10 : File /home/unskript/test/run_directory/summary_report.pdf uploaded successfully to lightbeam-reports/local_test/2024/05/29/summary_report.pdf
2024-05-29 22:37:10 : Uploading file /home/unskript/test/run_directory/kafka_failed_objects.txt to lightbeam-reports/local_test/2024/05/29/kafka_failed_objects.txt
2024-05-29 22:37:11 : File /home/unskript/test/run_directory/kafka_failed_objects.txt uploaded successfully to lightbeam-reports/local_test/2024/05/29/kafka_failed_objects.txt
2024-05-29 22:37:11 : Uploading file /home/unskript/test/run_directory/elasticsearch_failed_objects.txt to lightbeam-reports/local_test/2024/05/29/elasticsearch_failed_objects.txt
2024-05-29 22:37:11 : File /home/unskript/test/run_directory/elasticsearch_failed_objects.txt uploaded successfully to lightbeam-reports/local_test/2024/05/29/elasticsearch_failed_objects.txt

```

<img width="1791" alt="Screenshot 2024-05-29 at 3 46 29 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/87547684/798223d4-1303-4f4c-9efb-3f693287629f">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->



[EN-5468]: https://unskript.atlassian.net/browse/EN-5468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-5465]: https://unskript.atlassian.net/browse/EN-5465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ