### PR TITLE
Bring back script run status

### DIFF
--- a/unskript-ctl/unskript_ctl_notification.py
+++ b/unskript-ctl/unskript_ctl_notification.py
@@ -198,10 +198,10 @@ class EmailNotification(NotificationFactory):
         return list_of_failed_files
 
     def create_script_summary_message(self, output_metadata_file: str):
-        # message = ''
+        message = ''
         if os.path.exists(output_metadata_file) is False:
             self.logger.error(f"ERROR: The metadata file is missing, please check if file exists? {output_metadata_file}")
-            return ''
+            return message
 
         metadata = ''
         with open(output_metadata_file, 'r', encoding='utf-8') as f:
@@ -215,24 +215,24 @@ class EmailNotification(NotificationFactory):
         self.logger.debug(f"\tStatus: {metadata.get('status')} \n\tTime (in seconds): {metadata.get('time_taken')} \n\tError: {metadata.get('error')} \n")
 
         # Remove from email 
-        # message += f'''
-        #         <br>
-        #         <h3> Custom Script Run Result </h3>
-        #         <table border="1">
-        #             <tr>
-        #                 <th> Status </th>
-        #                 <th> Time (in seconds) </th>
-        #                 <th> Error </th>
-        #             </tr>
-        #             <tr>
-        #                 <td>{metadata.get('status')}</td>
-        #                 <td>{metadata.get('time_taken')}</td>
-        #                 <td>{metadata.get('error')}</td>
-        #             </tr>
-        #         </table>
-        # '''
+        message += f'''
+                <br>
+                <h3> Custom Script Run Result </h3>
+                <table border="1">
+                    <tr>
+                        <th> Status </th>
+                        <th> Time (in seconds) </th>
+                        <th> Error </th>
+                    </tr>
+                    <tr>
+                        <td>{metadata.get('status')}</td>
+                        <td>{metadata.get('time_taken')}</td>
+                        <td>{metadata.get('error')}</td>
+                    </tr>
+                </table>
+        '''
 
-        return ''
+        return message
 
     def create_info_legos_output_file(self):
         """create_info_legos_output_file: This function creates a file that will
@@ -469,6 +469,10 @@ class EmailNotification(NotificationFactory):
         if info_result:
             message += info_result
             self.create_info_legos_output_file()
+        # print("Output Metadata File\n",output_metadata_file)
+        if output_metadata_file:
+            message += self.create_script_summary_message(output_metadata_file=output_metadata_file)
+            temp_attachment = self.create_email_attachment(output_metadata_file=output_metadata_file)
 
         if len(os.listdir(self.execution_dir)) == 0 or not self.create_tarball_archive(tar_file_name=tar_file_name, output_metadata_file=None, parent_folder=parent_folder):
             self.logger.error("Execution directory is empty , tarball creation unsuccessful!")
@@ -559,6 +563,9 @@ class SendgridNotification(EmailNotification):
             # Check conditions for creating tarball
             if len(os.listdir(self.execution_dir)) == 0 or not self.create_tarball_archive(tar_file_name=tar_file_name, output_metadata_file=None, parent_folder=parent_folder):
                 self.logger.error("Execution directory is empty , tarball creation unsuccessful!")
+
+            if output_metadata_file:
+                html_message += self.create_script_summary_message(output_metadata_file=output_metadata_file)
 
             info_result = self.create_info_gathering_action_result()
             if info_result:


### PR DESCRIPTION
## Description
[EN-5534](https://unskript.atlassian.net/browse/EN-5534)

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
<img width="1073" alt="Screenshot 2024-05-23 at 5 14 25 PM" src="https://github.com/unskript/Awesome-CloudOps-Automation/assets/110628398/6b2c0dbf-4243-4c9d-bc62-2c417adc597d">


### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5534]: https://unskript.atlassian.net/browse/EN-5534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ