### PR TITLE
Email Retries and Log file inclusion in the attachment

### DIFF
--- a/unskript-ctl/config/unskript_ctl_config.yaml
+++ b/unskript-ctl/config/unskript_ctl_config.yaml
@@ -178,6 +178,15 @@ notification:
     verbose: true #Not yet supported
     enable: false
     email_subject_line: ""
+    # Skip Generating Summary pdf
+    skip_generating_summary_report: false
+    # Specify if SMTP credentials vault path
+    vault:
+      enable: false
+      smtp_credential_path: "v1/lb-secrets/smtp-server/credentials"
+      # Auth Type: "Basic Auth" or OAuth2
+      auth_type: "Basic Auth"
+
     # provider for the email. Possible values:
     #    - SMTP - SMTP server
     #    - SES -  AWS SES
@@ -199,6 +208,7 @@ notification:
       api_key: ""
       to-email: ""
       from-email: ""
+      
 
 #
 # Job section

--- a/unskript-ctl/unskript_ctl_main.py
+++ b/unskript-ctl/unskript_ctl_main.py
@@ -520,7 +520,7 @@ class UnskriptCtl(UnskriptFactory):
             return
 
         openvpn_log_file = "/tmp/openvpn_client.log"
-        command = [f"openvpn --config {remote_config_file} > {openvpn_log_file}"]
+        command = [f"sudo openvpn --config {remote_config_file} > {openvpn_log_file}"]
         try:
             process = subprocess.Popen(command,
                                     stdout=subprocess.PIPE,
@@ -577,9 +577,17 @@ class UnskriptCtl(UnskriptFactory):
             # Search for openvpn process. On Docker, we dont expect
             # Multiple process of openvpn to run.
             if proc.info['name'] == "openvpn":
-                process = psutil.Process(proc.info['pid'])
-                process.terminate()
-                process.wait()
+                p_id = proc.info['pid']
+                command = [f"sudo kill -9 {p_id}"]
+                try:
+                    process = subprocess.Popen(command,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    shell=True)
+                except Exception as e:
+                    self.logger.debug(f"Unable to stop debug session: {e}")
+                    print(f"ERROR: Unable to stop the debug session {e}")
+                    return
 
         self.logger.debug("Stopped Active Debug session successfully")
         print("Stopped Active Debug session successfully")


### PR DESCRIPTION
## Description
Fixes [EN-5684]

This PR Brings in support for
* Email retrial (Max 5 times with exponential backoff support)
* Inclusion of unskript_ctl.log file in the email archive
* Improved compression with `J` option to help reduce the email attachment file size



### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

#### Positive Case

```
unskript@awesome-awesome-runbooks-0:~$ unskript-ctl.sh run check --type vault --report
Running: 100%|████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.09it/s]

╒══════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name              │ Result   │   Failed Count │ Error   │
╞══════════════════════════╪══════════╪════════════════╪═════════╡
│ Get Vault service health │  PASS    │              0 │ N/A     │
╘══════════════════════════╧══════════╧════════════════╧═════════╛


Fetching logs...
Error: 'checks->diagnostics' section not found in '/etc/unskript/unskript_ctl_config.yaml'.
Skipping Diagnostics: No diagnostic command found. You can define them in the YAML configuration file
Uploading run artifacts to S3...
2024-09-10 19:37:02,776 - UnskriptCtlLogger - INFO - Slack Message was sent successfully!
2024-09-10 19:37:02,776 - UnskriptCtlLogger - INFO - Starting call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email', this is the 1st time calling it.
INFO:botocore.credentials:Found credentials in environment variables.
2024-09-10 19:37:03,700 - UnskriptCtlLogger - INFO - Email notification sent to XXX@XXX.COM
2024-09-10 19:37:03,702 - UnskriptCtlLogger - INFO - Successfully sent Email notification via AWS SES.
```

#### Negative Case

```
unskript@awesome-awesome-runbooks-0:~$ unskript-ctl.sh run check --type vault --report
Running: 100%|████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.11it/s]

╒══════════════════════════╤══════════╤════════════════╤═════════╕
│ Checks Name              │ Result   │   Failed Count │ Error   │
╞══════════════════════════╪══════════╪════════════════╪═════════╡
│ Get Vault service health │  PASS    │              0 │ N/A     │
╘══════════════════════════╧══════════╧════════════════╧═════════╛


Fetching logs...
Error: 'checks->diagnostics' section not found in '/etc/unskript/unskript_ctl_config.yaml'.
Skipping Diagnostics: No diagnostic command found. You can define them in the YAML configuration file
Uploading run artifacts to S3...
2024-09-10 19:41:40,870 - UnskriptCtlLogger - INFO - Slack Message was sent successfully!
2024-09-10 19:41:40,871 - UnskriptCtlLogger - INFO - Starting call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email', this is the 1st time calling it.
2024-09-10 19:41:40,897 - UnskriptCtlLogger - INFO - Finished call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email' after 0.027(s), this was the 1st time calling it.
2024-09-10 19:41:44,898 - UnskriptCtlLogger - INFO - Starting call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email', this is the 2nd time calling it.
2024-09-10 19:41:44,922 - UnskriptCtlLogger - INFO - Finished call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email' after 4.051(s), this was the 2nd time calling it.
2024-09-10 19:41:48,923 - UnskriptCtlLogger - INFO - Starting call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email', this is the 3rd time calling it.
2024-09-10 19:41:48,951 - UnskriptCtlLogger - INFO - Finished call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email' after 8.080(s), this was the 3rd time calling it.
2024-09-10 19:41:52,951 - UnskriptCtlLogger - INFO - Starting call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email', this is the 4th time calling it.
2024-09-10 19:41:52,976 - UnskriptCtlLogger - INFO - Finished call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email' after 12.105(s), this was the 4th time calling it.
2024-09-10 19:42:00,977 - UnskriptCtlLogger - INFO - Starting call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email', this is the 5th time calling it.
2024-09-10 19:42:01,025 - UnskriptCtlLogger - INFO - Finished call to 'unskript_ctl_notification.Notification._send_email.<locals>._do_send_email' after 20.154(s), this was the 5th time calling it.
2024-09-10 19:42:01,025 - UnskriptCtlLogger - INFO - Error sending email: RetryError[<Future at 0x7f507df39290 state=finished raised TypeError>]
unskript@awesome-awesome-runbooks-0:~$ 

```




### Checklist:
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->


[EN-5684]: https://unskript.atlassian.net/browse/EN-5684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ